### PR TITLE
Debugger fixes: #673, #675

### DIFF
--- a/src/Debugger/Engine/Impl/AD7PendingBreakpoint.cs
+++ b/src/Debugger/Engine/Impl/AD7PendingBreakpoint.cs
@@ -79,6 +79,10 @@ namespace Microsoft.R.Debugger.Engine {
                 return VSConstants.E_FAIL;
             }
 
+            if (_boundBreakpoint != null) {
+                Marshal.ThrowExceptionForHR(((IDebugBoundBreakpoint2)_boundBreakpoint).Enable(fEnable));
+            }
+
             _state = fEnable == 0 ? enum_PENDING_BP_STATE.PBPS_DISABLED : enum_PENDING_BP_STATE.PBPS_ENABLED;
             return VSConstants.S_OK;
         }

--- a/src/Debugger/Impl/rtvs/R/breakpoints.R
+++ b/src/Debugger/Impl/rtvs/R/breakpoints.R
@@ -241,5 +241,5 @@ debug_parse <- function(filename, encoding = getOption('encoding')) {
 }
 
 debug_source <- function(file, encoding = getOption('encoding')) {
-  eval.parent(debug_parse(file, encoding))
+  safe_eval(debug_parse(file, encoding), parent.frame(1))
 }


### PR DESCRIPTION
Fix  #673: Sourcing a file more than once with debugger attached results in strange behavior

Use safe_eval instead of eval in debug_source to avoid problems with debug flag being set on parent environment.

Fix #675: bkpoints are hit even after Debug/Disable bkpoints

Propagate Enable() calls from pending breakpoint to its child bound breakpoint, since VS doesn't do so automatically.
