### PR TITLE
Fix history category name in Tools | Options

### DIFF
--- a/src/Languages/Editor/Impl/BraceMatch/BraceHighlightTag.cs
+++ b/src/Languages/Editor/Impl/BraceMatch/BraceHighlightTag.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualStudio.Text.Tagging;
 namespace Microsoft.Languages.Editor.BraceMatch {
     public class BraceHighlightTag : TextMarkerTag {
         public BraceHighlightTag()
-            : base("MarkerFormatDefinition/HighlightedReference") {
+            : base("brace matching") {
         }
     }
 }

--- a/src/Package/Impl/Resources.Designer.cs
+++ b/src/Package/Impl/Resources.Designer.cs
@@ -851,6 +851,15 @@ namespace Microsoft.VisualStudio.R.Package {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to History.
+        /// </summary>
+        public static string Settings_HistoryCategory {
+            get {
+                return ResourceManager.GetString("Settings_HistoryCategory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to IntelliSense.
         /// </summary>
         public static string Settings_IntellisenseCategory {

--- a/src/Package/Impl/Resources.resx
+++ b/src/Package/Impl/Resources.resx
@@ -493,4 +493,7 @@ please navigate to https://cran.r-project.org, install R for Windows and restart
   <data name="Settings_RCommandLineArguments_Description" xml:space="preserve">
     <value>Additional arguments to pass to the R Host process</value>
   </data>
+  <data name="Settings_HistoryCategory" xml:space="preserve">
+    <value>History</value>
+  </data>
 </root>


### PR DESCRIPTION
Fix 'Brace Matching' color name
