### PR TITLE
Fix #71: crash from REPL after hitting return on last line

### DIFF
--- a/src/Package/Impl/Repl/RInteractiveEvaluator.cs
+++ b/src/Package/Impl/Repl/RInteractiveEvaluator.cs
@@ -59,6 +59,8 @@ namespace Microsoft.VisualStudio.R.Package.Repl
             CurrentWindow.WriteLine(Resources.MicrosoftRHostStopping);
             await _session.StopHostAsync();
 
+            _requestTcs = null;
+
             if (initialize)
             {
                 return await InitializeAsync();
@@ -76,6 +78,12 @@ namespace Microsoft.VisualStudio.R.Package.Repl
         {
             _requestTcs = new TaskCompletionSource<ExecutionResult>();
             var request = await _session.BeginInteractionAsync();
+
+            if (text.Length >= request.MaxLength) {
+                CurrentWindow.WriteErrorLine(string.Format(Resources.InputIsTooLong, request.MaxLength));
+                request.Dispose();
+                return await ExecutionResult.Failed;
+            }
 
             Task.Run(async () =>
             {

--- a/src/Package/Impl/Repl/Session/RSession.cs
+++ b/src/Package/Impl/Repl/Session/RSession.cs
@@ -173,7 +173,12 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session
             {
                 try
                 {
-                    return await ReadNextRequest(contexts, prompt, len);
+                    string response = await ReadNextRequest(contexts, prompt, len);
+                    Debug.Assert(response.Length < len); // len includes null terminator
+                    if (response.Length >= len) {
+                        response = response.Substring(0, len - 1);
+                    }
+                    return response;
                 }
                 catch (TaskCanceledException)
                 {

--- a/src/Package/Impl/Resources.Designer.cs
+++ b/src/Package/Impl/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace Microsoft.VisualStudio.R.Package {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Input is too long - no more than {0} characters expected..
+        /// </summary>
+        internal static string InputIsTooLong {
+            get {
+                return ResourceManager.GetString("InputIsTooLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to R.
         /// </summary>
         internal static string LanguageName {

--- a/src/Package/Impl/Resources.resx
+++ b/src/Package/Impl/Resources.resx
@@ -240,4 +240,7 @@
   <data name="MicrosoftRHostStopping" xml:space="preserve">
     <value>Stopping R Host process...</value>
   </data>
+  <data name="InputIsTooLong" xml:space="preserve">
+    <value>Input is too long - no more than {0} characters expected.</value>
+  </data>
 </root>


### PR DESCRIPTION
Avoid sending more than the requested amount of data to R when handling ReadConsole.

Check input length in R REPL provider and prevent user from executing input that is too long.

(This covers the VS side of things and should be sufficient to fix the issue entirely on all single-byte locales. Separate checks in RHost need to be added as a last line of defense and to handle multibyte case.)
