### PR TITLE
Fix #689, #719

### DIFF
--- a/src/Debugger/Impl/rtvs/R/breakpoints.R
+++ b/src/Debugger/Impl/rtvs/R/breakpoints.R
@@ -180,9 +180,10 @@ inject_breakpoints <- function(expr) {
     attr(after, 'srcref') <- before_srcref;
 
     for (i in 1:length(after)) {
-      if (!is.null(attr(after[[i]], 'rtvs::original_expr'))) {
-        # If it has the original_expr attribute, it's an injected breakpoint expression that replaced
-        # the original expression at the point where the breakpoint was set. It looks like this:
+      if (is.null(attr(before[[i]], 'rtvs::original_expr')) && !is.null(attr(after[[i]], 'rtvs::original_expr'))) {
+        # If it has the original_expr attribute that wasn't there before, it's an breakpoint expression that 
+        # was freshly injected, replacing the original expression at the point where the breakpoint was set.
+        # It looks like this:
         #
         # {.doTrace(...); <original expression>}
         #


### PR DESCRIPTION
Fix #689: Debugger fails if breakpoints are set on function definition and first line of its body

When injecting more than one breakpoint, use the expression produced by previous injection as input for the next one, instead of using the original expression all the time.

Fix #719: Source info is missing at breakpoint that is on a subexpression of another expression with a breakpoint

Recurse into subexpressions of injected breakpoints when copying srcrefs.
