### PR TITLE
Fix #868: Debugger error on multiline promises

### DIFF
--- a/src/Debugger/Impl/rtvs/R/eval.R
+++ b/src/Debugger/Impl/rtvs/R/eval.R
@@ -194,7 +194,7 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
 
       if (!is.null(code)) {
         # It's a promise - we don't want to force it as it could affect the debugged code.
-        value <- list(promise = deparse(code), expression = item_expr);
+        value <- list(promise = deparse_str(code), expression = item_expr);
       } else if (bindingIsActive(name, obj)) {
         # It's an active binding - we don't want to read it to avoid inadvertently changing program state.
         value <- list(active_binding = TRUE, expression = item_expr);
@@ -248,7 +248,7 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
       if (is_S4) {
         slot_expr <- paste0('(', expr, ')', accessor, collapse = '')
       } else {
-        slot_expr <- paste0('methods::slot((', expr, '), ', deparse(name), ')', collapse = '')
+        slot_expr <- paste0('methods::slot((', expr, '), ', deparse_str(name), ')', collapse = '')
       }
       
       value <- eval_and_describe(slot_expr, environment(), '@', fields, slot(obj, name), repr_max_length);
@@ -304,7 +304,7 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
           if (is.list(obj)) {
             accessor <- paste0('$', deparse_symbol(name), collapse = '');
           } else {
-            accessor <- paste0('[[', deparse(name), ']]', collapse = '');
+            accessor <- paste0('[[', deparse_str(name), ']]', collapse = '');
           }
         }
         

--- a/src/Debugger/Impl/rtvs/R/json.R
+++ b/src/Debugger/Impl/rtvs/R/json.R
@@ -14,7 +14,14 @@ toJSON <- function(data, con) {
   if (missing(con)) {
     con <- memory_connection(NA, 0x10000);
     on.exit(close(con), add = TRUE);
-    Recall(data, con);
+
+    tryCatch({
+        Recall(data, con);
+    }, error = function(e) {
+        warning('Error serializing to JSON:\n', data, '\n');
+        stop(e)
+    });
+
     return(memory_connection_tochar(con));
   }
 
@@ -35,13 +42,13 @@ toJSON <- function(data, con) {
         dput(data, con);
       }
     } else {
-      stop("vector must have 0 or 1 element to be convertible to JSON");
+      stop("vector must have 0 or 1 element to be convertible to JSON:\n\n", data);
     }
   }
 
   to_object <- function() {
     if (any(is.na(names)) || any(names == '')) {
-      stop("list must either have all elements named or all elements unnamed to be convertible to JSON");
+      stop("list must either have all elements named or all elements unnamed to be convertible to JSON:\n\n", data);
     }
     
     cat('{', file = con, sep = '');

--- a/src/Debugger/Impl/rtvs/R/util.R
+++ b/src/Debugger/Impl/rtvs/R/util.R
@@ -72,12 +72,16 @@ dput_str <- function(obj, max_length = NA, expected_length = NA, overflow_suffix
   gsub("^\\s+|\\s+$", "", memory_connection_tochar(con))
 }
 
+# Like deparse, but always returns a single string.
+deparse_str <- function(x)
+    paste0(deparse(x), collapse = '')
+
 # A wrapper for deparse that will first make name a symbol if it can be a legitimate one.
 deparse_symbol <- function(name) {
   if (is.character(name) && length(name) == 1 && !is.na(name) && nchar(name) > 0) {
     name <- as.symbol(name);
   }
-  deparse(name)
+  deparse_str(name)
 }
 
 # Like str(...)[[1]], but special-cases some common types to provide a more descriptive

--- a/src/Debugger/Test/Microsoft.R.Debugger.Test.csproj
+++ b/src/Debugger/Test/Microsoft.R.Debugger.Test.csproj
@@ -63,6 +63,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="SourceFile.cs" />
+    <Compile Include="ValuesTest.cs" />
     <Compile Include="SteppingTest.cs" />
     <Compile Include="BreakpointsTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Debugger/Test/ValuesTest.cs
+++ b/src/Debugger/Test/ValuesTest.cs
@@ -1,0 +1,65 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Languages.Editor.Shell;
+using Microsoft.R.Host.Client;
+using Microsoft.R.Host.Client.Test.Script;
+using Microsoft.UnitTests.Core.XUnit;
+using Xunit;
+
+namespace Microsoft.R.Debugger.Test {
+    [ExcludeFromCodeCoverage]
+    [Collection(CollectionNames.NonParallel)]
+    public class ValuesTest {
+        [Test]
+        [Category.R.Debugger]
+        public async Task MultilinePromise() {
+            const string code = @"
+f <- function(p, d) {
+    force(d)
+    browser()
+}
+x <- quote({{{}}})
+eval(substitute(f(P, x), list(P = x)))
+";
+
+            var sessionProvider = EditorShell.Current.ExportProvider.GetExportedValue<IRSessionProvider>();
+            using (new RHostScript(sessionProvider)) {
+                IRSession session = sessionProvider.GetOrCreate(GuidList.InteractiveWindowRSessionGuid, new RHostClientTestApp());
+                using (var debugSession = new DebugSession(session)) {
+                    using (var sf = new SourceFile(code)) {
+                        await debugSession.EnableBreakpointsAsync(true);
+
+                        var paused = new TaskCompletionSource<bool>();
+                        debugSession.Browse += delegate {
+                            paused.SetResult(true);
+                        };
+
+                        await sf.Source(session);
+                        await paused.Task;
+
+                        var stackFrames = (await debugSession.GetStackFramesAsync()).Reverse().ToArray();
+                        stackFrames.Should().NotBeEmpty();
+
+                        var evalResult = await stackFrames[0].GetEnvironmentAsync();
+                        evalResult.Should().BeAssignableTo<DebugValueEvaluationResult>();
+
+                        var frame = (DebugValueEvaluationResult)evalResult;
+                        var children = (await frame.GetChildrenAsync()).ToDictionary(er => er.Name);
+
+                        children.Should().ContainKey("p");
+                        children["p"].Should().BeAssignableTo<DebugPromiseEvaluationResult>();
+                        var p = (DebugPromiseEvaluationResult)children["p"];
+
+                        children.Should().ContainKey("d");
+                        children["d"].Should().BeAssignableTo<DebugValueEvaluationResult>();
+                        var d = (DebugValueEvaluationResult)children["d"];
+
+                        p.Code.Should().Be(d.Representation.Deparse);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Properly handle the case where deparse() returns multi-element character vector for promises, and harden other similar cases that can potentially fail for the same reason.

Improve error reporting for JSON parsing failures, so that logs contain sufficient information to diagnose errors.

Add unit test for multiline promises.
