### PR TITLE
Fix #723: Editing variables in Locals fails

### DIFF
--- a/src/Debugger/Engine/Impl/AD7Property.cs
+++ b/src/Debugger/Engine/Impl/AD7Property.cs
@@ -260,7 +260,7 @@ namespace Microsoft.R.Debugger.Engine {
             if (fields.HasFlag(enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_TYPE)) {
                 if (valueResult != null) {
                     dpi.bstrType = valueResult.TypeName;
-                    if (valueResult.Classes.Count > 0) {
+                    if (valueResult.Classes != null && valueResult.Classes.Count > 0) {
                         dpi.bstrType += " (" + string.Join(", ", valueResult.Classes) + ")";
                     }
                     dpi.dwFields |= enum_DEBUGPROP_INFO_FLAGS.DEBUGPROP_INFO_TYPE;

--- a/src/Debugger/Impl/DebugStackFrame.cs
+++ b/src/Debugger/Impl/DebugStackFrame.cs
@@ -21,7 +21,7 @@ namespace Microsoft.R.Debugger {
 
         public int Index { get; }
 
-        internal string SysFrame => Invariant($"sys.frame({Index})");
+        internal string SysFrame => Invariant($"base::sys.frame({Index})");
 
         public DebugStackFrame CallingFrame { get; }
 

--- a/src/Debugger/Impl/rtvs/R/eval.R
+++ b/src/Debugger/Impl/rtvs/R/eval.R
@@ -179,7 +179,7 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
       });
 
       item_expr <-
-        if (expr == 'environment()') {
+        if (expr == 'base::environment()') {
           dput_symbol(name)
         } else {
           paste0(expr, '$', dput_symbol(name), collapse = '')


### PR DESCRIPTION
`describe_children()` needs to trim leading "base::environment()" rather than "environment()" now that it's qualified in expressions generated for locals.

Also fix some null reference bugs and add more missing base:: qualifications.
