### PR TITLE
Fix #692: Stepping while stopped on a breakpoint requires pressing F10 too many times

### DIFF
--- a/src/Debugger/Impl/rtvs/R/breakpoints.R
+++ b/src/Debugger/Impl/rtvs/R/breakpoints.R
@@ -191,6 +191,10 @@ inject_breakpoints <- function(expr) {
         # the replacement expression, so that the same line is considered current for all of it.
         attr(after[[i]], 'srcref') <- rep(list(before_srcref[[i]]), length(after[[i]]));
 
+        # Auto-step over '{' and '.doTrace', so that stepping skips to the original expression.
+        attr(attr(after, 'srcref')[[i]], 'Microsoft.R.Host::auto_step_over') <- TRUE;
+        attr(attr(after[[i]], 'srcref')[[2]], 'Microsoft.R.Host::auto_step_over') <- TRUE;
+
         # Recurse into the original expression, in case it has more breakpoints inside.
         after[[i]][[3]] <- Recall(before[[i]], after[[i]][[3]]);
       } else if (is.language(after[[i]])) {

--- a/src/Debugger/Impl/rtvs/R/eval.R
+++ b/src/Debugger/Impl/rtvs/R/eval.R
@@ -25,10 +25,13 @@ describe_object <- function(obj, res, fields, repr_max_length = NA) {
     
     if (field('repr.deparse')) {
       repr$deparse <- paste0(collapse = '', NA_if_error(
-        if (is.na(repr_max_length))
+        if (is.na(repr_max_length)) {
             deparse(obj)
-        else
-            deparse(obj, width.cutoff = repr_max_length, nlines = 1)))
+        } else {
+            # Force max length into range permitted by deparse
+            cutoff <- min(max(repr_max_length, 20), 500);
+            deparse(obj, width.cutoff = cutoff, nlines = 1)
+        }))
     }
     
     if (field('repr.toString')) {


### PR DESCRIPTION
Mark injected instructions with Microsoft.R.Host::auto_step_over so that the host automatically steps over them at Browse prompts.

Also fix spurious warning message for invalid cutoff values coming from Locals.
