### PR TITLE
Fix and improve "Attach Debugger" command

### DIFF
--- a/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
+++ b/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
@@ -94,7 +94,7 @@
     <Compile Include="Publishing\Commands\PreviewWordCommand.cs" />
     <Compile Include="Publishing\Commands\PreviewPdfCommand.cs" />
     <Compile Include="Publishing\Commands\PreviewHtmlCommand.cs" />
-    <Compile Include="Repl\Commands\AttachDebuggerCommand.cs" />
+    <Compile Include="Repl\Workspace\AttachDebuggerCommand.cs" />
     <Compile Include="Repl\Commands\ReplTypingCommandHandler.cs" />
     <Compile Include="Commands\R\SourceRScriptCommand.cs" />
     <Compile Include="Repl\RSessionExtensions.cs" />

--- a/src/Package/Impl/Package.vsct
+++ b/src/Package/Impl/Package.vsct
@@ -154,7 +154,12 @@
       <Group guid="guidRToolsCmdSet" id="sessionSubMenuRGroup" priority="0x0200">
         <Parent guid="guidRToolsCmdSet" id="sessionSubMenu"/>
       </Group>
-      
+
+      <!-- Same as above, but excludes commands that are already present in Interactive Window toolbar (like Restart). -->
+      <Group guid="guidRToolsCmdSet" id="sessionSubMenuRInteractiveGroup" priority="0x0600">
+        <Parent guid="guidInteractiveWindowCmdSet" id="menuIdInteractiveToolbar"/>
+      </Group>
+
       <Group guid="guidRToolsCmdSet" id="sessionSubMenuDirectoryGroup" priority="0x0300">
         <Parent guid="guidRToolsCmdSet" id="sessionSubMenu"/>
       </Group>
@@ -183,6 +188,10 @@
       
       <!-- InteractiveWindow -->
       <Group guid="guidRToolsCmdSet" id="sessionSubMenuFileGroup" priority="0x0500">
+        <Parent guid="guidInteractiveWindowCmdSet" id="menuIdInteractiveToolbar"/>
+      </Group>
+
+      <Group guid="guidRToolsCmdSet" id="sessionSubMenuDirectoryGroup" priority="0x0700">
         <Parent guid="guidInteractiveWindowCmdSet" id="menuIdInteractiveToolbar"/>
       </Group>
 
@@ -226,7 +235,7 @@
         </Strings>
       </Button>
 
-      <Button guid="guidRToolsCmdSet" id="icmdInterruptR" priority="0x0300" type="Button">
+      <Button guid="guidRToolsCmdSet" id="icmdInterruptR" priority="0x0400" type="Button">
         <Parent guid="guidRToolsCmdSet" id="sessionSubMenuRGroup"/>
         <Icon guid="guidVsShellIcons" id="cmdidVsShellInteractiveSessionInterrupt"/>
         <CommandFlag>DefaultDisabled</CommandFlag>
@@ -234,6 +243,18 @@
           <ButtonText>Interrupt R</ButtonText>
           <MenuText>&amp;Interrupt R</MenuText>
           <CommandName>Interrupt R</CommandName>
+        </Strings>
+      </Button>
+
+      <Button guid="guidRToolsCmdSet" id="icmdAttachDebugger" priority="0x0500" type="Button">
+        <Parent guid="guidRToolsCmdSet" id="sessionSubMenuRGroup"/>
+        <Icon guid="ImageCatalogGuid" id="RemoteDebugger"/>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>DefaultDisabled</CommandFlag>
+        <Strings>
+          <ButtonText>Attach Debugger</ButtonText>
+          <MenuText>A&amp;ttach Debugger</MenuText>
+          <CommandName>Attach Debugger</CommandName>
         </Strings>
       </Button>
 
@@ -246,17 +267,6 @@
           <ButtonText>Set Working Directory...</ButtonText>
           <MenuText>Set Working &amp;Directory...</MenuText>
           <CommandName>Set Working Directory</CommandName>
-        </Strings>
-      </Button>
-
-      <Button guid="guidRToolsCmdSet" id="icmdAttachDebugger" priority="0x0500" type="Button">
-        <Parent guid="guidRToolsCmdSet" id="sessionSubMenuDirectoryGroup"/>
-        <Icon guid="ImageCatalogGuid" id="RemoteDebugger"/>
-        <CommandFlag>IconIsMoniker</CommandFlag>
-        <Strings>
-          <ButtonText>Attach Debugger</ButtonText>
-          <MenuText>A&amp;ttach Debugger</MenuText>
-          <CommandName>Attach Debugger</CommandName>
         </Strings>
       </Button>
       <!-- End Workspace flyout -->
@@ -734,6 +744,14 @@
       <Parent guid="guidRToolsCmdSet" id="plotToolbarZoomGroup"/>
     </CommandPlacement>
 
+    <CommandPlacement guid="guidRToolsCmdSet" id="icmdInterruptR" priority="0x0400">
+      <Parent guid="guidRToolsCmdSet" id="sessionSubMenuRInteractiveGroup"/>
+    </CommandPlacement>
+
+    <CommandPlacement guid="guidRToolsCmdSet" id="icmdAttachDebugger" priority="0x0500">
+      <Parent guid="guidRToolsCmdSet" id="sessionSubMenuRInteractiveGroup"/>
+    </CommandPlacement>
+
   </CommandPlacements>
 
   <KeyBindings>
@@ -816,6 +834,7 @@
       <IDSymbol name="sessionSubMenuFileGroup" value="551"/>
       <IDSymbol name="sessionSubMenuRGroup" value="552"/>
       <IDSymbol name="sessionSubMenuDirectoryGroup" value="553"/>
+      <IDSymbol name="sessionSubMenuRInteractiveGroup" value="554"/>
 
       <!-- Packages-->
       <IDSymbol name="icmdInstallPackages" value="601" />

--- a/src/Package/Impl/Packages/R/PackageCommands.cs
+++ b/src/Package/Impl/Packages/R/PackageCommands.cs
@@ -23,6 +23,7 @@ namespace Microsoft.VisualStudio.R.Packages.R
 
                 new LoadWorkspaceCommand(rSessionProvider, projectServiceAccessor),
                 new SaveWorkspaceCommand(rSessionProvider, projectServiceAccessor),
+                new AttachDebuggerCommand(rSessionProvider),
                 new RestartRCommand(),
                 new InterruptRCommand(),
 

--- a/src/Package/Impl/Repl/Commands/ReplCommandFactory.cs
+++ b/src/Package/Impl/Repl/Commands/ReplCommandFactory.cs
@@ -15,7 +15,6 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Commands
             commands.Add(new HistoryNavigationCommand(textView));
             commands.Add(new ReplTypingCommandHandler(textView));
             commands.Add(new RCompletionCommandHandler(textView));
-            commands.Add(new AttachDebuggerCommand(textView));
 
             return commands;
         }


### PR DESCRIPTION
Move "Attach Debugger" command to a more appropriate group, and make it a package command rather than an editor command, so that it does not require REPL to be in focus to invoke. Also display and focus the REPL window after successfully attaching.

Add workspace-related commands to the REPL toolbar (except for "Restart R", because REPL already has a restart button).
