### PR TITLE
Prevent VS crash on copy to clipboard

### DIFF
--- a/src/Package/Impl/Plots/PlotContentProvider.cs
+++ b/src/Package/Impl/Plots/PlotContentProvider.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.R.Package.Plots {
                                 Clipboard.SetImage(image);
 
                                 SafeFileDelete(fileName);
-                            } catch (IOException e) {
+                            } catch (Exception e) when (!e.IsCriticalException()) {
                                 MessageBox.Show(string.Format(Resources.PlotCopyToClipboardError, e.Message));
                             }
                         });
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.R.Package.Plots {
                                 Clipboard.SetData(DataFormats.EnhancedMetafile, mf);
 
                                 SafeFileDelete(fileName);
-                            } catch (IOException e) {
+                            } catch (Exception e) when (!e.IsCriticalException()) {
                                 MessageBox.Show(string.Format(Resources.PlotCopyToClipboardError, e.Message));
                             }
                         });


### PR DESCRIPTION
Fix for #722 Crash on copy to metafile.
Catch all non-critical exceptions when loading image from disk, in case R host created an invalid image file.
