### PR TITLE
Fix #659: Debugger is slow on large data sets

### DIFF
--- a/src/Debugger/Engine/Impl/AD7Property.cs
+++ b/src/Debugger/Engine/Impl/AD7Property.cs
@@ -11,10 +11,23 @@ namespace Microsoft.R.Debugger.Engine {
         internal const int ChildrenMaxLength = 100;
         internal const int ReprMaxLength = 100;
 
+        private const DebugEvaluationResultFields _prefetchedFields =
+            DebugEvaluationResultFields.Expression |
+            DebugEvaluationResultFields.Kind |
+            DebugEvaluationResultFields.Repr |
+            DebugEvaluationResultFields.ReprDPut |
+            DebugEvaluationResultFields.TypeName |
+            DebugEvaluationResultFields.Classes |
+            DebugEvaluationResultFields.Length |
+            DebugEvaluationResultFields.SlotCount |
+            DebugEvaluationResultFields.AttrCount |
+            DebugEvaluationResultFields.Flags;
+
         private IDebugProperty2 IDebugProperty2 => this;
         private IDebugProperty3 IDebugProperty3 => this;
 
         private Lazy<IReadOnlyList<DebugEvaluationResult>> _children;
+        private Lazy<string> _reprToString;
 
         public AD7Property Parent { get; }
         public AD7StackFrame StackFrame { get; }
@@ -35,9 +48,16 @@ namespace Microsoft.R.Debugger.Engine {
 
             _children = Lazy.Create(() =>
                 (EvaluationResult as DebugValueEvaluationResult)
-                ?.GetChildrenAsync(maxLength: ChildrenMaxLength, reprMaxLength: ReprMaxLength)
+                ?.GetChildrenAsync(_prefetchedFields, ChildrenMaxLength, ReprMaxLength)
                 ?.GetResultOnUIThread()
                 ?? new DebugEvaluationResult[0]);
+
+            _reprToString = Lazy.Create(() => 
+                (EvaluationResult
+                 .EvaluateAsync(DebugEvaluationResultFields.Repr | DebugEvaluationResultFields.ReprToString)
+                 .GetResultOnUIThread()
+                 as DebugValueEvaluationResult
+                )?.Representation.ToString);
         }
 
         int IDebugProperty2.EnumChildren(enum_DEBUGPROP_INFO_FLAGS dwFields, uint dwRadix, ref Guid guidFilter, enum_DBG_ATTRIB_FLAGS dwAttribFilter, string pszNameFilter, uint dwTimeout, out IEnumDebugPropertyInfo2 ppEnum) {
@@ -168,25 +188,23 @@ namespace Microsoft.R.Debugger.Engine {
         int IDebugProperty3.GetStringCharLength(out uint pLen) {
             pLen = 0;
 
-            var valueResult = EvaluationResult as DebugValueEvaluationResult;
-            if (valueResult == null || valueResult.Representation.ToString == null) {
+            if (_reprToString.Value == null) {
                 return VSConstants.E_FAIL;
             }
 
-            pLen = (uint)valueResult.Representation.ToString.Length;
+            pLen = (uint)_reprToString.Value.Length;
             return VSConstants.S_OK;
         }
 
         int IDebugProperty3.GetStringChars(uint buflen, ushort[] rgString, out uint pceltFetched) {
             pceltFetched = 0;
 
-            var valueResult = EvaluationResult as DebugValueEvaluationResult;
-            if (valueResult == null || valueResult.Representation.ToString == null) {
+            if (_reprToString.Value == null) {
                 return VSConstants.E_FAIL;
             }
 
             for (int i = 0; i < buflen; ++i) {
-                rgString[i] = valueResult.Representation.ToString[i];
+                rgString[i] = _reprToString.Value[i];
             }
             return VSConstants.S_OK;
         }

--- a/src/Debugger/Impl/DebugStackFrame.cs
+++ b/src/Debugger/Impl/DebugStackFrame.cs
@@ -70,8 +70,10 @@ namespace Microsoft.R.Debugger {
             return Session.EvaluateAsync(this, expression, name, null, fields, reprMaxLength);
         }
 
-        public Task<DebugEvaluationResult> GetEnvironmentAsync() {
-            return EvaluateAsync("environment()");
+        public Task<DebugEvaluationResult> GetEnvironmentAsync(
+            DebugEvaluationResultFields fields = DebugEvaluationResultFields.Expression | DebugEvaluationResultFields.Length
+        ) {
+            return EvaluateAsync("environment()", fields: fields);
         }
     }
 }


### PR DESCRIPTION
Do not fetch all data when fetching frame environments and children. In particular, do not fetch toString() repr.

Lazily fetch toString() when text visualizer requests the data (i.e. when user clicks on the magnifying glass icon next to the value).

Fix DebugEvaluationResult not properly handling missing Flags.
