### PR TITLE
Fix #691: Crash when stopping debugging

### DIFF
--- a/src/Debugger/Engine/Impl/AD7Engine.cs
+++ b/src/Debugger/Engine/Impl/AD7Engine.cs
@@ -70,7 +70,10 @@ namespace Microsoft.R.Debugger.Engine {
 
             IsDisposed = true;
 
-            ExitBrowserAsync(rSession).SilenceException<MessageTransportException>().DoNotWait();
+            ExitBrowserAsync(rSession)
+                .SilenceException<MessageTransportException>()
+                .SilenceException<RException>()
+                .DoNotWait();
         }
 
         private void ThrowIfDisposed() {


### PR DESCRIPTION
Ignore any R errors/warnings that result from responding "Q" to the Browse> prompt on debugger terminations.
