### PR TITLE
Fix #781: Cannot set breakpoint on expression and its immediate subexpression

### DIFF
--- a/src/Debugger/Impl/rtvs/R/breakpoints.R
+++ b/src/Debugger/Impl/rtvs/R/breakpoints.R
@@ -143,7 +143,7 @@ inject_breakpoints <- function(expr) {
       target_expr <- expr[[step]];
 
       # If there's already an injected breakpoint there, nothing to do for this line.
-      if (isTRUE(attr(target_expr, 'rtvs::at_breakpoint'))) {
+      if (isTRUE(attr(target_expr, 'rtvs::at_breakpoint')) || !is.null(attr(target_expr, 'rtvs::original_expr'))) {
         next;
       }
 


### PR DESCRIPTION
Additional check to prevent double injection of breakpoint code for the same expression.
