### PR TITLE
Fixes related to #1011

### DIFF
--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -49,7 +49,7 @@ namespace Microsoft.R.Host.Client.Session {
         public string Prompt { get; private set; } = DefaultPrompt;
         public int MaxLength { get; private set; } = 0x1000;
         public bool IsHostRunning => _isHostRunning;
-        public Task HostStarted => _initializationTcs?.Task ?? Task.FromCanceled(CancellationToken.None);
+        public Task HostStarted => _initializationTcs?.Task ?? Task.FromCanceled(new CancellationToken(true));
 
         static RSession() {
             var tcs = new CancellationTokenSource();

--- a/src/Host/Client/Test/Mocks/RSessionMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionMock.cs
@@ -12,7 +12,7 @@ namespace Microsoft.R.Host.Client.Test.Mocks {
 
         public bool IsHostRunning { get; set; }
 
-        public Task HostStarted => IsHostRunning ? Task.FromResult(0) : Task.FromCanceled(CancellationToken.None);
+        public Task HostStarted => IsHostRunning ? Task.FromResult(0) : Task.FromCanceled(new CancellationToken(true));
 
         public string Prompt { get; set; } = ">";
 

--- a/src/Package/Impl/ProjectSystem/RProjectLoadHooks.cs
+++ b/src/Package/Impl/ProjectSystem/RProjectLoadHooks.cs
@@ -55,8 +55,9 @@ namespace Microsoft.VisualStudio.R.Package.ProjectSystem {
             await Project.CreateInMemoryImport();
             _fileWatcher.Start();
 
-            // Force REPL window up
-            VsAppShell.Current.DispatchOnUIThread(ReplWindow.EnsureReplWindow);
+            // Force REPL window up and continue only when it is shown
+            await _threadHandling.SwitchToUIThread();
+            ReplWindow.EnsureReplWindow();
 
             try {
                 await _session.HostStarted;


### PR DESCRIPTION
- Use `Task.FromCanceled(new CancellationToken(true))` instead of `Task.FromCanceled(CancellationToken.None)`
- Revert `VsAppShell.Current.DispatchOnUIThread` to `await _threadHandling.SwitchToUIThread();`
