### PR TITLE
Fix #970: Cannot set a breakpoint on NULL

### DIFF
--- a/src/Debugger/Impl/rtvs/R/breakpoints.R
+++ b/src/Debugger/Impl/rtvs/R/breakpoints.R
@@ -147,6 +147,11 @@ inject_breakpoints <- function(expr) {
         next;
       }
 
+      # Attributes cannot be set on NULL, so wrap it in (), and set attributes on the resulting call object.
+      if (identical(target_expr, NULL)) {
+        target_expr <- quote((NULL));
+      }
+
       new_expr[[step]] <- substitute({
         .doTrace(if (rtvs:::is_breakpoint(FILENAME, LINE_NUMBER)) browser());
         EXPR
@@ -155,7 +160,7 @@ inject_breakpoints <- function(expr) {
         LINE_NUMBER = line_num,
         EXPR = target_expr
       ));
-     
+
       attr(new_expr[[step]], 'rtvs::original_expr') <- target_expr;
       attr(new_expr[[step]][[2]], 'rtvs::is_breakpoint') <- TRUE;
       attr(new_expr[[step]][[3]], 'rtvs::at_breakpoint') <- TRUE;


### PR DESCRIPTION
If NULL is the target of a breakpoint, substitute (NULL) instead.
