### PR TITLE
Make product code different for all versions so MSI upgrades

### DIFF
--- a/src/Setup/Product.wxs
+++ b/src/Setup/Product.wxs
@@ -5,7 +5,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 
-  <Product Id="{83BA6F08-ACC3-4A57-9A2C-9DFBC0F03AD2}"
+  <Product Id="*"
            Name="$(var.ProductName)"
            Language="1033"
            Version="$(var.MsiVersion)"


### PR DESCRIPTION
Per http://wixtoolset.org/documentation/manual/v3/howtos/updates/major_upgrade.html
Product code must change since otherwise MSI thinks product is already installed. MSI also must have MajorUpgrade element and the UpgradeCode must match previous version. This way setup will install and during install detect existing upgrade code and uninstall it since it is a major upgrade. As an indicator initial install requires 7 MB. Upgrade over it claims it needs 12MB which is correct since it needs space to uninstall previous version.

Also disable plot commands when plot hasn't been created yet.
