### PR TITLE
Improve "Attach Debugger" command visibility

### DIFF
--- a/src/Package/Impl/Commands/R/RPackageCommandId.cs
+++ b/src/Package/Impl/Commands/R/RPackageCommandId.cs
@@ -27,6 +27,7 @@
         public const int icmdStepInto = 513;
         public const int icmdStepOut = 514;
         public const int icmdStepOver = 515;
+        public const int icmdAttachToRInteractive = 516;
 
         public const int icmdRexecuteReplCmd = 571;
         public const int icmdPasteReplCmd = 572;

--- a/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
+++ b/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Repl\Commands\ReplFormatDocumentCommand.cs" />
     <Compile Include="Repl\Commands\WorkingDirectoryCommand.cs" />
     <Compile Include="Repl\Commands\RexecuteCommand.cs" />
+    <Compile Include="Repl\Debugger\AttachToRInteractiveCommand.cs" />
     <Compile Include="Repl\Debugger\DebuggerCommandVisibility.cs" />
     <Compile Include="Repl\Debugger\StepIntoCommand.cs" />
     <Compile Include="Repl\Debugger\StopDebuggingCommand.cs" />

--- a/src/Package/Impl/Package.vsct
+++ b/src/Package/Impl/Package.vsct
@@ -5,6 +5,8 @@
   <Extern href="vsshlids.h" />
   <Extern href="vsshell\shellicons.h" />
   <Extern href="sharedids.h"/>
+  <Extern href="VSDbgCmd.h"/>
+  <Extern href="VsDebugGuids.h"/>
 
   <!-- ImageCatalog icons from the ImageService-->
   <!-- See http://glyphlist.azurewebsites.net/knownmonikers -->
@@ -344,10 +346,23 @@
         <CommandFlag>IconIsMoniker</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>IconAndText</CommandFlag>
         <Strings>
           <ButtonText>Attach Debugger</ButtonText>
           <MenuText>A&amp;ttach Debugger</MenuText>
           <CommandName>Attach Debugger</CommandName>
+        </Strings>
+      </Button>
+
+      <Button guid="guidRToolsCmdSet" id="icmdAttachToRInteractive" priority="0x0500" type="Button">
+        <Icon guid="ImageCatalogGuid" id="RemoteDebugger"/>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Attach to R Interactive</ButtonText>
+          <MenuText>Attach to R I&amp;nteractive</MenuText>
+          <CommandName>Attach to R Interactive</CommandName>
         </Strings>
       </Button>
 
@@ -1099,6 +1114,10 @@
       <Parent guid="guidRToolsCmdSet" id="sessionSubMenuRInteractiveGroup"/>
     </CommandPlacement>
 
+    <CommandPlacement guid="guidRToolsCmdSet" id="icmdAttachToRInteractive" priority="0x0E01">
+      <Parent guid="guidVSDebugGroup" id="IDG_EXECUTION"/>
+    </CommandPlacement>
+    
     <CommandPlacement guid="guidRToolsCmdSet" id="icmdContinueDebugging" priority="0x0460">
       <Parent guid="guidRToolsCmdSet" id="sessionSubMenuRInteractiveGroup"/>
     </CommandPlacement>
@@ -1221,6 +1240,7 @@
       <IDSymbol name="icmdStepInto" value="513" />
       <IDSymbol name="icmdStepOut" value="514" />
       <IDSymbol name="icmdStepOver" value="515" />
+      <IDSymbol name="icmdAttachToRInteractive" value="516" />
 
       <IDSymbol name="sessionSubMenuFileGroup" value="551"/>
       <IDSymbol name="sessionSubMenuRGroup" value="552"/>

--- a/src/Package/Impl/Packages/R/PackageCommands.cs
+++ b/src/Package/Impl/Packages/R/PackageCommands.cs
@@ -32,6 +32,7 @@ namespace Microsoft.VisualStudio.R.Packages.R {
                 new SaveWorkspaceCommand(rSessionProvider, projectServiceAccessor),
 
                 new AttachDebuggerCommand(rSessionProvider),
+                new AttachToRInteractiveCommand(rSessionProvider),
                 new StopDebuggingCommand(rSessionProvider),
                 new ContinueDebuggingCommand(rSessionProvider),
                 new StepOverCommand(rSessionProvider),

--- a/src/Package/Impl/Repl/Debugger/AttachDebuggerCommand.cs
+++ b/src/Package/Impl/Repl/Debugger/AttachDebuggerCommand.cs
@@ -9,9 +9,13 @@ using Microsoft.VisualStudio.R.Package.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.R.Package.Repl.Debugger {
-    internal sealed class AttachDebuggerCommand : DebuggerCommand {
+    internal class AttachDebuggerCommand : DebuggerCommand {
         public AttachDebuggerCommand(IRSessionProvider rSessionProvider)
             : base(rSessionProvider, RPackageCommandId.icmdAttachDebugger, DebuggerCommandVisibility.DesignMode) {
+        }
+
+        protected AttachDebuggerCommand(IRSessionProvider rSessionProvider, int cmdId, DebuggerCommandVisibility visibility)
+            : base(rSessionProvider, cmdId, visibility) {
         }
 
         protected unsafe override void Handle() {

--- a/src/Package/Impl/Repl/Debugger/AttachToRInteractiveCommand.cs
+++ b/src/Package/Impl/Repl/Debugger/AttachToRInteractiveCommand.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.R.Host.Client;
+using Microsoft.VisualStudio.R.Package.Commands;
+
+namespace Microsoft.VisualStudio.R.Package.Repl.Debugger {
+    // Identical to AttachDebugger, and only exists as a separate command so that it can be
+    // given a different label for better fit in the "Debug" top-level menu.
+    internal sealed class AttachToRInteractiveCommand : AttachDebuggerCommand {
+        public AttachToRInteractiveCommand(IRSessionProvider rSessionProvider)
+            : base(rSessionProvider, RPackageCommandId.icmdAttachToRInteractive, DebuggerCommandVisibility.DesignMode) {
+        }
+    }
+}


### PR DESCRIPTION
Show label for "Attach Debugger" command on the toolbar.

Add "Attach to R Interactive" command, identical to "Attach Debugger", but placed under the top-level "Debug" menu.
