### PR TITLE
Make JSON serializer more strict with respect to vectors

### DIFF
--- a/src/Debugger/Impl/rtvs/R/eval.R
+++ b/src/Debugger/Impl/rtvs/R/eval.R
@@ -81,7 +81,7 @@ describe_object <- function(obj, res, fields, repr_max_length = NA) {
   }
 
   if (field('flags')) {
-    res$flags <- c(
+    res$flags <- list(
       if (is.atomic(obj)) "atomic" else NA,
       if (is.recursive(obj)) "recursive" else NA,
       if (has_parent_env) "has_parent_env" else NA


### PR DESCRIPTION
Make JSON serializer more strict with respect to vectors - only allow 0- or 1-element vectors, and don't treat multi-element ones as arrays (use list for that).

Fix some unrelated bugs and incorrect comments in the serializer.
