### PR TITLE
Fix #920: VS dies when reset REPL during first debugging

### DIFF
--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -286,7 +286,8 @@ namespace Microsoft.R.Host.Client {
         /// </summary>
         public async Task CancelAllAsync() {
             if (_runTask == null) {
-                throw new InvalidOperationException("Not connected to host.");
+                // Nothing to cancel.
+                return;
             }
 
             await TaskUtilities.SwitchToBackgroundThread();


### PR DESCRIPTION
Do not throw exception fron CancelAllAsync if host is down; treat it as a no-op instead.
