### PR TITLE
Fix #626: demo(graphics) doesn't run in interactive mode

### DIFF
--- a/src/Package/Impl/Repl/RInteractiveEvaluator.cs
+++ b/src/Package/Impl/Repl/RInteractiveEvaluator.cs
@@ -109,6 +109,11 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
                 return ExecutionResult.Failure;
             }
 
+            // TODO: Workaround for bug https://github.com/dotnet/roslyn/issues/8569
+            if (text[0] == '\u0002') {
+                text = text.Substring(1);
+            }
+
             try {
                 await request.RespondAsync(text);
                 return ExecutionResult.Success;

--- a/src/Package/Impl/Repl/ReplWindow.cs
+++ b/src/Package/Impl/Repl/ReplWindow.cs
@@ -166,6 +166,9 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
                         textView.Caret.MoveTo(point.Value);
                     }
 
+                    // TODO: Workaround for bug https://github.com/dotnet/roslyn/issues/8569
+                    current.InteractiveWindow.CurrentLanguageBuffer.Insert(0, "\u0002");
+
                     current.InteractiveWindow.Operations.Return();
                 } else {
                     // Otherwise insert a line break in the middle of an input


### PR DESCRIPTION
Fix is a workaround for bug https://github.com/dotnet/roslyn/issues/8569
Interactive Window always swallows empty and whitespace only lines, so we need to add something to such line to ensure that it is sent to RInteractiveEvaluator.
