### PR TITLE
Fix #767: Stop debugging in infinite loop hangs VS

### DIFF
--- a/src/Debugger/Engine/Impl/AD7Engine.cs
+++ b/src/Debugger/Engine/Impl/AD7Engine.cs
@@ -32,6 +32,7 @@ namespace Microsoft.R.Debugger.Engine {
 
         internal bool IsDisposed { get; private set; }
         internal bool IsConnected { get; private set; }
+        internal bool IsProgramDestroyed { get; private set; }
         internal DebugSession DebugSession { get; private set; }
         internal AD7Thread MainThread { get; private set; }
 
@@ -88,7 +89,20 @@ namespace Microsoft.R.Debugger.Engine {
         }
 
         private async Task ExitBrowserAsync(IRSession session) {
-            using (var inter = await session.BeginInteractionAsync(isVisible: true)) {
+            await TaskUtilities.SwitchToBackgroundThread();
+
+            var cts = new CancellationTokenSource(1000);
+            IRSessionInteraction inter;
+            try {
+                inter = await session.BeginInteractionAsync(true, cts.Token);
+            } catch (OperationCanceledException) {
+                // If we couldn't get a prompt to put "Q" into within a reasonable timeframe, just
+                // abort the current interaction;
+                await session.CancelAllAsync();
+                return;
+            }
+
+            using (inter) {
                 // Check if this is still the same prompt as the last Browse prompt that we've seen.
                 // If it isn't, then session has moved on already, and there's nothing for us to exit.
                 DebugBrowseEventArgs currentBrowseDebugEventArgs;
@@ -147,7 +161,7 @@ namespace Microsoft.R.Debugger.Engine {
             IsConnected = true;
 
             // Enable breakpoint instrumentation.
-            TaskExtensions.RunSynchronouslyOnUIThread(ct => DebugSession.EnableBreakpoints(true, ct));
+            TaskExtensions.RunSynchronouslyOnUIThread(ct => DebugSession.EnableBreakpointsAsync(true, ct));
 
             // Send notification after acquiring the session - we need it in case there were any breakpoints pending before
             // the attach, in which case we'll immediately get breakpoint creation requests as soon as we send these, and
@@ -276,15 +290,25 @@ namespace Microsoft.R.Debugger.Engine {
             return IDebugEngine2.CauseBreak();
         }
 
+        private void DestroyProgram() {
+            IsProgramDestroyed = true;
+            Send(new AD7ProgramDestroyEvent(0), AD7ProgramDestroyEvent.IID);
+        }
+
         int IDebugProgram2.Detach() {
             ThrowIfDisposed();
 
             try {
-                // Disable breakpoint instrumentation.
-                TaskExtensions.RunSynchronouslyOnUIThread(ct => DebugSession.EnableBreakpoints(false, ct));
+                // Queue disabling breakpoint instrumentation, but do not wait for it to complete -
+                // if there's currently some code running, this may take a while, so just detach and
+                // let breakpoints be taken care of later.
+                DebugSession.EnableBreakpointsAsync(false)
+                    .SilenceException<MessageTransportException>()
+                    .SilenceException<RException>()
+                    .DoNotWait();
             } finally {
                 // Detach should never fail, even if something above didn't work.
-                Send(new AD7ProgramDestroyEvent(0), AD7ProgramDestroyEvent.IID);
+                DestroyProgram();
             }
 
             return VSConstants.S_OK;
@@ -580,7 +604,7 @@ namespace Microsoft.R.Debugger.Engine {
 
         private void RSession_Disconnected(object sender, EventArgs e) {
             IsConnected = false;
-            Send(new AD7ProgramDestroyEvent(0), AD7ProgramDestroyEvent.IID);
+            DestroyProgram();
         }
     }
 }

--- a/src/Debugger/Impl/DebugBreakpoint.cs
+++ b/src/Debugger/Impl/DebugBreakpoint.cs
@@ -57,13 +57,13 @@ namespace Microsoft.R.Debugger {
             return Invariant($"rtvs:::add_breakpoint({fileName.ToRStringLiteral()}, {Location.LineNumber}, {(reapply ? "TRUE" : "FALSE")})");
         }
 
-        internal async Task SetBreakpointAsync(CancellationToken cancellationToken) {
+        internal async Task SetBreakpointAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             TaskUtilities.AssertIsOnBackgroundThread();
             await Session.InvokeDebugHelperAsync(GetAddBreakpointExpression(true), cancellationToken);
             ++UseCount;
         }
 
-        public async Task DeleteAsync(CancellationToken cancellationToken) {
+        public async Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             Trace.Assert(UseCount > 0);
             await TaskUtilities.SwitchToBackgroundThread();
             await Session.InitializeAsync(cancellationToken);

--- a/src/Debugger/Impl/DebugEvaluationResult.cs
+++ b/src/Debugger/Impl/DebugEvaluationResult.cs
@@ -94,12 +94,12 @@ namespace Microsoft.R.Debugger {
             return new DebugValueEvaluationResult(stackFrame, expression, name, json);
         }
 
-        public Task<DebugEvaluationResult> SetValueAsync(string value, CancellationToken cancellationToken) {
+        public Task<DebugEvaluationResult> SetValueAsync(string value, CancellationToken cancellationToken = default(CancellationToken)) {
             if (string.IsNullOrEmpty(Expression)) {
                 throw new InvalidOperationException(Invariant($"{nameof(SetValueAsync)} is not supported for this {nameof(DebugEvaluationResult)} because it doesn't have an associated {nameof(Expression)}."));
             }
 
-            return StackFrame.EvaluateAsync(Invariant($"{Expression} <- {value}"), reprMaxLength: 0, cancellationToken:cancellationToken);
+            return StackFrame.EvaluateAsync(Invariant($"{Expression} <- {value}"), reprMaxLength: 0, cancellationToken: cancellationToken);
         }
 
         public Task<DebugEvaluationResult> EvaluateAsync(

--- a/src/Debugger/Impl/DebugSession.cs
+++ b/src/Debugger/Impl/DebugSession.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core;
@@ -180,14 +178,14 @@ namespace Microsoft.R.Debugger {
             return DebugEvaluationResult.Parse(stackFrame, name, jEvalResult);
         }
 
-        public async Task Break() {
+        public async Task Break(CancellationToken ct = default(CancellationToken)) {
             await TaskUtilities.SwitchToBackgroundThread();
-            using (var inter = await RSession.BeginInteractionAsync(isVisible: true)) {
+            using (var inter = await RSession.BeginInteractionAsync(true, ct)) {
                 await inter.RespondAsync("browser()\n");
             }
         }
 
-        public async Task Continue(CancellationToken cancellationToken) {
+        public async Task Continue(CancellationToken cancellationToken = default(CancellationToken)) {
             await TaskUtilities.SwitchToBackgroundThread();
             ExecuteBrowserCommandAsync("c", cancellationToken)
                 .SilenceException<MessageTransportException>()
@@ -195,15 +193,15 @@ namespace Microsoft.R.Debugger {
                 .DoNotWait();
         }
 
-        public Task<bool> StepIntoAsync(CancellationToken cancellationToken) {
+        public Task<bool> StepIntoAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             return StepAsync(cancellationToken, "s");
         }
 
-        public Task<bool> StepOverAsync(CancellationToken cancellationToken) {
+        public Task<bool> StepOverAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             return StepAsync(cancellationToken, "n");
         }
 
-        public Task<bool> StepOutAsync(CancellationToken cancellationToken) {
+        public Task<bool> StepOutAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             return StepAsync(cancellationToken, "rtvs:::browser_set_debug()", "c");
         }
 
@@ -267,13 +265,13 @@ namespace Microsoft.R.Debugger {
             return stackFrames;
         }
 
-        public async Task EnableBreakpoints(bool enable, CancellationToken ct) {
+        public async Task EnableBreakpointsAsync(bool enable, CancellationToken ct = default(CancellationToken)) {
             ThrowIfDisposed();
             await TaskUtilities.SwitchToBackgroundThread();
             await InvokeDebugHelperAsync(Invariant($"rtvs:::enable_breakpoints({(enable ? "TRUE" : "FALSE")})"), ct);
         }
 
-        public async Task<DebugBreakpoint> CreateBreakpointAsync(DebugBreakpointLocation location, CancellationToken cancellationToken) {
+        public async Task<DebugBreakpoint> CreateBreakpointAsync(DebugBreakpointLocation location, CancellationToken cancellationToken = default(CancellationToken)) {
             ThrowIfDisposed();
 
             await TaskUtilities.SwitchToBackgroundThread();

--- a/src/Debugger/Impl/DebugStackFrame.cs
+++ b/src/Debugger/Impl/DebugStackFrame.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Diagnostics;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.R.Host.Client;
 using Newtonsoft.Json.Linq;
 using static System.FormattableString;
 
@@ -49,7 +46,7 @@ namespace Microsoft.R.Debugger {
             var match = _doTraceRegex.Match(Call);
             if (match.Success) {
                 FrameKind = DebugStackFrameKind.DoTrace;
-            } 
+            }
 
             if (fallbackFrame != null) {
                 // If we still don't have the filename and line number, use those from the fallback frame.
@@ -76,7 +73,7 @@ namespace Microsoft.R.Debugger {
             DebugEvaluationResultFields fields = DebugEvaluationResultFields.Expression | DebugEvaluationResultFields.Length | DebugEvaluationResultFields.AttrCount,
             CancellationToken cancellationToken = default(CancellationToken)
         ) {
-            return EvaluateAsync("base::environment()", fields: fields, cancellationToken:cancellationToken);
+            return EvaluateAsync("base::environment()", fields: fields, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Debugger/Impl/IDebugSessionProvider.cs
+++ b/src/Debugger/Impl/IDebugSessionProvider.cs
@@ -4,6 +4,6 @@ using Microsoft.R.Host.Client;
 
 namespace Microsoft.R.Debugger {
     public interface IDebugSessionProvider {
-        Task<DebugSession> GetDebugSessionAsync(IRSession session, CancellationToken cancellationToken = default (CancellationToken));
+        Task<DebugSession> GetDebugSessionAsync(IRSession session, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Debugger/Test/BreakpointsTest.cs
+++ b/src/Debugger/Test/BreakpointsTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.R.Debugger.Test {
   z <- 3
 ";
                     using (var sf = new SourceFile(content)) {
-                        await debugSession.EnableBreakpoints(true, default(CancellationToken));
+                        await debugSession.EnableBreakpointsAsync(true, default(CancellationToken));
 
                         var bpl = new DebugBreakpointLocation(sf.FilePath, 2);
                         DebugBreakpoint bp = await debugSession.CreateBreakpointAsync(bpl, default(CancellationToken));


### PR DESCRIPTION
Add a timeout when waiting for prompt to issue "Q" command, and abort the current interaction as a fallback.

When VS requests to delete breakpoints during engine shutdown, do not wait for the corresponding evals to complete.

Minor refactoring - add missing default values for CancellationToken arguments, clean up usings & reformat.
