### PR TITLE
Use ConfigureAwait(false) throughout RHost & RSession code

### DIFF
--- a/src/Package/Impl/Repl/Session/RSessionInteractionCommands.cs
+++ b/src/Package/Impl/Repl/Session/RSessionInteractionCommands.cs
@@ -4,7 +4,7 @@ using Microsoft.R.Host.Client;
 namespace Microsoft.VisualStudio.R.Package.Repl.Session {
     public static class RSessionInteractionCommands {
         public static async Task Quit(this IRSessionInteraction interaction) {
-            await interaction.RespondAsync("q()\n");
+            await interaction.RespondAsync("q()\n").ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Use ConfigureAwait(false) throughout RHost & RSession code to avoid unnecessary thread affinity, and prevent deadlocks when async methods are called synchronously from the UI thread.
