### PR TITLE
Fix #621: Step In on a line with breakpoint breaks things [RTVS]

### DIFF
--- a/src/Host/Client/Impl/Definitions/IRExpressionEvaluator.cs
+++ b/src/Host/Client/Impl/Definitions/IRExpressionEvaluator.cs
@@ -14,6 +14,7 @@ namespace Microsoft.R.Host.Client {
         BaseEnv = 1 << 3,
         EmptyEnv = 1 << 4,
         Cancelable = 1 << 5,
+        UnprotectedEnv = 1 << 6,
     }
 
     public interface IRExpressionEvaluator {

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -239,6 +239,9 @@ namespace Microsoft.R.Host.Client {
             if (kind.HasFlag(REvaluationKind.EmptyEnv)) {
                 nameBuilder.Append('E');
             }
+            if (kind.HasFlag(REvaluationKind.UnprotectedEnv)) {
+                nameBuilder.Append("U");
+            }
             var name = nameBuilder.ToString();
 
             _canEval = false;

--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -25,30 +25,30 @@ namespace Microsoft.R.Host.Client.Session {
 
         public static Task<REvaluationResult> SetVsGraphicsDevice(this IRSessionEvaluation evaluation) {
             var script = @"
-.rtvs.vsgdresize <- function(width, height) {
+.GlobalEnv$.rtvs.vsgdresize <- function(width, height) {
    invisible(.External('Microsoft.R.Host::External.ide_graphicsdevice_resize', width, height))
 }
-.rtvs.vsgd <- function() {
+.GlobalEnv$.rtvs.vsgd <- function() {
    invisible(.External('Microsoft.R.Host::External.ide_graphicsdevice_new'))
 }
-.rtvs.vsgdexportimage <- function(filename, device) {
+.GlobalEnv$.rtvs.vsgdexportimage <- function(filename, device) {
     dev.copy(device=device,filename=filename)
     dev.off()
 }
-.rtvs.vsgdexportpdf <- function(filename) {
+.GlobalEnv$.rtvs.vsgdexportpdf <- function(filename) {
     dev.copy(device=pdf,file=filename)
     dev.off()
 }
-.rtvs.vsgdnextplot <- function() {
+.GlobalEnv$.rtvs.vsgdnextplot <- function() {
    invisible(.External('Microsoft.R.Host::External.ide_graphicsdevice_next_plot'))
 }
-.rtvs.vsgdpreviousplot <- function() {
+.GlobalEnv$.rtvs.vsgdpreviousplot <- function() {
    invisible(.External('Microsoft.R.Host::External.ide_graphicsdevice_previous_plot'))
 }
-.rtvs.vsgdhistoryinfo <- function() {
+.GlobalEnv$.rtvs.vsgdhistoryinfo <- function() {
    .External('Microsoft.R.Host::External.ide_graphicsdevice_history_info')
 }
-xaml <- function(filename, width, height) {
+.GlobalEnv$xaml <- function(filename, width, height) {
    invisible(.External('Microsoft.R.Host::External.xaml_graphicsdevice_new', filename, width, height))
 }
 options(device='.rtvs.vsgd')
@@ -111,13 +111,13 @@ options(device='.rtvs.vsgd')
 
         public static Task<REvaluationResult> SetRdHelpExtraction(this IRSessionEvaluation evaluation) {
             var script =
-@" .rtvs.signature.help2 <- function(f, p) {
+@" .GlobalEnv$.rtvs.signature.help2 <- function(f, p) {
         x <- help(paste(f), paste(p))
         y <- utils:::.getHelpFile(x)
         paste0(y, collapse = '')
     }
 
-    .rtvs.signature.help1 <- function(f) {
+    .GlobalEnv$.rtvs.signature.help1 <- function(f) {
         x <- help(paste(f))
         y <- utils:::.getHelpFile(x)
         paste0(y, collapse = '')


### PR DESCRIPTION
Add support for the new "unprotected environment" flag for evaluations. Since the new default in R-Host is protected, not using the flag fixes the bug.

Fix evals that assign values in global environment to explicity reference it, since assignments don't change the target environment if eval is protected.
