### PR TITLE
Debugger fixes: #677, #698, #666

### DIFF
--- a/src/Debugger/Engine/Impl/AD7Engine.cs
+++ b/src/Debugger/Engine/Impl/AD7Engine.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Microsoft.Common.Core;
 using Microsoft.R.Debugger.Engine.PortSupplier;
 using Microsoft.R.Host.Client;
@@ -396,7 +397,7 @@ namespace Microsoft.R.Debugger.Engine {
         int IDebugProgram2.Step(IDebugThread2 pThread, enum_STEPKIND sk, enum_STEPUNIT Step) {
             ThrowIfDisposed();
 
-            Task step;
+            Task<bool> step;
             switch (sk) {
                 case enum_STEPKIND.STEP_OVER:
                     step = DebugSession.StepOverAsync();
@@ -412,7 +413,20 @@ namespace Microsoft.R.Debugger.Engine {
             }
 
             step.ContinueWith(t => {
-                Send(new AD7SteppingCompleteEvent(), AD7SteppingCompleteEvent.IID);
+                // If step was interrupted midway (e.g. by a breakpoint), we have already reported breakpoint
+                // hit event, and so we must not report step complete. Note that interrupting is not the same
+                // as canceling, and if step was canceled, we must report step completion.
+
+                bool completed = true;
+                try {
+                    completed = t.GetAwaiter().GetResult();
+                } catch (OperationCanceledException) {
+                } catch (MessageTransportException) {
+                }
+
+                if (completed) {
+                    Send(new AD7SteppingCompleteEvent(), AD7SteppingCompleteEvent.IID);
+                }
             });
 
             return VSConstants.S_OK;

--- a/src/Debugger/Engine/Impl/AD7Property.cs
+++ b/src/Debugger/Engine/Impl/AD7Property.cs
@@ -70,7 +70,7 @@ namespace Microsoft.R.Debugger.Engine {
 
             var valueResult = EvaluationResult as DebugValueEvaluationResult;
             if (valueResult != null && valueResult.HasAttributes == true) {
-                string attrExpr = Invariant($"attributes({valueResult.Expression})");
+                string attrExpr = Invariant($"base::attributes({valueResult.Expression})");
                 var attrResult = StackFrame.StackFrame.EvaluateAsync(attrExpr, "attributes()", reprMaxLength: ReprMaxLength).GetResultOnUIThread();
                 if (!(attrResult is DebugErrorEvaluationResult)) {
                     var attrInfo = new AD7Property(this, attrResult, isSynthetic: true).GetDebugPropertyInfo(dwRadix, dwFields);

--- a/src/Debugger/Impl/DebugEvaluationResult.cs
+++ b/src/Debugger/Impl/DebugEvaluationResult.cs
@@ -57,7 +57,7 @@ namespace Microsoft.R.Debugger {
             }
 
             var fieldNames = _mapping.Where(kv => fields.HasFlag(kv.Key)).Select(kv => "'" + kv.Value + "'");
-            return Invariant($"c({string.Join(", ", fieldNames)})");
+            return Invariant($"base::c({string.Join(", ", fieldNames)})");
         }
     }
 
@@ -169,9 +169,9 @@ namespace Microsoft.R.Debugger {
 
         public bool IsAtomic => Flags.HasFlag(DebugValueEvaluationResultFlags.Atomic);
         public bool IsRecursive => Flags.HasFlag(DebugValueEvaluationResultFlags.Recursive);
-        public bool HasAttributes => AttributeCount != 0;
-        public bool HasSlots => SlotCount != 0;
-        public bool HasChildren => HasSlots || Length > (IsAtomic || TypeName == "closure" ? 1 : 0);
+        public bool HasAttributes => AttributeCount != null && AttributeCount != 0;
+        public bool HasSlots => SlotCount != null && SlotCount != 0;
+        public bool HasChildren => HasSlots || (Length != null && (Length > (IsAtomic || TypeName == "closure" ? 1 : 0)));
 
         internal DebugValueEvaluationResult(DebugStackFrame stackFrame, string expression, string name, JObject json)
             : base(stackFrame, expression, name) {

--- a/src/Debugger/Impl/DebugStackFrame.cs
+++ b/src/Debugger/Impl/DebugStackFrame.cs
@@ -71,9 +71,9 @@ namespace Microsoft.R.Debugger {
         }
 
         public Task<DebugEvaluationResult> GetEnvironmentAsync(
-            DebugEvaluationResultFields fields = DebugEvaluationResultFields.Expression | DebugEvaluationResultFields.Length
+            DebugEvaluationResultFields fields = DebugEvaluationResultFields.Expression | DebugEvaluationResultFields.Length | DebugEvaluationResultFields.AttrCount
         ) {
-            return EvaluateAsync("environment()", fields: fields);
+            return EvaluateAsync("base::environment()", fields: fields);
         }
     }
 }

--- a/src/Package/Impl/Plots/PlotContentProvider.cs
+++ b/src/Package/Impl/Plots/PlotContentProvider.cs
@@ -19,7 +19,6 @@ using Microsoft.VisualStudio.Shell;
 namespace Microsoft.VisualStudio.R.Package.Plots {
     internal sealed class PlotContentProvider : IPlotContentProvider {
         private IRSession _rSession;
-        private IDebugSessionProvider _debugSessionProvider;
         private string _lastLoadFile;
         private int _lastWidth;
         private int _lastHeight;
@@ -32,14 +31,6 @@ namespace Microsoft.VisualStudio.R.Package.Plots {
             _rSession = sessionProvider.GetInteractiveWindowRSession();
             _rSession.Mutated += RSession_Mutated;
             _rSession.Connected += RSession_Connected;
-
-            _debugSessionProvider = VsAppShell.Current.ExportProvider.GetExportedValue<IDebugSessionProvider>();
-
-            IdleTimeAction.Create(() => {
-                // debug session is created to trigger a load of the R package
-                // that has functions we need such as rtvs:::toJSON
-                _debugSessionProvider.GetDebugSessionAsync(_rSession).DoNotWait();
-            }, 10, typeof(PlotContentProvider));
         }
 
         private void RSession_Mutated(object sender, EventArgs e) {

--- a/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
+++ b/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
                     var globalStackFrame = stackFrames.FirstOrDefault(s => s.IsGlobal);
                     if (globalStackFrame != null) {
-                        DebugEvaluationResult evaluation = await globalStackFrame.EvaluateAsync("environment()", "Global Environment");
+                        DebugEvaluationResult evaluation = await globalStackFrame.EvaluateAsync("base::environment()", "Global Environment");
                         var e = new RSessionDataObject(evaluation);  // root level doesn't truncate children and return every variables
 
                         _topLevelVariables.Clear();


### PR DESCRIPTION
Fix #677: When stepping to/over line with a breakpoint, stepping doesn't do anything intermittently

When stepping ends up on a line with breakpoint, do not report both "step complete" and "breakpoint hit" events to VS - only report the latter.

Remove DebugSession from PlotContentProvider - it was there to trigger loading of 'rtvs' package, which is handled elsewhere now.

Fix DebugSession initialization to dispose the session (and unregister events) on failure.

Fix #698: Naming of functions can cause a debugger crash / hang

Explicitly qualify functions from the base package in evals, in case someone redefines them in .GlobalEnv.

Fix #666: Need to hide attributes() function in the locals window

Fetch attribute count for environment() by default, and fix DebugEvaluationResult.HasAttributes incorrectly returning true if attribute count wasn't fetched.
