### PR TITLE
Fix #912: Step Out at top level doesn't work

### DIFF
--- a/src/Debugger/Impl/DebugSession.cs
+++ b/src/Debugger/Impl/DebugSession.cs
@@ -112,15 +112,24 @@ namespace Microsoft.R.Debugger {
             }
         }
 
-        public async Task ExecuteBrowserCommandAsync(string command, CancellationToken cancellationToken = default(CancellationToken)) {
+        public async Task<bool> ExecuteBrowserCommandAsync(string command, Func<IRSessionInteraction, Task<bool>> prepare = null, CancellationToken cancellationToken = default(CancellationToken)) {
             ThrowIfDisposed();
             await TaskUtilities.SwitchToBackgroundThread();
 
             using (var inter = await RSession.BeginInteractionAsync(isVisible: true, cancellationToken: cancellationToken)) {
+                if (prepare != null) {
+                    if (!await prepare(inter)) {
+                        return false;
+                    }
+                }
+
                 if (IsBrowserContext(inter.Contexts)) {
                     await inter.RespondAsync(command + "\n");
+                    return true;
                 }
             }
+
+            return false;
         }
 
         internal async Task<REvaluationResult> InvokeDebugHelperAsync(string expression, CancellationToken cancellationToken, bool json = false) {
@@ -187,7 +196,7 @@ namespace Microsoft.R.Debugger {
 
         public async Task Continue(CancellationToken cancellationToken = default(CancellationToken)) {
             await TaskUtilities.SwitchToBackgroundThread();
-            ExecuteBrowserCommandAsync("c", cancellationToken)
+            ExecuteBrowserCommandAsync("c", null, cancellationToken)
                 .SilenceException<MessageTransportException>()
                 .SilenceException<RException>()
                 .DoNotWait();
@@ -202,31 +211,37 @@ namespace Microsoft.R.Debugger {
         }
 
         public Task<bool> StepOutAsync(CancellationToken cancellationToken = default(CancellationToken)) {
-            return StepAsync(cancellationToken, "rtvs:::browser_set_debug()", "c");
+            return StepAsync(cancellationToken, "c", async inter => {
+                using (var eval = await RSession.BeginEvaluationAsync(false, cancellationToken)) {
+                    // EvaluateAsync will push a new toplevel context on the context stack before
+                    // evaluating the expression, so tell browser_set_debug to skip 1 toplevel context
+                    // before locating the target context for step-out.
+                    var res = await eval.EvaluateAsync("rtvs:::browser_set_debug(1, 1)");
+                    Trace.Assert(res.ParseStatus == RParseStatus.OK);
+
+                    if (res.ParseStatus != RParseStatus.OK || res.Error != null) {
+                        _stepTcs.TrySetResult(false);
+                        return false;
+                    }
+
+                    return true;
+                }
+            });
         }
 
         /// <returns>
         /// <c>true</c> if step completed successfully, and <c>false</c> if it was interrupted midway by something
         /// else pausing the process, such as a breakpoint.
         /// </returns>
-        private async Task<bool> StepAsync(CancellationToken cancellationToken, params string[] commands) {
-            Trace.Assert(commands.Length > 0);
+        private async Task<bool> StepAsync(CancellationToken cancellationToken, string command, Func<IRSessionInteraction, Task<bool>> prepare = null) {
             ThrowIfDisposed();
-
             await TaskUtilities.SwitchToBackgroundThread();
 
             _stepTcs = new TaskCompletionSource<bool>();
-            for (int i = 0; i < commands.Length - 1; ++i) {
-                await ExecuteBrowserCommandAsync(commands[i], cancellationToken);
-            }
-
-            // If RException happens, it means that the expression we just stepped over caused an error.
-            // The step is still considered successful and complete in that case, so we just ignore it.
-            ExecuteBrowserCommandAsync(commands.Last(), cancellationToken)
+            ExecuteBrowserCommandAsync(command, prepare, cancellationToken)
                 .SilenceException<MessageTransportException>()
                 .SilenceException<RException>()
                 .DoNotWait();
-
             return await _stepTcs.Task;
         }
 

--- a/src/Debugger/Impl/rtvs/R/util.R
+++ b/src/Debugger/Impl/rtvs/R/util.R
@@ -34,8 +34,8 @@ set_rdebug <- function(obj, debug) {
   call_embedded("set_rdebug", obj, debug)
 }
 
-browser_set_debug <- function(n = 1) {
-  call_embedded("browser_set_debug", n)
+browser_set_debug <- function(n = 1, skip_toplevel = 0) {
+  call_embedded("browser_set_debug", n, skip_toplevel)
 }
 
 NA_if_error <- function(expr) {

--- a/src/Debugger/Test/SteppingTest.cs
+++ b/src/Debugger/Test/SteppingTest.cs
@@ -93,9 +93,9 @@ z <- x + y";
             }
         }
 
-        [Test]
+        [Test(Skip = "https://github.com/Microsoft/RTVS/issues/975")]
         [Category.R.Debugger]
-        public async Task StepOut() {
+        public async Task StepOutToGlobal() {
             var sessionProvider = EditorShell.Current.ExportProvider.GetExportedValue<IRSessionProvider>();
             using (new RHostScript(sessionProvider)) {
                 IRSession session = sessionProvider.GetOrCreate(GuidList.InteractiveWindowRSessionGuid, new RHostClientTestApp());
@@ -124,6 +124,86 @@ z <- x + y";
                         stackFrames.Should().HaveCount(n => n >= 2);
                         stackFrames[0].LineNumber.Should().Be(6);
                         stackFrames[1].Call.Should().NotBe("f(x)");
+                    }
+                }
+            }
+        }
+
+        [Test]
+        [Category.R.Debugger]
+        public async Task StepOutToFunction() {
+            const string code =
+@"f <- function() {
+    1
+}
+g <- function() {
+    f()
+    1
+}
+g()";
+
+            var sessionProvider = EditorShell.Current.ExportProvider.GetExportedValue<IRSessionProvider>();
+            using (new RHostScript(sessionProvider)) {
+                IRSession session = sessionProvider.GetOrCreate(GuidList.InteractiveWindowRSessionGuid, new RHostClientTestApp());
+                using (var debugSession = new DebugSession(session)) {
+                    using (var sf = new SourceFile(code)) {
+                        await debugSession.EnableBreakpointsAsync(true);
+
+                        var bp = await debugSession.CreateBreakpointAsync(new DebugBreakpointLocation(sf.FilePath, 2));
+                        var bpHit = new TaskCompletionSource<bool>();
+                        bp.BreakpointHit += (s, e) => {
+                            bpHit.SetResult(true);
+                        };
+
+                        await sf.Source(session);
+                        await bpHit.Task;
+
+                        var stackFrames = (await debugSession.GetStackFramesAsync()).Reverse().ToArray();
+                        stackFrames.Should().HaveCount(n => n >= 2);
+                        stackFrames[0].LineNumber.Should().Be(bp.Location.LineNumber);
+                        stackFrames[1].Call.Should().Be("f()");
+
+                        bool stepCompleted = await debugSession.StepOutAsync();
+                        stepCompleted.Should().Be(true);
+
+                        stackFrames = (await debugSession.GetStackFramesAsync()).Reverse().ToArray();
+                        stackFrames.Should().HaveCount(n => n >= 2);
+                        stackFrames[0].LineNumber.Should().Be(6);
+                        stackFrames[1].Call.Should().Be("g()");
+                    }
+                }
+            }
+        }
+
+        [Test]
+        [Category.R.Debugger]
+        public async Task StepOutFromGlobal() {
+            var sessionProvider = EditorShell.Current.ExportProvider.GetExportedValue<IRSessionProvider>();
+            using (new RHostScript(sessionProvider)) {
+                IRSession session = sessionProvider.GetOrCreate(GuidList.InteractiveWindowRSessionGuid, new RHostClientTestApp());
+                using (var debugSession = new DebugSession(session)) {
+                    using (var sf = new SourceFile(code)) {
+                        await debugSession.EnableBreakpointsAsync(true);
+
+                        var bp1 = await debugSession.CreateBreakpointAsync(new DebugBreakpointLocation(sf.FilePath, 4));
+                        var bp2 = await debugSession.CreateBreakpointAsync(new DebugBreakpointLocation(sf.FilePath, 5));
+
+                        var bpHit = new TaskCompletionSource<bool>();
+                        bp1.BreakpointHit += (s, e) => {
+                            bpHit.SetResult(true);
+                        };
+
+                        await sf.Source(session);
+                        await bpHit.Task;
+
+                        var stackFrames = (await debugSession.GetStackFramesAsync()).Reverse().ToArray();
+                        stackFrames[0].LineNumber.Should().Be(bp1.Location.LineNumber);
+
+                        bool stepSuccessful = await debugSession.StepOutAsync();
+                        stepSuccessful.Should().Be(false);
+
+                        stackFrames = (await debugSession.GetStackFramesAsync()).Reverse().ToArray();
+                        stackFrames[0].LineNumber.Should().Be(bp2.Location.LineNumber);
                     }
                 }
             }


### PR DESCRIPTION
Do browser_set_debug in an evaluation rather than an interaction, and abort step if it results in an error.

Split step out tests into several tests exercising different corner cases.
