### PR TITLE
Several bug fixes

### DIFF
--- a/src/Languages/Editor/Impl/EditorHelpers/TextBufferHelper.cs
+++ b/src/Languages/Editor/Impl/EditorHelpers/TextBufferHelper.cs
@@ -183,6 +183,30 @@ namespace Microsoft.Languages.Editor.EditorHelpers {
             return textBuffer.ContentType.TypeName.EndsWithIgnoreCase(" Signature Help");
         }
 
+        public static bool IsContentEqualsOrdinal(this ITextBuffer textBuffer, ITrackingSpan span1, ITrackingSpan span2) {
+            var snapshot = textBuffer.CurrentSnapshot;
+            var snapshotSpan1 = span1.GetSpan(snapshot);
+            var snapshotSpan2 = span2.GetSpan(snapshot);
+
+            if (snapshotSpan1 == snapshotSpan2) {
+                return true;
+            }
+
+            if (snapshotSpan1.Length != snapshotSpan2.Length) {
+                return false;
+            }
+
+            var start1 = snapshotSpan1.Start;
+            var start2 = snapshotSpan2.Start;
+            for (int i = 0; i < snapshotSpan1.Length; i++) {
+                if (snapshot[start1 + i] != snapshot[start2 + i]) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         public static string GetLineBreakText(this ITextBuffer textBuffer) {
             return (textBuffer.CurrentSnapshot.LineCount > 0)
                 ? textBuffer.CurrentSnapshot.GetLineFromLineNumber(0).GetLineBreakText()

--- a/src/Package/Impl/Commands/R/RPackageCommandId.cs
+++ b/src/Package/Impl/Commands/R/RPackageCommandId.cs
@@ -80,5 +80,6 @@
         public const int icmdSendHistoryToSource = 1203;
         public const int icmdDeleteSelectedHistoryEntries = 1204;
         public const int icmdDeleteAllHistoryEntries = 1205;
+        public const int icmdToggleMultilineSelection = 1206;
     }
 }

--- a/src/Package/Impl/Commands/R/VsRCommandFactory.cs
+++ b/src/Package/Impl/Commands/R/VsRCommandFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.R.Package.Commands.R {
             var commands = new List<ICommand>();
 
             commands.Add(new ShowContextMenuCommand(textView, RGuidList.RPackageGuid, RGuidList.RCmdSetGuid, (int)RContextMenuId.R));
-            commands.Add(new SendToReplCommand(textView, textBuffer));
+            commands.Add(new SendToReplCommand(textView));
             commands.Add(new SourceRScriptCommand(textView));
             commands.Add(new GoToFormattingOptionsCommand(textView, textBuffer));
             commands.Add(new WorkingDirectoryCommand());

--- a/src/Package/Impl/Commands/RHistory/VsRHistoryCommandFactory.cs
+++ b/src/Package/Impl/Commands/RHistory/VsRHistoryCommandFactory.cs
@@ -2,9 +2,11 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.Languages.Editor.Controller;
 using Microsoft.R.Editor.ContentType;
+using Microsoft.R.Support.Settings;
 using Microsoft.VisualStudio.R.Package.Commands.R;
 using Microsoft.VisualStudio.R.Package.History;
 using Microsoft.VisualStudio.R.Package.History.Commands;
+using Microsoft.VisualStudio.R.Package.Repl.Commands;
 using Microsoft.VisualStudio.R.Package.Utilities;
 using Microsoft.VisualStudio.R.Packages.R;
 using Microsoft.VisualStudio.Text;
@@ -47,6 +49,7 @@ namespace Microsoft.VisualStudio.R.Package.Commands.RHistory {
                 new DeleteAllHistoryEntriesCommand(textView, _historyProvider),
                 new HistoryWindowVsStd2KCmdIdReturnCommand(textView, sendToReplCommand, sendToSourceCommand),
                 new HistoryWindowVsStd97CmdIdSelectAllCommand(textView, _historyProvider),
+                new ToggleMultilineHistorySelectionCommand(textView, _historyProvider, RToolsSettings.Current), 
                 new CopySelectedHistoryCommand(textView, _historyProvider, _editorOperationsService)
             };
         }

--- a/src/Package/Impl/History/Commands/HistoryWindowVsStd97CmdIdSelectAllCommand.cs
+++ b/src/Package/Impl/History/Commands/HistoryWindowVsStd97CmdIdSelectAllCommand.cs
@@ -1,7 +1,6 @@
 using System;
 using Microsoft.Languages.Editor;
 using Microsoft.Languages.Editor.Controller.Command;
-using Microsoft.Languages.Editor.Shell;
 using Microsoft.VisualStudio.R.Package.Repl;
 using Microsoft.VisualStudio.Text.Editor;
 

--- a/src/Package/Impl/History/Commands/SendHistoryToReplCommand.cs
+++ b/src/Package/Impl/History/Commands/SendHistoryToReplCommand.cs
@@ -11,7 +11,10 @@ namespace Microsoft.VisualStudio.R.Package.History.Commands {
         private readonly IRHistory _history;
 
         public SendHistoryToReplCommand(ITextView textView, IRHistoryProvider historyProvider)
-            : base(textView, RGuidList.RCmdSetGuid, RPackageCommandId.icmdSendHistoryToRepl, false) {
+            : base(textView, new [] {
+                new CommandId(RGuidList.RCmdSetGuid, RPackageCommandId.icmdSendHistoryToRepl),
+                new CommandId(VSConstants.VsStd11, (int)VSConstants.VSStd11CmdID.ExecuteLineInInteractive)
+            }, false) {
             _history = historyProvider.GetAssociatedRHistory(textView);
         }
 

--- a/src/Package/Impl/History/Commands/SendHistoryToSourceCommand.cs
+++ b/src/Package/Impl/History/Commands/SendHistoryToSourceCommand.cs
@@ -25,18 +25,25 @@ namespace Microsoft.VisualStudio.R.Package.History.Commands {
         }
 
         public override CommandStatus Status(Guid guid, int id) {
-            return ReplWindow.ReplWindowExists() && (_history.HasSelectedEntries || !TextView.Selection.IsEmpty)
+            return ReplWindow.ReplWindowExists() && (_history.HasSelectedEntries || !TextView.Selection.IsEmpty) && GetLastActiveRTextView() != null
                 ? CommandStatus.SupportedAndEnabled
                 : CommandStatus.Supported;
         }
 
         public override CommandResult Invoke(Guid group, int id, object inputArg, ref object outputArg) {
-            var textView = _textViewTracker.GetLastActiveTextView(_contentType);
-            if (textView != null && !textView.IsClosed && textView.VisualElement.IsVisible) {
+            var textView = GetLastActiveRTextView();
+            if (textView != null) {
                 _history.SendSelectedToTextView(textView);
             }
 
             return CommandResult.Executed;
+        }
+
+        private IWpfTextView GetLastActiveRTextView() {
+            var textView = _textViewTracker.GetLastActiveTextView(_contentType);
+            return textView != null && !textView.IsClosed && textView.VisualElement.IsVisible
+                ? textView
+                : null;
         }
     }
 }

--- a/src/Package/Impl/History/Commands/ToggleMultilineHistorySelectionCommand.cs
+++ b/src/Package/Impl/History/Commands/ToggleMultilineHistorySelectionCommand.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.Languages.Editor;
+using Microsoft.Languages.Editor.Controller.Command;
+using Microsoft.R.Support.Settings;
+using Microsoft.R.Support.Settings.Definitions;
+using Microsoft.VisualStudio.R.Package.Commands;
+using Microsoft.VisualStudio.R.Package.Repl;
+using Microsoft.VisualStudio.R.Packages.R;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Microsoft.VisualStudio.R.Package.History.Commands {
+    internal class ToggleMultilineHistorySelectionCommand : ViewCommand {
+        private readonly IRToolsSettings _settings;
+        private readonly IRHistory _history;
+
+        public ToggleMultilineHistorySelectionCommand(ITextView textView, IRHistoryProvider historyProvider, IRToolsSettings settings)
+            : base(textView, RGuidList.RCmdSetGuid, RPackageCommandId.icmdToggleMultilineSelection, false) {
+            _history = historyProvider.GetAssociatedRHistory(textView);
+            _settings = settings;
+        }
+
+        public override CommandStatus Status(Guid guid, int id) {
+            return ReplWindow.ReplWindowExists()
+                ? RToolsSettings.Current.MultilineHistorySelection 
+                    ? CommandStatus.Latched | CommandStatus.SupportedAndEnabled
+                    : CommandStatus.SupportedAndEnabled
+                : CommandStatus.Supported;
+        }
+
+        public override CommandResult Invoke(Guid guid, int id, object inputArg, ref object outputArg) {
+            _settings.MultilineHistorySelection = !_settings.MultilineHistorySelection;
+            _history.IsMultiline = _settings.MultilineHistorySelection;
+            return CommandResult.Executed;
+        }
+    }
+}

--- a/src/Package/Impl/History/HistoryWindowPaneMouseProcessor.cs
+++ b/src/Package/Impl/History/HistoryWindowPaneMouseProcessor.cs
@@ -217,7 +217,11 @@ namespace Microsoft.VisualStudio.R.Package.History {
         private bool HandleDoubleClick(InputEventArgs e, ModifierKeys modifiers) {
             switch (modifiers) {
                 case ModifierKeys.None:
-                    _history.SendSelectedToRepl();
+                    var point = GetAdjustedPosition(e, _textView);
+                    var textLine = GetTextViewLineUnderPoint(point);
+                    if (textLine != null) {
+                        _history.SendSelectedToRepl();
+                    }
                     return true;
 
                 default:

--- a/src/Package/Impl/History/IRHistory.cs
+++ b/src/Package/Impl/History/IRHistory.cs
@@ -9,6 +9,7 @@ namespace Microsoft.VisualStudio.R.Package.History {
         event EventHandler<EventArgs> HistoryChanged;
         bool HasSelectedEntries { get; }
         bool HasEntries { get; }
+        bool IsMultiline { get; set; }
 
         bool TryLoadFromFile(string path);
         bool TrySaveToFile(string path);
@@ -20,13 +21,14 @@ namespace Microsoft.VisualStudio.R.Package.History {
 
         IReadOnlyList<SnapshotSpan> GetSelectedHistoryEntrySpans();
         string GetSelectedText();
+
         SnapshotSpan SelectHistoryEntry(int lineNumber);
         SnapshotSpan DeselectHistoryEntry(int lineNumber);
         SnapshotSpan ToggleHistoryEntrySelection(int lineNumber);
-
         void SelectHistoryEntries(IEnumerable<int> lineNumbers);
         void SelectAllEntries();
         void ClearHistoryEntrySelection();
+
         void DeleteSelectedHistoryEntries();
         void DeleteAllHistoryEntries();
         void Filter(string searchPattern);

--- a/src/Package/Impl/History/IRHistoryEntries.cs
+++ b/src/Package/Impl/History/IRHistoryEntries.cs
@@ -1,18 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.R.Package.History {
     internal interface IRHistoryEntries {
         IReadOnlyList<IRHistoryEntry> GetEntries();
         IReadOnlyList<IRHistoryEntry> GetSelectedEntries();
-        IEnumerable<string> GetEntriesText();
-        IEnumerable<string> GetSelectedEntriesText();
         IRHistoryEntry Find(Func<IRHistoryEntry, bool> predicate);
         IRHistoryEntry FirstOrDefault();
         IRHistoryEntry LastOrDefault();
+        bool IsMultiline { get; }
         bool HasEntries { get; }
         bool HasSelectedEntries { get; }
-        IRHistoryEntry Add(string text);
+        void Add(ITrackingSpan entrySpan);
         void Remove(IRHistoryEntry historyEntry);
         void SelectAll();
         void UnselectAll();

--- a/src/Package/Impl/History/IRHistoryEntry.cs
+++ b/src/Package/Impl/History/IRHistoryEntry.cs
@@ -2,8 +2,8 @@
 
 namespace Microsoft.VisualStudio.R.Package.History {
     public interface IRHistoryEntry {
-        string Text { get; }
-        ITrackingSpan TrackingSpan { get; set; }
+        ITrackingSpan EntrySpan { get; }
+        ITrackingSpan Span { get; }
         bool IsSelected { get; set; }
 
         IRHistoryEntry Next { get; }

--- a/src/Package/Impl/History/MultilineRHistoryEntries.cs
+++ b/src/Package/Impl/History/MultilineRHistoryEntries.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.R.Package.History {
+    internal sealed class MultilineRHistoryEntries : RHistoryEntries {
+        public override bool IsMultiline => true;
+
+        public MultilineRHistoryEntries() {
+        }
+
+        public MultilineRHistoryEntries(IRHistoryEntries entries) {
+            if (!entries.IsMultiline) {
+                CloneFromSingleline(entries);
+            } else {
+                CloneEntries(entries);
+            }
+        }
+
+        public override void Add(ITrackingSpan entrySpan) {
+            AddMultilineEntry(entrySpan);
+        }
+
+        private void CloneFromSingleline(IRHistoryEntries existingEntries) {
+            foreach (var entrySpanGroup in existingEntries.GetEntries().GroupBy(e => e.EntrySpan)) {
+                var newEntry = AddMultilineEntry(entrySpanGroup.Key);
+                newEntry.IsSelected = entrySpanGroup.Any(e => e.IsSelected);
+            }
+        }
+
+        private IRHistoryEntry AddMultilineEntry(ITrackingSpan entrySpan) {
+            return AddEntry(entrySpan, entrySpan);
+        }
+    }
+}

--- a/src/Package/Impl/History/RHistoryProvider.cs
+++ b/src/Package/Impl/History/RHistoryProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.Common.Core.IO;
+using Microsoft.R.Support.Settings;
 using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text.Editor;
@@ -38,7 +39,7 @@ namespace Microsoft.VisualStudio.R.Package.History {
             }
 
             var vsUiShell = VsAppShell.Current.GetGlobalService<IVsUIShell>(typeof(SVsUIShell));
-            return new RHistory(textView, FileSystem, EditorOperationsFactory, elisionBuffer, RtfBuilderService, TextSearchService, vsUiShell);
+            return new RHistory(textView, FileSystem, RToolsSettings.Current, EditorOperationsFactory, elisionBuffer, RtfBuilderService, TextSearchService, vsUiShell);
         }
     }
 }

--- a/src/Package/Impl/History/SinglelineRHistoryEntries.cs
+++ b/src/Package/Impl/History/SinglelineRHistoryEntries.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.R.Package.History {
+    internal sealed class SinglelineRHistoryEntries : RHistoryEntries {
+        public override bool IsMultiline => false;
+
+        public SinglelineRHistoryEntries() {
+        }
+
+        public SinglelineRHistoryEntries(IRHistoryEntries entries) {
+            if (entries.IsMultiline) {
+                CloneFromMultiline(entries);
+            } else { 
+                CloneEntries(entries);
+            }
+        }
+
+        public override void Add(ITrackingSpan entrySpan) {
+            AddSinglelineEntries(entrySpan);
+        }
+
+        private void CloneFromMultiline(IRHistoryEntries existingEntries) {
+            foreach (var existingEntry in existingEntries.GetEntries()) {
+                var entriesGroup = AddSinglelineEntries(existingEntry.EntrySpan);
+                foreach (var newEntry in entriesGroup) {
+                    newEntry.IsSelected = existingEntry.IsSelected;
+                }
+            }
+        }
+
+        private IEnumerable<IRHistoryEntry> AddSinglelineEntries(ITrackingSpan entrySpan) {
+            var snapshot = entrySpan.TextBuffer.CurrentSnapshot;
+            var snapshotEntrySpan = entrySpan.GetSpan(snapshot);
+            var spans = snapshot.Lines
+                .Where(l => snapshotEntrySpan.Contains((SnapshotSpan) l.Extent))
+                .Select(l => snapshot.CreateTrackingSpan(l.Start, l.Length, SpanTrackingMode.EdgeExclusive));
+
+            foreach (var span in spans) {
+                yield return AddEntry(entrySpan, span);
+            }
+        }
+    }
+}

--- a/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
+++ b/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
@@ -118,6 +118,7 @@
     <Compile Include="History\Commands\SaveHistoryCommand.cs" />
     <Compile Include="History\Commands\SendHistoryToReplCommand.cs" />
     <Compile Include="History\Commands\SendHistoryToSourceCommand.cs" />
+    <Compile Include="History\Commands\ToggleMultilineHistorySelectionCommand.cs" />
     <Compile Include="History\HistorySelectionTextAdornment.cs" />
     <Compile Include="History\HistorySelectionTextAdornmentFactory.cs" />
     <Compile Include="History\HistoryWindowPane.cs" />
@@ -126,11 +127,13 @@
     <Compile Include="History\IRHistory.cs" />
     <Compile Include="History\IRHistoryEntries.cs" />
     <Compile Include="History\IRHistoryProvider.cs" />
+    <Compile Include="History\MultilineRHistoryEntries.cs" />
     <Compile Include="History\RHistory.cs" />
     <Compile Include="History\RHistoryEntries.cs" />
     <Compile Include="History\RHistoryProvider.cs" />
     <Compile Include="History\IRHistoryEntry.cs" />
     <Compile Include="History\ShowHistoryWindowCommand.cs" />
+    <Compile Include="History\SinglelineRHistoryEntries.cs" />
     <Compile Include="Imaging\ImagesProvider.cs" />
     <Compile Include="Interop\MailUtility.cs" />
     <Compile Include="Logging\LogCleanup.cs" />

--- a/src/Package/Impl/Options/R/RToolsOptionsPage.cs
+++ b/src/Package/Impl/Options/R/RToolsOptionsPage.cs
@@ -83,6 +83,15 @@ namespace Microsoft.VisualStudio.R.Package.Options.R {
             set { RToolsSettings.Current.ClearFilterOnAddHistory = value; }
         }
 
+        [LocCategory("Settings_HistoryCategory")]
+        [CustomLocDisplayName("Settings_MultilineHistorySelection")]
+        [LocDescription("Settings_MultilineHistorySelection_Description")]
+        [DefaultValue(false)]
+        public bool MultilineHistorySelection {
+            get { return RToolsSettings.Current.MultilineHistorySelection; }
+            set { RToolsSettings.Current.MultilineHistorySelection = value; }
+        }
+
         [LocCategory("Settings_GeneralCategory")]
         [CustomLocDisplayName("Settings_RBasePath")]
         [LocDescription("Settings_RBasePath_Description")]

--- a/src/Package/Impl/Options/R/Tools/RToolsSettingsImplementation.cs
+++ b/src/Package/Impl/Options/R/Tools/RToolsSettingsImplementation.cs
@@ -36,6 +36,8 @@ namespace Microsoft.VisualStudio.R.Package.Options.R {
 
         public bool ClearFilterOnAddHistory { get; set; } = true;
 
+        public bool MultilineHistorySelection { get; set; } = true;
+
         public string CranMirror {
             get { return _cranMirror; }
             set {

--- a/src/Package/Impl/Package.vsct
+++ b/src/Package/Impl/Package.vsct
@@ -289,6 +289,9 @@
       <Group guid="guidRToolsCmdSet" id="historyWindowDeleteGroup" priority="0x0100">
         <Parent guid="guidRToolsCmdSet" id="historyWindowToolBarId"/>
       </Group>
+      <Group guid="guidRToolsCmdSet" id="historyWindowSettingsGroup" priority="0x0100">
+        <Parent guid="guidRToolsCmdSet" id="historyWindowToolBarId"/>
+      </Group>
       <Group guid="guidRToolsCmdSet" id="historyCopySelectedGroup" priority="0x100">
       </Group>
 
@@ -876,6 +879,16 @@
           <ButtonText>Delete all history entries</ButtonText>
         </Strings>
       </Button>
+      
+      <Button guid="guidRToolsCmdSet" id="icmdToggleMultilineSelection" priority="0x0100" type="Button">
+        <Parent guid="guidRToolsCmdSet" id="historyWindowSettingsGroup"/>
+        <Icon guid="ImageCatalogGuid" id="BlockSelection"/>
+        <CommandFlag>DefaultDisabled</CommandFlag>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>Toggle Multiline Selection</ButtonText>
+        </Strings>
+      </Button>
       <!-- End history window buttons -->
       
       <Button guid="guidRToolsCmdSet" id="icmdGoToFormattingOptions" priority="0x0200" type="Button">
@@ -1390,6 +1403,7 @@
       <IDSymbol name="icmdSendHistoryToSource" value="1203" />
       <IDSymbol name="icmdDeleteSelectedHistoryEntries" value="1204" />
       <IDSymbol name="icmdDeleteAllHistoryEntries" value="1205" />
+      <IDSymbol name="icmdToggleMultilineSelection" value="1206" />
 
       <IDSymbol name="plotToolbarFileGroup" value="0x1000" />
       <IDSymbol name="plotToolbarPrintGroup" value="0x1100" />
@@ -1405,7 +1419,8 @@
       <IDSymbol name="historyWindowLoadSaveGroup" value="0x2021"/>
       <IDSymbol name="historyWindowSendToGroup" value="0x2022"/>
       <IDSymbol name="historyWindowDeleteGroup" value="0x2023"/>
-      <IDSymbol name="historyCopySelectedGroup" value="0x2024"/>
+      <IDSymbol name="historyWindowSettingsGroup" value="0x2024"/>
+      <IDSymbol name="historyCopySelectedGroup" value="0x2025"/>
 
       <!-- Submenus-->
       <IDSymbol name="mainMenuGroup" value="0x100"/>

--- a/src/Package/Impl/Repl/Commands/ReplCommandFactory.cs
+++ b/src/Package/Impl/Repl/Commands/ReplCommandFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Commands {
                 new ReplFormatDocumentCommand(textView, textBuffer),
                 new FormatSelectionCommand(textView, textBuffer),
                 new FormatOnPasteCommand(textView, textBuffer),
-                new SendToReplCommand(textView, textBuffer),
+                new SendToReplCommand(textView),
                 new RTypingCommandHandler(textView),
                 new RCompletionCommandHandler(textView),
                 new ExecuteCurrentCodeCommand(textView),

--- a/src/Package/Impl/Repl/Commands/SendToReplCommand.cs
+++ b/src/Package/Impl/Repl/Commands/SendToReplCommand.cs
@@ -11,9 +11,8 @@ using Microsoft.VisualStudio.TextManager.Interop;
 namespace Microsoft.VisualStudio.R.Package.Repl.Commands {
     public sealed class SendToReplCommand : ViewCommand {
         private ReplWindow _replWindow;
-        private static readonly object _executedToEnd = new object();
 
-        public SendToReplCommand(ITextView textView, ITextBuffer textBuffer) :
+        public SendToReplCommand(ITextView textView) :
             base(textView, new[]
             {
                 new CommandId(VSConstants.VsStd11, (int)VSConstants.VSStd11CmdID.ExecuteLineInInteractive),

--- a/src/Package/Impl/Resources.Designer.cs
+++ b/src/Package/Impl/Resources.Designer.cs
@@ -923,6 +923,24 @@ namespace Microsoft.VisualStudio.R.Package {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use multiline selection.
+        /// </summary>
+        public static string Settings_MultilineHistorySelection {
+            get {
+                return ResourceManager.GetString("Settings_MultilineHistorySelection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Single click in R history window selects the entire fragment that was sent to R.\r\nUp/Down arrows in the R Interactive Window navigate through chunks instead of single lines..
+        /// </summary>
+        public static string Settings_MultilineHistorySelection_Description {
+            get {
+                return ResourceManager.GetString("Settings_MultilineHistorySelection_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Match partially typed argument names.
         /// </summary>
         public static string Settings_PartialArgumentNameMatch {

--- a/src/Package/Impl/Resources.resx
+++ b/src/Package/Impl/Resources.resx
@@ -419,6 +419,12 @@
   <data name="Settings_ClearFilterOnAddHistory_Description" xml:space="preserve">
     <value>Reset search filter in history window when new entry is added or .RHistory file is loaded</value>
   </data>
+  <data name="Settings_MultilineHistorySelection" xml:space="preserve">
+    <value>Use multiline selection</value>
+  </data>
+  <data name="Settings_MultilineHistorySelection_Description" xml:space="preserve">
+    <value>Single click in R history window selects the entire fragment that was sent to R.\r\nUp/Down arrows in the R Interactive Window navigate through chunks instead of single lines.</value>
+  </data>
   <data name="Ask" xml:space="preserve">
     <value>Ask</value>
   </data>

--- a/src/R/Editor/Impl/Commands/RMainController.cs
+++ b/src/R/Editor/Impl/Commands/RMainController.cs
@@ -5,27 +5,22 @@ using Microsoft.Languages.Editor.Services;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 
-namespace Microsoft.R.Editor.Commands
-{
+namespace Microsoft.R.Editor.Commands {
     /// <summary>
     /// Main R editor command controller
     /// </summary>
-    public class RMainController : ViewController
-    {
+    public class RMainController : ViewController {
         public RMainController(ITextView textView, ITextBuffer textBuffer)
-            : base(textView, textBuffer)
-        {
+            : base(textView, textBuffer) {
             ServiceManager.AddService(this, textView);
         }
 
         /// <summary>
         /// Attaches command controller to the view and projected buffer
         /// </summary>
-        public static RMainController Attach(ITextView textView, ITextBuffer textBuffer)
-        {
+        public static RMainController Attach(ITextView textView, ITextBuffer textBuffer) {
             RMainController controller = FromTextView(textView);
-            if (controller == null)
-            {
+            if (controller == null) {
                 controller = new RMainController(textView, textBuffer);
             }
 
@@ -35,17 +30,14 @@ namespace Microsoft.R.Editor.Commands
         /// <summary>
         /// Retrieves R command controller from text view
         /// </summary>
-        public static RMainController FromTextView(ITextView textView)
-        {
+        public static RMainController FromTextView(ITextView textView) {
             return ServiceManager.GetService<RMainController>(textView);
         }
 
-        public override CommandStatus Status(Guid group, int id)
-        {
-            if ((NonRoutedStatus(group, id, null) & CommandStatus.SupportedAndEnabled) == CommandStatus.SupportedAndEnabled
-                && !IsCompletionCommand(group, id))
-            {
-                return CommandStatus.SupportedAndEnabled;
+        public override CommandStatus Status(Guid group, int id) {
+            var status = NonRoutedStatus(@group, id, null);
+            if ((status & CommandStatus.SupportedAndEnabled) == CommandStatus.SupportedAndEnabled && !IsCompletionCommand(group, id)) {
+                return status;
             }
 
             return base.Status(group, id);
@@ -54,8 +46,7 @@ namespace Microsoft.R.Editor.Commands
         /// <summary>
         /// Determines if command is one of the completion commands
         /// </summary>
-        private bool IsCompletionCommand(Guid group, int id)
-        {
+        private bool IsCompletionCommand(Guid group, int id) {
             ICommand cmd = Find(group, id);
             return cmd is RCompletionCommandHandler;
         }
@@ -63,10 +54,8 @@ namespace Microsoft.R.Editor.Commands
         /// <summary>
         /// Disposes main controller and removes it from service manager.
         /// </summary>
-        protected override void Dispose(bool disposing)
-        {
-            if (TextView != null)
-            {
+        protected override void Dispose(bool disposing) {
+            if (TextView != null) {
                 ServiceManager.RemoveService<RMainController>(TextView);
             }
 

--- a/src/R/Support/Impl/Settings/Definitions/IRToolsSettings.cs
+++ b/src/R/Support/Impl/Settings/Definitions/IRToolsSettings.cs
@@ -20,6 +20,7 @@ namespace Microsoft.R.Support.Settings.Definitions {
 
         bool AlwaysSaveHistory { get; set; }
         bool ClearFilterOnAddHistory { get; set; }
+        bool MultilineHistorySelection { get; set; }
 
         /// <summary>
         /// Current working directory for REPL

--- a/src/R/Support/Test/Utility/TestRToolsSettings.cs
+++ b/src/R/Support/Test/Utility/TestRToolsSettings.cs
@@ -43,6 +43,11 @@ namespace Microsoft.R.Support.Test.Utility {
             set { }
         }
 
+        public bool MultilineHistorySelection {
+            get { return true; }
+            set { }
+        }
+
         public void LoadFromStorage() {
         }
 


### PR DESCRIPTION
- Fix #531: Send to Source file in history should be disabled when there is nothing open
- Fix #510: Double click in history window empty space should not do anything
- Fix #504: Ctrl-Enter when focus is on History Window should send the line from History Window to REPL
- Added setting and toggle button to switch singleline/multiline selection
- Fixed memory leak in RHistoryEntries. Also, it doesn't store strings anymore - only tracking spans
