### PR TITLE
Plot resize

### DIFF
--- a/src/Package/Impl/Plots/PlotWindowPane.cs
+++ b/src/Package/Impl/Plots/PlotWindowPane.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
+using Microsoft.Languages.Editor.Tasks;
 using Microsoft.VisualStudio.R.Package.Commands;
 using Microsoft.VisualStudio.R.Package.Plots.Definitions;
 using Microsoft.VisualStudio.R.Package.Shell;
@@ -39,7 +40,12 @@ namespace Microsoft.VisualStudio.R.Package.Plots {
             // and user will be able to use scrollbars to see the whole thing
             int width = Math.Max((int)e.NewSize.Width, MinWidth);
             int height = Math.Max((int)e.NewSize.Height, MinHeight);
-            PlotContentProvider.DoNotWait(PlotHistory.PlotContentProvider.ResizePlotAsync(width, height));
+
+            // Throttle resize requests since we get a lot of size changed events when the tool window is undocked
+            IdleTimeAction.Cancel(this);
+            IdleTimeAction.Create(() => {
+                PlotContentProvider.DoNotWait(PlotHistory.PlotContentProvider.ResizePlotAsync(width, height));
+            }, 100, this);
         }
 
         private void OnPlotHistoryHistoryChanged(object sender, EventArgs e) {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/RTVS/issues/650

When the tool window is undocked, the resize happens live ie. we get size changed events as the window border are being dragged.  This was resulting in a lot of calls into R to render the plot at the new size.

We now throttle those requests by canceling previous requests within a small delay.  In practice, I see that the performance issues are now gone.

FYI we can't just look at the status of the mouse button and ignore the event if the mouse button is down.  There is no guarantee that we'll get a size changed event after the button is released, meaning that we would never process the resize (I tried it and that's what I experienced).
