### PR TITLE
Task 183: Implement safe repr (dput) - RTVS

### DIFF
--- a/src/Debugger/Engine/Impl/AD7Expression.cs
+++ b/src/Debugger/Engine/Impl/AD7Expression.cs
@@ -31,7 +31,7 @@ namespace Microsoft.R.Debugger.Engine {
             _cts = new CancellationTokenSource();
             Task.Run(async () => {
                 try {
-                    var res = await StackFrame.StackFrame.EvaluateAsync(_expression);
+                    var res = await StackFrame.StackFrame.EvaluateAsync(_expression, reprMaxLength: AD7Property.ReprMaxLength);
                     _cts.Token.ThrowIfCancellationRequested();
                     var prop = new AD7Property(StackFrame, res);
                     StackFrame.Engine.Send(new AD7ExpressionEvaluationCompleteEvent(this, prop), AD7ExpressionEvaluationCompleteEvent.IID);
@@ -45,7 +45,7 @@ namespace Microsoft.R.Debugger.Engine {
         }
 
         int IDebugExpression2.EvaluateSync(enum_EVALFLAGS dwFlags, uint dwTimeout, IDebugEventCallback2 pExprCallback, out IDebugProperty2 ppResult) {
-            var res = StackFrame.StackFrame.EvaluateAsync(_expression).WaitAndUnwrapExceptions();
+            var res = StackFrame.StackFrame.EvaluateAsync(_expression, reprMaxLength: AD7Property.ReprMaxLength).WaitAndUnwrapExceptions();
             ppResult = new AD7Property(StackFrame, res);
             return VSConstants.S_OK;
         }

--- a/src/Debugger/Impl/DebugStackFrame.cs
+++ b/src/Debugger/Impl/DebugStackFrame.cs
@@ -102,8 +102,13 @@ namespace Microsoft.R.Debugger {
             }
         }
 
-        public Task<DebugEvaluationResult> EvaluateAsync(string expression, string name = null) {
-            return Session.EvaluateAsync(this, expression, name, SysFrame);
+        public Task<DebugEvaluationResult> EvaluateAsync(
+            string expression,
+            string name = null,
+            DebugEvaluationResultFields fields = DebugEvaluationResultFields.All,
+            int? reprMaxLength = null
+        ) {
+            return Session.EvaluateAsync(this, expression, name, null, fields, reprMaxLength);
         }
 
         public Task<DebugEvaluationResult> GetEnvironmentAsync() {

--- a/src/Debugger/Impl/rtvs/R/json.R
+++ b/src/Debugger/Impl/rtvs/R/json.R
@@ -12,11 +12,10 @@
 # If any element of a vector, list or environment is NA, that element is skipped.
 toJSON <- function(data, con) {
   if (missing(con)) {
-    con <- textConnection(NULL, open = "w");
+    con <- memory_connection(NA, 0x10000);
     on.exit(close(con), add = TRUE);
     Recall(data, con);
-    cat('\n', file = con, sep = '');
-    return(paste0(textConnectionValue(con), collapse=''));
+    return(memory_connection_tochar(con));
   }
 
   to_literal_or_array <- function() {

--- a/src/Package/Impl/DataInspect/EvaluationWrapper.cs
+++ b/src/Package/Impl/DataInspect/EvaluationWrapper.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
                 var fields = (DebugEvaluationResultFields.All & ~DebugEvaluationResultFields.ReprAll) |
                     DebugEvaluationResultFields.Repr | DebugEvaluationResultFields.ReprStr;
-                var children = await valueEvaluation.GetChildrenAsync(fields, _truncateChildren ? (int?)20 : null);    // TODO: consider exception propagation such as OperationCanceledException
+                var children = await valueEvaluation.GetChildrenAsync(fields, _truncateChildren ? (int?)20 : null, 100);    // TODO: consider exception propagation such as OperationCanceledException
 
                 result = new List<EvaluationWrapper>();
                 foreach (var child in children) {


### PR DESCRIPTION
Utilize limited_connection to size-limit output produced by dput and str.

Refactor .Call usage - use unified format for function names, and explicitly designate package to speed up lookups.
