### PR TITLE
Fix #620: Stepping out into a loop does not work

### DIFF
--- a/src/Debugger/Impl/DebugSession.cs
+++ b/src/Debugger/Impl/DebugSession.cs
@@ -203,7 +203,7 @@ namespace Microsoft.R.Debugger {
         }
 
         public Task<bool> StepOutAsync() {
-            return StepAsync("browserSetDebug()", "c");
+            return StepAsync("rtvs:::browser_set_debug()", "c");
         }
 
         /// <returns>

--- a/src/Debugger/Impl/rtvs/R/util.R
+++ b/src/Debugger/Impl/rtvs/R/util.R
@@ -34,6 +34,10 @@ set_rdebug <- function(obj, debug) {
   call_embedded("set_rdebug", obj, debug)
 }
 
+browser_set_debug <- function(n = 1) {
+  call_embedded("browser_set_debug", n)
+}
+
 NA_if_error <- function(expr) {
   tryCatch(expr, error = function(e) { NA })
 }


### PR DESCRIPTION
Use rtvs:::browser_set_debug in lieu of browserSetDebug.

(also see https://github.com/Microsoft/R-Host/pull/28)
