### PR TITLE
Fix #473 and #485

### DIFF
--- a/src/Debugger/Engine/Impl/AD7Engine.cs
+++ b/src/Debugger/Engine/Impl/AD7Engine.cs
@@ -53,6 +53,7 @@ namespace Microsoft.R.Debugger.Engine {
 
             DebugSession.Browse -= Session_Browse;
             DebugSession.RSession.AfterRequest -= RSession_AfterRequest;
+            DebugSession.RSession.Disconnected -= RSession_Disconnected;
 
             _events = null;
             _program = null;
@@ -130,6 +131,7 @@ namespace Microsoft.R.Debugger.Engine {
             // we may get a Browse event immediately, and we want to raise a breakpoint notification in response to that
             // to pause the debugger - but it will be ignored unless the engine has reported its creation.
             DebugSession.RSession.AfterRequest += RSession_AfterRequest;
+            DebugSession.RSession.Disconnected += RSession_Disconnected;
             DebugSession.Browse += Session_Browse;
 
             return VSConstants.S_OK;
@@ -514,6 +516,10 @@ namespace Microsoft.R.Debugger.Engine {
                 var ex = Marshal.GetExceptionForHR(vsShell.PostExecCommand(ref group, (uint)VSConstants.VSStd97CmdID.Start, 0, ref arg));
                 Trace.Assert(ex == null);
             }
+        }
+
+        private async void RSession_Disconnected(object sender, EventArgs e) {
+            Send(new AD7ProgramDestroyEvent(0), AD7ProgramDestroyEvent.IID);
         }
     }
 }

--- a/src/Debugger/Impl/DebugBreakpoint.cs
+++ b/src/Debugger/Impl/DebugBreakpoint.cs
@@ -69,6 +69,7 @@ namespace Microsoft.R.Debugger {
         public async Task DeleteAsync() {
             Trace.Assert(UseCount > 0);
             await TaskUtilities.SwitchToBackgroundThread();
+            await Session.InitializeAsync();
 
             string fileName = null;
             try {


### PR DESCRIPTION
Fix #473: Eval is broken immediately after stepping in

Use C-level .Internal(parse) detouring instead of R code.

Use a nested browser() trick to reset the last stepping command and prevent R from breaking in eval after step-in.

Fix #485: Debugger remains attached if R-Host goes down

Detach debugger if host is disconnected.
