### PR TITLE
Fix #688: debugger: bkpoint not hit, cant type anything in repl

### DIFF
--- a/src/Package/Impl/Repl/ReplWindow.cs
+++ b/src/Package/Impl/Repl/ReplWindow.cs
@@ -151,6 +151,12 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
             IVsInteractiveWindow current = Instance.Value.GetInteractiveWindow();
             if (current != null && !current.InteractiveWindow.IsInitializing && !string.IsNullOrWhiteSpace(code)) {
                 current.InteractiveWindow.AddInput(code);
+
+                var buffer = current.InteractiveWindow.CurrentLanguageBuffer;
+                var endPoint = current.InteractiveWindow.TextView.MapUpToBuffer(buffer.CurrentSnapshot.Length, buffer);
+                if (endPoint != null) {
+                    current.InteractiveWindow.TextView.Caret.MoveTo(endPoint.Value);
+                }
                 current.InteractiveWindow.Operations.ExecuteInput();
             }
         }


### PR DESCRIPTION
Move caret to the end of the buffer to make InteractiveWindowOperations.ExecuteInput work
