### PR TITLE
Fix #526: Cannot step when at top-level

### DIFF
--- a/src/Debugger/Impl/rtvs/NAMESPACE
+++ b/src/Debugger/Impl/rtvs/NAMESPACE
@@ -1,0 +1,1 @@
+export(debug_source)

--- a/src/Package/Impl/Commands/R/SourceRScriptCommand.cs
+++ b/src/Package/Impl/Commands/R/SourceRScriptCommand.cs
@@ -4,7 +4,9 @@ using Microsoft.Languages.Editor;
 using Microsoft.Languages.Editor.Controller.Command;
 using Microsoft.R.Debugger;
 using Microsoft.VisualStudio.R.Package.Repl;
+using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.R.Packages.R;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 
@@ -15,11 +17,34 @@ namespace Microsoft.VisualStudio.R.Package.Commands {
         };
 
         private readonly ReplWindow _replWindow;
+        private readonly IVsMonitorSelection _monitorSelection;
+        private readonly uint _debugUIContextCookie;
 
         public SourceRScriptCommand(ITextView textView)
             : base(textView, Commands, false) {
             ReplWindow.EnsureReplWindow().DoNotWait();
             _replWindow = ReplWindow.Current;
+
+            _monitorSelection = VsAppShell.Current.GetGlobalService<IVsMonitorSelection>(typeof(SVsShellMonitorSelection));
+            if (_monitorSelection != null) {
+                var debugUIContextGuid = new Guid(UIContextGuids.Debugging);
+                if (ErrorHandler.Failed(_monitorSelection.GetCmdUIContextCookie(ref debugUIContextGuid, out _debugUIContextCookie))) {
+                    _monitorSelection = null;
+                }
+            }
+        }
+
+        private bool IsDebugging() {
+            if (_monitorSelection == null) {
+                return false;
+            }
+
+            int fActive;
+            if (ErrorHandler.Succeeded(_monitorSelection.IsCmdUIContextActive(_debugUIContextCookie, out fActive))) {
+                return fActive != 0;
+            }
+
+            return false;
         }
 
         private string GetFilePath() {
@@ -41,17 +66,8 @@ namespace Microsoft.VisualStudio.R.Package.Commands {
                 return CommandResult.NotSupported;
             }
 
-            _replWindow.ExecuteCode($"source({filePath.ToRStringLiteral()})");
+            _replWindow.ExecuteCode($"{(IsDebugging() ? "rtvs::debug_source" : "source")}({filePath.ToRStringLiteral()})");
             return CommandResult.Executed;
         }
-
-        //protected override void Dispose(bool disposing) {
-        //    if (_replWindow != null) {
-        //        _replWindow.Dispose();
-        //        _replWindow = null;
-        //    }
-
-        //    base.Dispose(disposing);
-        //}
     }
 }


### PR DESCRIPTION
Add a function that behaves (mostly) like source(), but also enables stepping for expressions that are on the top level.

Use that function in lieu of source() when "Source R Script" command is invoked while debugging.
