### PR TITLE
Bug fixes

### DIFF
--- a/src/Package/Impl/History/HistoryWindowPane.cs
+++ b/src/Package/Impl/History/HistoryWindowPane.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.R.Package.History {
             _history.HistoryChanged += OnHistoryChanged;
             _historyFiltering = _historyProvider.CreateFiltering(_history);
 
-            var textView = _history.GetOrCreateTextView();
+            var textView = _historyProvider.GetOrCreateTextView(_history);
             Content = _textEditorFactory.CreateTextViewHost(textView, false);
             _commandTarget = new CommandTargetToOleShim(textView, RMainController.FromTextView(textView));
 

--- a/src/Package/Impl/History/HistoryWindowPaneMouseProcessor.cs
+++ b/src/Package/Impl/History/HistoryWindowPaneMouseProcessor.cs
@@ -23,20 +23,6 @@ namespace Microsoft.VisualStudio.R.Package.History {
         public HistoryWindowPaneMouseProcessor(IWpfTextView wpfTextView, IRHistoryProvider historyProvider) {
             _textView = wpfTextView;
             _history = historyProvider.GetAssociatedRHistory(_textView);
-
-            _textView.Selection.SelectionChanged += SelectionChanged;
-            _textView.Closed += TextViewClosed;
-        }
-
-        private void TextViewClosed(object sender, EventArgs e) {
-            _textView.Selection.SelectionChanged -= SelectionChanged;
-            _textView.Closed -= TextViewClosed;
-        }
-
-        private void SelectionChanged(object sender, EventArgs args) {
-            if (_textView.Selection.Start != _textView.Selection.End) {
-                _history.ClearHistoryEntrySelection();
-            }
         }
 
         #region IMouseProcessorProvider Member Implementations

--- a/src/Package/Impl/History/IRHistory.cs
+++ b/src/Package/Impl/History/IRHistory.cs
@@ -6,9 +6,10 @@ using Microsoft.VisualStudio.Text.Projection;
 
 namespace Microsoft.VisualStudio.R.Package.History {
     public interface IRHistory : IDisposable {
-        IWpfTextView GetOrCreateTextView();
+        IWpfTextView GetOrCreateTextView(ITextEditorFactoryService textEditorFactory);
 
         event EventHandler<EventArgs> SelectionChanged;
+        event EventHandler<EventArgs> HistoryChanging;
         event EventHandler<EventArgs> HistoryChanged;
         bool HasSelectedEntries { get; }
         bool HasEntries { get; }
@@ -37,7 +38,5 @@ namespace Microsoft.VisualStudio.R.Package.History {
         void DeleteAllHistoryEntries();
 
         void AddToHistory(string text);
-
-        void Workaround169159(IElisionBuffer elisionBuffer);
     }
 }

--- a/src/Package/Impl/History/IRHistoryProvider.cs
+++ b/src/Package/Impl/History/IRHistoryProvider.cs
@@ -6,5 +6,6 @@ namespace Microsoft.VisualStudio.R.Package.History {
         IRHistory CreateRHistory(IRInteractive rInteractive);
         IRHistory GetAssociatedRHistory(ITextView textView);
         IRHistoryFiltering CreateFiltering(IRHistory history);
+        IWpfTextView GetOrCreateTextView(IRHistory history);
     }
 }

--- a/src/Package/Impl/History/RHistoryProvider.cs
+++ b/src/Package/Impl/History/RHistoryProvider.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.Common.Core.IO;
@@ -45,13 +43,18 @@ namespace Microsoft.VisualStudio.R.Package.History {
         }
 
         public IRHistoryFiltering CreateFiltering(IRHistory history) {
-            return new RHistoryFiltering(history, RToolsSettings.Current, _textSearchService);
+            var textView = GetOrCreateTextView(history);
+            return new RHistoryFiltering(history, textView, RToolsSettings.Current, _textSearchService);
+        }
+
+        public IWpfTextView GetOrCreateTextView(IRHistory history) {
+            return history.GetOrCreateTextView(_textEditorFactory);
         }
 
         public IRHistory CreateRHistory(IRInteractive rInteractive) {
             var vsUiShell = VsAppShell.Current.GetGlobalService<IVsUIShell>(typeof(SVsUIShell));
             var textBuffer = _textBufferFactory.CreateTextBuffer(_contentType);
-            var history = new RHistory(rInteractive, _textEditorFactory, textBuffer, _fileSystem, RToolsSettings.Current, _editorOperationsFactory, _rtfBuilderService, vsUiShell, () => RemoveRHistory(textBuffer));
+            var history = new RHistory(rInteractive, textBuffer, _fileSystem, RToolsSettings.Current, _editorOperationsFactory, _rtfBuilderService, vsUiShell, () => RemoveRHistory(textBuffer));
             _histories[textBuffer] = history;
             return history;
         }


### PR DESCRIPTION
- Fix bug #634: Crash when history entry added to history window with filter
- Remove workaround for bug #169159
- Fix incorrect filtered span generation for the case when only one entry should be visible
