### PR TITLE
Fix #756: 1-dimensional arrays crash debugger, VE and Intellisense

### DIFF
--- a/src/Debugger/Impl/rtvs/R/eval.R
+++ b/src/Debugger/Impl/rtvs/R/eval.R
@@ -68,7 +68,7 @@ describe_object <- function(obj, res, fields, repr_max_length = NA) {
   if (field('dim')) {
     dim <- NA_if_error(dim(obj));
     if (is.integer(dim) && !anyNA(dim)) {
-      res$dim <- dim;
+      res$dim <- as.list(dim);
     }
   }
     


### PR DESCRIPTION
Always pass "dim" attribute as a JSON array, even if it only has a single element.
