### PR TITLE
Background threads / async overhaul

### DIFF
--- a/src/Common/Core/Impl/Microsoft.Common.Core.csproj
+++ b/src/Common/Core/Impl/Microsoft.Common.Core.csproj
@@ -78,6 +78,7 @@
     <Compile Include="StackExtensions.cs" />
     <Compile Include="StringBuilderExtensions.cs" />
     <Compile Include="TaskExtensions.cs" />
+    <Compile Include="TaskUtilities.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="35MSSharedLib1024.snk" />

--- a/src/Common/Core/Impl/TaskExtensions.cs
+++ b/src/Common/Core/Impl/TaskExtensions.cs
@@ -1,16 +1,13 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-namespace Microsoft.Common.Core
-{
-    public static class TaskExtensions
-    {
+namespace Microsoft.Common.Core {
+    public static class TaskExtensions {
         /// <summary>
         /// Suppresses warnings about unawaited tasks and ensures that unhandled
         /// errors will cause the process to terminate.
         /// </summary>
-        public static async void DoNotWait(this Task task)
-        {
+        public static async void DoNotWait(this Task task) {
             await task;
         }
 
@@ -19,8 +16,7 @@ namespace Microsoft.Common.Core
         /// will be raised without being wrapped in a
         /// <see cref="AggregateException"/>.
         /// </summary>
-        public static void WaitAndUnwrapExceptions(this Task task)
-        {
+        public static void WaitAndUnwrapExceptions(this Task task) {
             task.GetAwaiter().GetResult();
         }
 
@@ -29,23 +25,18 @@ namespace Microsoft.Common.Core
         /// will be raised without being wrapped in a
         /// <see cref="AggregateException"/>.
         /// </summary>
-        public static T WaitAndUnwrapExceptions<T>(this Task<T> task)
-        {
+        public static T WaitAndUnwrapExceptions<T>(this Task<T> task) {
             return task.GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Silently handles the specified exception.
         /// </summary>
-        public static Task SilenceException<T>(this Task task) where T : Exception
-        {
+        public static Task SilenceException<T>(this Task task) where T : Exception {
             return task.ContinueWith(t => {
-                try
-                {
+                try {
                     t.Wait();
-                }
-                catch (AggregateException ex)
-                {
+                } catch (AggregateException ex) {
                     ex.Handle(e => e is T);
                 }
             });
@@ -54,15 +45,11 @@ namespace Microsoft.Common.Core
         /// <summary>
         /// Silently handles the specified exception.
         /// </summary>
-        public static Task<U> SilenceException<T, U>(this Task<U> task) where T : Exception
-        {
+        public static Task<U> SilenceException<T, U>(this Task<U> task) where T : Exception {
             return task.ContinueWith(t => {
-                try
-                {
+                try {
                     return t.Result;
-                }
-                catch (AggregateException ex)
-                {
+                } catch (AggregateException ex) {
                     ex.Handle(e => e is T);
                     return default(U);
                 }

--- a/src/Common/Core/Impl/TaskUtilities.cs
+++ b/src/Common/Core/Impl/TaskUtilities.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Common.Core {
+    public static class TaskUtilities {
+        public static bool IsOnBackgroundThread() {
+            var taskScheduler = TaskScheduler.Current;
+            var syncContext = SynchronizationContext.Current;
+            return taskScheduler == TaskScheduler.Default && (syncContext == null || syncContext.GetType() == typeof(SynchronizationContext));
+        }
+
+        /// <summary>
+        /// If awaited on a thread with custom scheduler or synchronization context, invokes the continuation
+        /// on a background (thread pool) thread. If already on such a thread, await is a no-op.
+        /// </summary>
+        public static BackgroundThreadAwaitable SwitchToBackgroundThread() {
+            return new BackgroundThreadAwaitable();
+        }
+
+        public struct BackgroundThreadAwaitable {
+            public Awaiter GetAwaiter() {
+                return new Awaiter();
+            }
+
+            public struct Awaiter : ICriticalNotifyCompletion {
+                private static readonly WaitCallback waitCallback = (state) => ((Action)state)();
+
+                public bool IsCompleted => IsOnBackgroundThread();
+
+                public void OnCompleted(Action continuation) {
+                    Trace.Assert(continuation != null);
+                    ThreadPool.QueueUserWorkItem(waitCallback, continuation);
+                }
+
+                public void UnsafeOnCompleted(Action continuation) {
+                    Trace.Assert(continuation != null);
+                    ThreadPool.UnsafeQueueUserWorkItem(waitCallback, continuation);
+                }
+
+                public void GetResult() {
+                }
+            }
+        }
+
+        [Conditional("TRACE")]
+        public static void AssertIsOnBackgroundThread(
+            [CallerMemberName] string memberName = "",
+            [CallerFilePath] string sourceFilePath = "",
+            [CallerLineNumber] int sourceLineNumber = 0
+        ) {
+            if (!IsOnBackgroundThread()) {
+                Trace.Fail($"{memberName} at {sourceFilePath}:{sourceLineNumber} was incorrectly called from a non-background thread.");
+            }
+        }
+    }
+}

--- a/src/Host/Client/Impl/RHost.cs
+++ b/src/Host/Client/Impl/RHost.cs
@@ -7,6 +7,7 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Common.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -34,6 +35,8 @@ namespace Microsoft.R.Host.Client {
         }
 
         public async Task CreateAndRun(string rHome, ProcessStartInfo psi = null, CancellationToken ct = default(CancellationToken)) {
+            await TaskUtilities.SwitchToBackgroundThread();
+
             string rhostExe = Path.Combine(Path.GetDirectoryName(typeof(RHost).Assembly.ManifestModule.FullyQualifiedName), RHostExe);
             string rBinPath = Path.Combine(rHome, RBinPathX64);
 
@@ -58,17 +61,17 @@ namespace Microsoft.R.Host.Client {
                         var uri = new Uri("ws://localhost:" + DefaultPort);
                         for (int i = 0; ; ++i) {
                             try {
-                                await _socket.ConnectAsync(uri, ct).ConfigureAwait(false);
+                                await _socket.ConnectAsync(uri, ct);
                                 break;
                             } catch (WebSocketException) {
                                 if (i > 10) {
                                     throw;
                                 }
-                                await Task.Delay(100, ct).ConfigureAwait(false);
+                                await Task.Delay(100, ct);
                             }
                         }
 
-                        await Run(ct).ConfigureAwait(false);
+                        await Run(ct);
                     }
                 } catch (Exception ex) when (!(ex is OperationCanceledException)) { // TODO: replace with better logging
                     Trace.Fail("Exception in RHost run loop:\n" + ex);
@@ -86,14 +89,18 @@ namespace Microsoft.R.Host.Client {
         }
 
         public async Task AttachAndRun(Uri uri, CancellationToken ct = default(CancellationToken)) {
+            await TaskUtilities.SwitchToBackgroundThread();
+
             ct = CancellationTokenSource.CreateLinkedTokenSource(ct, _cts.Token).Token;
             using (_socket = new ClientWebSocket()) {
-                await _socket.ConnectAsync(uri, ct).ConfigureAwait(false);
-                await Run(ct).ConfigureAwait(false);
+                await _socket.ConnectAsync(uri, ct);
+                await Run(ct);
             }
         }
 
         private async Task Run(CancellationToken ct) {
+            TaskUtilities.AssertIsOnBackgroundThread();
+
             if (_isRunning) {
                 throw new InvalidOperationException("This host is already running.");
             }
@@ -102,16 +109,16 @@ namespace Microsoft.R.Host.Client {
             _isRunning = true;
             try {
                 try {
-                    var webSocketReceiveResult = await _socket.ReceiveAsync(new ArraySegment<byte>(_buffer), ct).ConfigureAwait(false);
+                    var webSocketReceiveResult = await _socket.ReceiveAsync(new ArraySegment<byte>(_buffer), ct);
                     string s = Encoding.UTF8.GetString(_buffer, 0, webSocketReceiveResult.Count);
                     var obj = JObject.Parse(s);
                     int protocolVersion = (int)(double)obj["protocol_version"];
                     Debug.Assert(protocolVersion == 1);
                     string rVersion = (string)obj["R_version"];
-                    await _callbacks.Connected(rVersion).ConfigureAwait(false);
-                    await RunLoop(ct, allowEval: true).ConfigureAwait(false);
+                    await _callbacks.Connected(rVersion);
+                    await RunLoop(ct, allowEval: true);
                 } finally {
-                    await _callbacks.Disconnected().ConfigureAwait(false);
+                    await _callbacks.Disconnected();
                 }
             } finally {
                 _isRunning = false;
@@ -119,11 +126,13 @@ namespace Microsoft.R.Host.Client {
         }
 
         private async Task<JObject> RunLoop(CancellationToken ct, bool allowEval) {
+            TaskUtilities.AssertIsOnBackgroundThread();
+
             while (!ct.IsCancellationRequested) {
                 WebSocketReceiveResult webSocketReceiveResult;
                 var s = string.Empty;
                 do {
-                    webSocketReceiveResult = await _socket.ReceiveAsync(new ArraySegment<byte>(_buffer), ct).ConfigureAwait(false);
+                    webSocketReceiveResult = await _socket.ReceiveAsync(new ArraySegment<byte>(_buffer), ct);
                     if (webSocketReceiveResult.CloseStatus != null) {
                         return null;
                     }
@@ -136,24 +145,24 @@ namespace Microsoft.R.Host.Client {
                 var evt = (string)obj["event"];
                 switch (evt) {
                     case "YesNoCancel":
-                        await YesNoCancel(contexts, obj, allowEval, ct).ConfigureAwait(false);
+                        await YesNoCancel(contexts, obj, allowEval, ct);
                         break;
 
                     case "ReadConsole":
-                        await ReadConsole(contexts, obj, allowEval, ct).ConfigureAwait(false);
+                        await ReadConsole(contexts, obj, allowEval, ct);
                         break;
 
                     case "WriteConsoleEx":
                         await
-                            _callbacks.WriteConsoleEx(contexts, (string)obj["buf"], (OutputType)(double)obj["otype"], ct).ConfigureAwait(false);
+                            _callbacks.WriteConsoleEx(contexts, (string)obj["buf"], (OutputType)(double)obj["otype"], ct);
                         break;
 
                     case "ShowMessage":
-                        await _callbacks.ShowMessage(contexts, (string)obj["s"], ct).ConfigureAwait(false);
+                        await _callbacks.ShowMessage(contexts, (string)obj["s"], ct);
                         break;
 
                     case "Busy":
-                        await _callbacks.Busy(contexts, (bool)obj["which"], ct).ConfigureAwait(false);
+                        await _callbacks.Busy(contexts, (bool)obj["which"], ct);
                         break;
 
                     case "CallBack":
@@ -163,7 +172,7 @@ namespace Microsoft.R.Host.Client {
                         return obj;
 
                     case "PlotXaml":
-                        await _callbacks.PlotXaml(contexts, (string)obj["filepath"], ct).ConfigureAwait(false);
+                        await _callbacks.PlotXaml(contexts, (string)obj["filepath"], ct);
                         // TODO: delete temporary xaml and bitmap files
                         break;
 
@@ -179,16 +188,20 @@ namespace Microsoft.R.Host.Client {
         }
 
         private async Task YesNoCancel(RContext[] contexts, JObject obj, bool allowEval, CancellationToken ct) {
+            TaskUtilities.AssertIsOnBackgroundThread();
+
             try {
                 _canEval = allowEval;
-                YesNoCancel input = await _callbacks.YesNoCancel(contexts, (string)obj["s"], _canEval, ct).ConfigureAwait(false);
-                await SendAsync((double)input, ct).ConfigureAwait(false);
+                YesNoCancel input = await _callbacks.YesNoCancel(contexts, (string)obj["s"], _canEval, ct);
+                await SendAsync((double)input, ct);
             } finally {
                 _canEval = false;
             }
         }
 
         private async Task ReadConsole(RContext[] contexts, JObject obj, bool allowEval, CancellationToken ct) {
+            TaskUtilities.AssertIsOnBackgroundThread();
+
             try {
                 _canEval = allowEval;
 
@@ -197,22 +210,24 @@ namespace Microsoft.R.Host.Client {
                 var len = (int)(double)obj["len"];
                 var addToHistory = (bool)obj["addToHistory"];
 
-                string input = await _callbacks.ReadConsole(contexts, prompt, buf, len, addToHistory, _canEval, ct).ConfigureAwait(false);
+                string input = await _callbacks.ReadConsole(contexts, prompt, buf, len, addToHistory, _canEval, ct);
                 input = input.Replace("\r\n", "\n");
-                await SendAsync(input, ct).ConfigureAwait(false);
+                await SendAsync(input, ct);
             } finally {
                 _canEval = false;
             }
         }
 
         private async Task SendAsync<T>(T input, CancellationToken ct) {
+            TaskUtilities.AssertIsOnBackgroundThread();
+
             if (ct.IsCancellationRequested) {
                 return;
             }
 
             var response = JsonConvert.SerializeObject(input);
             byte[] responseBytes = Encoding.UTF8.GetBytes(response);
-            await _socket.SendAsync(new ArraySegment<byte>(responseBytes, 0, responseBytes.Length), WebSocketMessageType.Text, true, ct).ConfigureAwait(false);
+            await _socket.SendAsync(new ArraySegment<byte>(responseBytes, 0, responseBytes.Length), WebSocketMessageType.Text, true, ct);
         }
 
         private static RContext[] GetContexts(JObject obj) {
@@ -228,6 +243,8 @@ namespace Microsoft.R.Host.Client {
         }
 
         async Task<REvaluationResult> IRExpressionEvaluator.EvaluateAsync(string expression, bool reentrant, CancellationToken ct) {
+            await TaskUtilities.SwitchToBackgroundThread();
+
             if (!_canEval) {
                 throw new InvalidOperationException("EvaluateAsync can only be called while ReadConsole or YesNoCancel is pending.");
             }
@@ -240,9 +257,9 @@ namespace Microsoft.R.Host.Client {
                 });
 
                 var requestBytes = Encoding.UTF8.GetBytes(request);
-                await _socket.SendAsync(new ArraySegment<byte>(requestBytes, 0, requestBytes.Length), WebSocketMessageType.Text, true, ct).ConfigureAwait(false);
+                await _socket.SendAsync(new ArraySegment<byte>(requestBytes, 0, requestBytes.Length), WebSocketMessageType.Text, true, ct);
 
-                var obj = await RunLoop(ct, reentrant).ConfigureAwait(false);
+                var obj = await RunLoop(ct, reentrant);
 
                 JToken result, error, parseStatus;
                 obj.TryGetValue("result", out result);

--- a/src/Package/Impl/Repl/RSessionExtensions.cs
+++ b/src/Package/Impl/Repl/RSessionExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
         }
 
         private static async Task GetScheduleEvaluationTask(this IRSession session, Func<IRSessionEvaluation, Task> function) {
+            TaskUtilities.AssertIsOnBackgroundThread();
             using (var evaluation = await session.BeginEvaluationAsync()) {
                 await function(evaluation);
             } 

--- a/src/Package/Impl/Repl/Session/RSession.cs
+++ b/src/Package/Impl/Repl/Session/RSession.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
+using Microsoft.Common.Core;
 using Microsoft.Languages.Editor.Shell;
 using Microsoft.R.Host.Client;
 using Microsoft.R.Support.Settings;
@@ -60,24 +61,25 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
             return source.Task;
         }
 
-        public Task StartHostAsync() {
+        public async Task StartHostAsync() {
             if (_hostRunTask != null && !_hostRunTask.IsCompleted) {
                 throw new InvalidOperationException("Another instance of RHost is running for this RSession. Stop it before starting new one.");
             }
 
+            await TaskUtilities.SwitchToBackgroundThread();
+
             _host = new RHost(this);
             _initializationTcs = new TaskCompletionSource<object>();
 
-            _hostRunTask = Task.Run(() => _host.CreateAndRun(RToolsSettings.GetRVersionPath()));
+            _hostRunTask = _host.CreateAndRun(RToolsSettings.GetRVersionPath());
             this.ScheduleEvaluation(async e => {
-                await e.SetVsGraphicsDevice().ConfigureAwait(false);
-                await e.SetDefaultWorkingDirectory().ConfigureAwait(false);
-                await e.PrepareDataInspect().ConfigureAwait(false);
+                await e.SetVsGraphicsDevice();
+                await e.SetDefaultWorkingDirectory();
+                await e.PrepareDataInspect();
             });
 
             var initializationTask = _initializationTcs.Task;
-
-            return Task.WhenAny(initializationTask, _hostRunTask).Unwrap();
+            await Task.WhenAny(initializationTask, _hostRunTask).Unwrap();
         }
 
         public async Task StopHostAsync() {
@@ -85,14 +87,16 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
                 return;
             }
 
-            var request = await BeginInteractionAsync(false).ConfigureAwait(false);
+            await TaskUtilities.SwitchToBackgroundThread();
+
+            var request = await BeginInteractionAsync(false);
             if (_hostRunTask.IsCompleted) {
                 request.Dispose();
                 return;
             }
 
-            await request.Quit().ConfigureAwait(false);
-            await _hostRunTask.ConfigureAwait(false);
+            await request.Quit();
+            await _hostRunTask;
         }
 
         Task IRCallbacks.Connected(string rVersion) {
@@ -101,7 +105,6 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
         }
 
         Task IRCallbacks.Disconnected() {
-
             var currentRequest = Interlocked.Exchange(ref _currentRequestSource, null);
             currentRequest?.Complete();
 
@@ -127,6 +130,8 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
         }
 
         async Task<string> IRCallbacks.ReadConsole(IReadOnlyList<IRContext> contexts, string prompt, string buf, int len, bool addToHistory, bool isEvaluationAllowed, CancellationToken ct) {
+            await TaskUtilities.SwitchToBackgroundThread();
+
             var currentRequest = Interlocked.Exchange(ref _currentRequestSource, null);
 
             _contexts = contexts;
@@ -139,7 +144,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
             Task evaluationTask;
 
             if (isEvaluationAllowed) {
-                await EvaluateAll(contexts, ct).ConfigureAwait(false);
+                await EvaluateAll(contexts, ct);
                 evaluationCts = new CancellationTokenSource();
                 evaluationTask = EvaluateUntilCancelled(contexts, evaluationCts.Token, ct);
             } else {
@@ -155,7 +160,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
                 ct.ThrowIfCancellationRequested();
 
                 try {
-                    consoleInput = await ReadNextRequest(prompt, len, ct).ConfigureAwait(false);
+                    consoleInput = await ReadNextRequest(prompt, len, ct);
                 } catch (TaskCanceledException) {
                     // If request was canceled through means other than our token, it indicates the refusal of
                     // that requestor to respond to that particular prompt, so move on to the next requestor.
@@ -166,7 +171,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
 
             // If evaluation was allowed, cancel evaluation processing but await evaluation that is in progress
             evaluationCts?.Cancel();
-            await evaluationTask.ConfigureAwait(false);
+            await evaluationTask;
 
             OnAfterRequest(contexts, prompt, len, addToHistory);
 
@@ -174,15 +179,16 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
         }
 
         private async Task<string> ReadNextRequest(string prompt, int len, CancellationToken ct) {
-            var requestSource = await _pendingRequestSources.ReceiveAsync(ct).ConfigureAwait(false);
+            TaskUtilities.AssertIsOnBackgroundThread();
 
+            var requestSource = await _pendingRequestSources.ReceiveAsync(ct);
             TaskCompletionSource<string> requestTcs = new TaskCompletionSource<string>();
             Interlocked.Exchange(ref _currentRequestSource, requestSource);
 
             requestSource.Request(prompt, len, requestTcs);
             ct.Register(delegate { requestTcs.TrySetCanceled(); });
 
-            string response = await requestTcs.Task.ConfigureAwait(false);
+            string response = await requestTcs.Task;
 
             Debug.Assert(response.Length < len); // len includes null terminator
             if (response.Length >= len) {
@@ -193,12 +199,13 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
         }
 
         private async Task EvaluateUntilCancelled(IReadOnlyList<IRContext> contexts, CancellationToken evaluationCancellationToken, CancellationToken hostCancellationToken) {
-            var ct = CancellationTokenSource.CreateLinkedTokenSource(hostCancellationToken, evaluationCancellationToken).Token;
+            TaskUtilities.AssertIsOnBackgroundThread();
 
+            var ct = CancellationTokenSource.CreateLinkedTokenSource(hostCancellationToken, evaluationCancellationToken).Token;
             while (!ct.IsCancellationRequested) {
                 try {
-                    var evaluationSource = await _pendingEvaluationSources.ReceiveAsync(ct).ConfigureAwait(false);
-                    await evaluationSource.BeginEvaluationAsync(contexts, _host, hostCancellationToken).ConfigureAwait(false);
+                    var evaluationSource = await _pendingEvaluationSources.ReceiveAsync(ct);
+                    await evaluationSource.BeginEvaluationAsync(contexts, _host, hostCancellationToken);
                 } catch (TaskCanceledException) {
                     return;
                 }
@@ -206,9 +213,11 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
         }
 
         private async Task EvaluateAll(IReadOnlyList<IRContext> contexts, CancellationToken ct) {
+            TaskUtilities.AssertIsOnBackgroundThread();
+
             RSessionEvaluationSource source;
             while (!ct.IsCancellationRequested && _pendingEvaluationSources.TryReceive(out source)) {
-                await source.BeginEvaluationAsync(contexts, _host, ct).ConfigureAwait(false);
+                await source.BeginEvaluationAsync(contexts, _host, ct);
             }
         }
 
@@ -231,8 +240,10 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
         }
 
         async Task<YesNoCancel> IRCallbacks.YesNoCancel(IReadOnlyList<IRContext> contexts, string s, bool isEvaluationAllowed, CancellationToken ct) {
+            await TaskUtilities.SwitchToBackgroundThread();
+
             if (isEvaluationAllowed) {
-                await EvaluateAll(contexts, ct).ConfigureAwait(false);
+                await EvaluateAll(contexts, ct);
             }
 
             return YesNoCancel.Yes;
@@ -246,7 +257,6 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(CancellationToken.None);
 
             var frame = FindPlotWindow(__VSFINDTOOLWIN.FTW_fFindFirst | __VSFINDTOOLWIN.FTW_fForceCreate);  // TODO: acquire plot content provider through service
-
             if (frame != null) {
                 object docView;
                 ErrorHandler.ThrowOnFailure(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out docView));

--- a/src/Package/Impl/Repl/Session/RSessionInteraction.cs
+++ b/src/Package/Impl/Repl/Session/RSessionInteraction.cs
@@ -3,10 +3,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.R.Host.Client;
 
-namespace Microsoft.VisualStudio.R.Package.Repl.Session
-{
-    internal sealed class RSessionInteraction : IRSessionInteraction
-    {
+namespace Microsoft.VisualStudio.R.Package.Repl.Session {
+    internal sealed class RSessionInteraction : IRSessionInteraction {
         private readonly TaskCompletionSource<string> _requestTcs;
         private readonly TaskCompletionSource<object> _responseTcs;
 
@@ -19,8 +17,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session
             TaskCompletionSource<object> responseTcs,
             string prompt,
             int maxLength,
-            IReadOnlyList<IRContext> contexts)
-        {
+            IReadOnlyList<IRContext> contexts) {
             _requestTcs = requestTcs;
             _responseTcs = responseTcs;
             Prompt = prompt;
@@ -28,14 +25,12 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session
             Contexts = contexts;
         }
 
-        public Task RespondAsync(string messageText)
-        {
+        public Task RespondAsync(string messageText) {
             _requestTcs.SetResult(messageText);
             return _responseTcs.Task;
         }
 
-        public void Dispose()
-        {
+        public void Dispose() {
             _requestTcs.TrySetCanceled();
         }
     }

--- a/src/Package/Impl/Repl/Session/RSessionInteractionCommands.cs
+++ b/src/Package/Impl/Repl/Session/RSessionInteractionCommands.cs
@@ -3,8 +3,8 @@ using Microsoft.R.Host.Client;
 
 namespace Microsoft.VisualStudio.R.Package.Repl.Session {
     public static class RSessionInteractionCommands {
-        public static async Task Quit(this IRSessionInteraction interaction) {
-            await interaction.RespondAsync("q()\n").ConfigureAwait(false);
+        public static Task Quit(this IRSessionInteraction interaction) {
+            return interaction.RespondAsync("q()\n");
         }
     }
 }

--- a/src/Package/Impl/Repl/Session/RSessionRequestSource.cs
+++ b/src/Package/Impl/Repl/Session/RSessionRequestSource.cs
@@ -2,10 +2,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.R.Host.Client;
 
-namespace Microsoft.VisualStudio.R.Package.Repl.Session
-{
-    internal sealed class RSessionRequestSource
-    {
+namespace Microsoft.VisualStudio.R.Package.Repl.Session {
+    internal sealed class RSessionRequestSource {
         private readonly TaskCompletionSource<IRSessionInteraction> _createRequestTcs;
         private readonly TaskCompletionSource<object> _responseTcs;
 
@@ -13,8 +11,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session
         public bool IsVisible { get; }
         public IReadOnlyList<IRContext> Contexts { get; }
 
-        public RSessionRequestSource(bool isVisible, IReadOnlyList<IRContext> contexts)
-        {
+        public RSessionRequestSource(bool isVisible, IReadOnlyList<IRContext> contexts) {
             _createRequestTcs = new TaskCompletionSource<IRSessionInteraction>();
             _responseTcs = new TaskCompletionSource<object>();
 
@@ -22,19 +19,16 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Session
             Contexts = contexts ?? new[] { RHost.TopLevelContext };
         }
 
-        public void Request(string prompt, int maxLength, TaskCompletionSource<string> requestTcs)
-        {
+        public void Request(string prompt, int maxLength, TaskCompletionSource<string> requestTcs) {
             var request = new RSessionInteraction(requestTcs, _responseTcs, prompt, maxLength, Contexts);
             _createRequestTcs.SetResult(request);
         }
 
-        public void Fail(string text)
-        {
+        public void Fail(string text) {
             _responseTcs.SetException(new RException(text));
         }
 
-        public void Complete()
-        {
+        public void Complete() {
             _responseTcs.SetResult(null);
         }
 


### PR DESCRIPTION
Add helper methods to deal with background threads in async code: swiching to a background thread unless already on one, checking if current thread is a background thread, and asserting the same.

Remove ConfigureAwait(false) throughout RHost and RSession code and replace them with switches and asserts as needed.
