### PR TITLE
Fix Variable Explorer break due to debugger changes

### DIFF
--- a/src/Package/Impl/DataInspect/VariableProvider.cs
+++ b/src/Package/Impl/DataInspect/VariableProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         #region Public
 
-        public const string GlobalEnvironmentExpression = "environment()";
+        public const string GlobalEnvironmentExpression = "base::.GlobalEnv";
 
         public IRSession RSession { get; }
 

--- a/src/Package/Test/DataInspect/VariableRHostScript.cs
+++ b/src/Package/Test/DataInspect/VariableRHostScript.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.R.Package.Test.DataInspect {
                 _mre = new ManualResetEventSlim();
 
                 _globalEnv = null;
-                subscription = _variableProvider.Subscribe(0, "environment()", OnGlobalEnvironmentEvaluated);
+                subscription = _variableProvider.Subscribe(0, VariableProvider.GlobalEnvironmentExpression, OnGlobalEnvironmentEvaluated);
 
                 using (var evaluation = await base.Session.BeginEvaluationAsync()) {
                     await evaluation.EvaluateAsync(rScript, REvaluationKind.UnprotectedEnv);


### PR DESCRIPTION
Fix Variable Explorer breakage introduced by using base::environment() instead of unqualified environment() in debugger, and fix related tests.
