### PR TITLE
Fix #1053: Disable support for deferred project saving

### DIFF
--- a/src/Package/Impl/Templates/ProjectTemplates/EmptyProject/EmptyProject.vstemplate
+++ b/src/Package/Impl/Templates/ProjectTemplates/EmptyProject/EmptyProject.vstemplate
@@ -9,7 +9,8 @@
     <CreateNewFolder>true</CreateNewFolder>
     <DefaultName>rproject</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
-      <CreateInPlace>true</CreateInPlace>
+    <CreateInPlace>true</CreateInPlace>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
   </TemplateData>
   <TemplateContent>
     <Project TargetFileName="$safeprojectname$.rproj" File="rproject.rproj" ReplaceParameters="true">


### PR DESCRIPTION
**Risk:** Minimal. No code changes, the only change is in the project template
**Affected user scenarios:** People with `Save new project when created` off can't save newly created project
**Workaround**: Switch `Save new project when created` on. Though it will not affect currently opened project, which user will have to discard.
