### PR TITLE
Fix #1064: CPS load may try and create interactive workflow before package loads

### DIFF
--- a/src/Package/Impl/Commands/R/VsRCommandFactory.cs
+++ b/src/Package/Impl/Commands/R/VsRCommandFactory.cs
@@ -18,18 +18,20 @@ namespace Microsoft.VisualStudio.R.Package.Commands.R {
     [ContentType(RContentTypeDefinition.ContentType)]
     internal class VsRCommandFactory : ICommandFactory {
         private readonly IRInteractiveWorkflowProvider _workflowProvider;
+        private readonly IInteractiveWindowComponentContainerFactory _componentContainerFactory;
 
         [ImportingConstructor]
-        public VsRCommandFactory(IRInteractiveWorkflowProvider workflowProvider) {
+        public VsRCommandFactory(IRInteractiveWorkflowProvider workflowProvider, IInteractiveWindowComponentContainerFactory componentContainerFactory) {
             _workflowProvider = workflowProvider;
+            _componentContainerFactory = componentContainerFactory;
         }
 
         public IEnumerable<ICommand> GetCommands(ITextView textView, ITextBuffer textBuffer) {
             var workflow = _workflowProvider.GetOrCreate();
 
             if (workflow.ActiveWindow == null) {
-                _workflowProvider
-                    .CreateInteractiveWindowAsync(workflow)
+                workflow
+                    .GetOrCreateVisualComponent(_componentContainerFactory)
                     .ContinueOnRanToCompletion(w => w.Container.Show(false));
             }
 

--- a/src/Package/Impl/Packages/R/PackageCommands.cs
+++ b/src/Package/Impl/Packages/R/PackageCommands.cs
@@ -23,6 +23,7 @@ namespace Microsoft.VisualStudio.R.Packages.R {
     internal static class PackageCommands {
         public static IEnumerable<MenuCommand> GetCommands(ExportProvider exportProvider) {
             var interactiveWorkflowProvider = exportProvider.GetExportedValue<IRInteractiveWorkflowProvider>();
+            var interactiveWorkflowComponentContainerFactory = exportProvider.GetExportedValue<IInteractiveWindowComponentContainerFactory>();
             var interactiveWorkflow = interactiveWorkflowProvider.GetOrCreate();
             var projectServiceAccessor = exportProvider.GetExportedValue<IProjectServiceAccessor>();
             var plotHistoryProvider = exportProvider.GetExportedValue<IPlotHistoryProvider>();
@@ -70,7 +71,7 @@ namespace Microsoft.VisualStudio.R.Packages.R {
 
                 // Window commands
                 new ShowPlotWindowsCommand(),
-                new ShowRInteractiveWindowsCommand(interactiveWorkflowProvider),
+                new ShowRInteractiveWindowsCommand(interactiveWorkflowProvider, interactiveWorkflowComponentContainerFactory),
                 new ShowVariableWindowCommand(),
                 new ShowHelpWindowCommand(),
                 new ShowHelpOnCurrentCommand(interactiveWorkflow, textViewTracker),

--- a/src/Package/Impl/Repl/VsRInteractiveWorkflowProvider.cs
+++ b/src/Package/Impl/Repl/VsRInteractiveWorkflowProvider.cs
@@ -1,23 +1,17 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Languages.Editor.Shell;
-using Microsoft.R.Components.ContentTypes;
 using Microsoft.R.Components.History;
 using Microsoft.R.Components.InteractiveWorkflow;
-using Microsoft.R.Editor.ContentType;
 using Microsoft.R.Host.Client;
 using Microsoft.R.Support.Settings;
-using Microsoft.VisualStudio.R.Package.Utilities;
-using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.R.Package.Repl {
     [Export(typeof(IRInteractiveWorkflowProvider))]
     internal class VsRInteractiveWorkflowProvider : IRInteractiveWorkflowProvider {
         private readonly IRSessionProvider _sessionProvider;
         private readonly IRHistoryProvider _historyProvider;
-        private readonly IInteractiveWindowComponentContainerFactory _componentContainerFactory;
         private readonly IActiveWpfTextViewTracker _activeTextViewTracker;
         private readonly IDebuggerModeTracker _debuggerModeTracker;
 
@@ -26,13 +20,11 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
         [ImportingConstructor]
         public VsRInteractiveWorkflowProvider(IRSessionProvider sessionProvider
             , IRHistoryProvider historyProvider
-            , IInteractiveWindowComponentContainerFactory componentContainerFactory
             , IActiveWpfTextViewTracker activeTextViewTracker
             , IDebuggerModeTracker debuggerModeTracker) {
 
             _sessionProvider = sessionProvider;
             _historyProvider = historyProvider;
-            _componentContainerFactory = componentContainerFactory;
             _activeTextViewTracker = activeTextViewTracker;
             _debuggerModeTracker = debuggerModeTracker;
         }
@@ -41,11 +33,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
             Interlocked.CompareExchange(ref _instanceLazy, new Lazy<IRInteractiveWorkflow>(CreateRInteractiveWorkflow),null);
             return _instanceLazy.Value;
         }
-
-        public Task<IInteractiveWindowVisualComponent> CreateInteractiveWindowAsync(IRInteractiveWorkflow workflow, int instanceId = 0) {
-            return workflow.GetOrCreateVisualComponent(_componentContainerFactory, instanceId);
-        }
-
+        
         private IRInteractiveWorkflow CreateRInteractiveWorkflow() {
             var shell = EditorShell.Current;
             var settings = RToolsSettings.Current;

--- a/src/Package/Impl/Repl/Workspace/ShowRInteractiveWindowsCommand.cs
+++ b/src/Package/Impl/Repl/Workspace/ShowRInteractiveWindowsCommand.cs
@@ -7,10 +7,12 @@ using Microsoft.VisualStudio.R.Packages.R;
 namespace Microsoft.VisualStudio.R.Package.Repl.Workspace {
     internal sealed class ShowRInteractiveWindowsCommand : PackageCommand {
         private readonly IRInteractiveWorkflowProvider _interactiveWorkflowProvider;
+        private readonly IInteractiveWindowComponentContainerFactory _componentContainerFactory;
 
-        public ShowRInteractiveWindowsCommand(IRInteractiveWorkflowProvider interactiveWorkflowProvider) :
+        public ShowRInteractiveWindowsCommand(IRInteractiveWorkflowProvider interactiveWorkflowProvider, IInteractiveWindowComponentContainerFactory componentContainerFactory) :
             base(RGuidList.RCmdSetGuid, RPackageCommandId.icmdShowReplWindow) {
             _interactiveWorkflowProvider = interactiveWorkflowProvider;
+            _componentContainerFactory = componentContainerFactory;
         }
 
         protected override void Handle() {
@@ -21,8 +23,8 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Workspace {
                 return;
             }
 
-            _interactiveWorkflowProvider
-                .CreateInteractiveWindowAsync(interactiveWorkflow)
+            interactiveWorkflow
+                .GetOrCreateVisualComponent(_componentContainerFactory)
                 .ContinueOnRanToCompletion(w => w.Container.Show(true));
         }
     }

--- a/src/Package/Impl/Shell/VsAppShell.cs
+++ b/src/Package/Impl/Shell/VsAppShell.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.R.Package.Shell {
     /// </summary>
     [Export(typeof(IApplicationShell))]
     public sealed class VsAppShell : IApplicationShell, IIdleTimeService, IDisposable {
-        private static Lazy<VsAppShell> _instance = Lazy.Create(() => new VsAppShell());
+        private static readonly Lazy<VsAppShell> _instance = Lazy.Create(() =>  new VsAppShell());
 
         private static IApplicationShell _testShell;
         private IdleTimeSource _idleTimeSource;
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.R.Package.Shell {
                 return sp.GetService(type ?? typeof(T)) as T;
             }
 
-            return RPackage.GetGlobalService(type ?? typeof(T)) as T;
+            return VisualStudio.Shell.Package.GetGlobalService(type ?? typeof(T)) as T;
         }
 
         /// <summary>
@@ -381,8 +381,8 @@ namespace Microsoft.VisualStudio.R.Package.Shell {
             this.IsUITestEnvironment = false;
         }
 
-        private IVsPackage EnsurePackageLoaded(Guid guidPackage) {
-            var shell = GetGlobalService<IVsShell>();
+        public static IVsPackage EnsurePackageLoaded(Guid guidPackage) {
+            var shell = (IVsShell)VisualStudio.Shell.Package.GetGlobalService(typeof(IVsShell));
             var guid = guidPackage;
             IVsPackage package;
             int hr = ErrorHandler.ThrowOnFailure(shell.IsPackageLoaded(ref guid, out package), VSConstants.E_FAIL);

--- a/src/Package/Test/FakeFactories/TestRInteractiveWorkflowProviderFactory.cs
+++ b/src/Package/Test/FakeFactories/TestRInteractiveWorkflowProviderFactory.cs
@@ -16,19 +16,17 @@ namespace Microsoft.VisualStudio.R.Package.Test.FakeFactories {
     public static class TestRInteractiveWorkflowProviderFactory {
         public static IRInteractiveWorkflowProvider Create(IRSessionProvider sessionProvider = null
             , IRHistoryProvider historyProvider = null
-            , IInteractiveWindowComponentContainerFactory componentContainerFactory = null
             , IActiveWpfTextViewTracker activeTextViewTracker = null
             , IDebuggerModeTracker debuggerModeTracker = null
             , ICoreShell shell = null
             , IRSettings settings = null) {
             sessionProvider = sessionProvider ?? new RSessionProviderMock();
             historyProvider = historyProvider ?? RHistoryProviderStubFactory.CreateDefault();
-            componentContainerFactory = componentContainerFactory ?? new InteractiveWindowComponentContainerFactoryMock();
 
             activeTextViewTracker = activeTextViewTracker ?? new ActiveTextViewTrackerMock(string.Empty, RContentTypeDefinition.ContentType);
             debuggerModeTracker = debuggerModeTracker ?? new VsDebuggerModeTracker();
 
-           return new TestRInteractiveWorkflowProvider(sessionProvider, historyProvider, componentContainerFactory, activeTextViewTracker, debuggerModeTracker, shell ?? VsAppShell.Current, settings ?? RToolsSettings.Current);
+           return new TestRInteractiveWorkflowProvider(sessionProvider, historyProvider, activeTextViewTracker, debuggerModeTracker, shell ?? VsAppShell.Current, settings ?? RToolsSettings.Current);
         }
     }
 }

--- a/src/Package/TestApp/Utility/ViewTreeDump.cs
+++ b/src/Package/TestApp/Utility/ViewTreeDump.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Utility {
             if (_regenerateBaselineFiles) {
                 var serializedActual = SerializeVisualTree(actual);
 
-                string baselineFilePath = Path.Combine(fixture.SourcePath, Path.GetFileName(testFileName));
+                string baselineFilePath = fixture.GetSourcePath(testFileName);
                 TestFiles.UpdateBaseline(baselineFilePath, serializedActual);
             } else {
                 var deserializedExpected = DeserializeVisualTree(testFilePath);

--- a/src/R.sln
+++ b/src/R.sln
@@ -85,8 +85,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		R.Wix.Settings.targets = R.Wix.Settings.targets
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.R.Components", "R\Components\Impl\Microsoft.R.Components.csproj", "{506141BE-1418-4D75-8E24-54A9280B0A66}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.R.Components.Test", "R\Components\Test\Microsoft.R.Components.Test.csproj", "{2AA8762F-3A84-4CD5-9AA0-77829A766769}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SetupCustomActions", "SetupCustomActions\SetupCustomActions.csproj", "{F2149709-A88B-4F36-ABCA-307CA96E9FD1}"
@@ -94,6 +92,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.R.Debugger.Test", "Debugger\Test\Microsoft.R.Debugger.Test.csproj", "{6D3AC84F-D53F-4494-8142-DD2BC8FD9CFD}"
 EndProject
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "SetupRHost", "SetupRHost\SetupRHost.wixproj", "{A5265B92-029A-423E-9006-A7C1F52476ED}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.R.Components", "R\Components\Impl\Microsoft.R.Components.csproj", "{506141BE-1418-4D75-8E24-54A9280B0A66}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -358,7 +358,6 @@ Global
 		{56534417-6C60-48A5-B355-12225C70431E}.Release|x86.ActiveCfg = Release|Any CPU
 		{56534417-6C60-48A5-B355-12225C70431E}.Release|x86.Build.0 = Release|Any CPU
 		{B86E0BA1-82AF-45F8-9BE8-FDDCB8EF7F13}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{B86E0BA1-82AF-45F8-9BE8-FDDCB8EF7F13}.Debug|Any CPU.Build.0 = Debug|x86
 		{B86E0BA1-82AF-45F8-9BE8-FDDCB8EF7F13}.Debug|x64.ActiveCfg = Debug|x86
 		{B86E0BA1-82AF-45F8-9BE8-FDDCB8EF7F13}.Debug|x86.ActiveCfg = Debug|x86
 		{B86E0BA1-82AF-45F8-9BE8-FDDCB8EF7F13}.Release|Any CPU.ActiveCfg = Release|x86
@@ -526,18 +525,6 @@ Global
 		{130C9240-9537-42D4-A62C-2A13815F0020}.Release|x64.Build.0 = Release|Any CPU
 		{130C9240-9537-42D4-A62C-2A13815F0020}.Release|x86.ActiveCfg = Release|Any CPU
 		{130C9240-9537-42D4-A62C-2A13815F0020}.Release|x86.Build.0 = Release|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|x64.Build.0 = Debug|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|x86.Build.0 = Debug|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|Any CPU.Build.0 = Release|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|x64.ActiveCfg = Release|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|x64.Build.0 = Release|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|x86.ActiveCfg = Release|Any CPU
-		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|x86.Build.0 = Release|Any CPU
 		{2AA8762F-3A84-4CD5-9AA0-77829A766769}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2AA8762F-3A84-4CD5-9AA0-77829A766769}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2AA8762F-3A84-4CD5-9AA0-77829A766769}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -582,6 +569,18 @@ Global
 		{A5265B92-029A-423E-9006-A7C1F52476ED}.Release|x64.ActiveCfg = Release|x86
 		{A5265B92-029A-423E-9006-A7C1F52476ED}.Release|x86.ActiveCfg = Release|x86
 		{A5265B92-029A-423E-9006-A7C1F52476ED}.Release|x86.Build.0 = Release|x86
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|x64.Build.0 = Debug|Any CPU
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Debug|x86.Build.0 = Debug|Any CPU
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|x64.ActiveCfg = Release|Any CPU
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|x64.Build.0 = Release|Any CPU
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|x86.ActiveCfg = Release|Any CPU
+		{506141BE-1418-4D75-8E24-54A9280B0A66}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/R/Components/Impl/InteractiveWorkflow/IRInteractiveWorkflowProvider.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/IRInteractiveWorkflowProvider.cs
@@ -3,6 +3,5 @@ using System.Threading.Tasks;
 namespace Microsoft.R.Components.InteractiveWorkflow {
     public interface IRInteractiveWorkflowProvider {
         IRInteractiveWorkflow GetOrCreate();
-        Task<IInteractiveWindowVisualComponent> CreateInteractiveWindowAsync(IRInteractiveWorkflow workflow, int instanceId = 0);
     }
 }

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
@@ -98,11 +98,6 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
         }
 
         public async Task<ExecutionResult> ExecuteCodeAsync(string text) {
-            // TODO: Workaround for bug https://github.com/dotnet/roslyn/issues/8569
-            if (text[0] == '\u0002') {
-                text = text.Substring(1);
-            }
-
             var start = 0;
             var end = text.IndexOf('\n');
             if (end == -1) {

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflowOperations.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflowOperations.cs
@@ -81,9 +81,6 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
                     textView.Caret.MoveTo(point.Value);
                 }
 
-                // TODO: Workaround for bug https://github.com/dotnet/roslyn/issues/8569
-                InteractiveWindow.CurrentLanguageBuffer.Insert(0, "\u0002");
-
                 InteractiveWindow.Operations.Return();
             } else {
                 // Otherwise insert a line break in the middle of an input

--- a/src/R/Components/Impl/Microsoft.R.Components.csproj
+++ b/src/R/Components/Impl/Microsoft.R.Components.csproj
@@ -139,7 +139,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\Core\Impl\Microsoft.Common.Core.csproj">
-      <Project>{8D408909-459F-4853-A36C-745118F99869}</Project>
+      <Project>{8d408909-459f-4853-a36c-745118f99869}</Project>
       <Name>Microsoft.Common.Core</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\Host\Client\Impl\Microsoft.R.Host.Client.csproj">

--- a/src/R/Components/Test/Fakes/InteractiveWindow/TestRInteractiveWorkflowProvider.cs
+++ b/src/R/Components/Test/Fakes/InteractiveWindow/TestRInteractiveWorkflowProvider.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel.Composition;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Common.Core.Shell;
 using Microsoft.R.Components.History;
 using Microsoft.R.Components.InteractiveWorkflow;
@@ -14,7 +13,6 @@ namespace Microsoft.R.Components.Test.Fakes.InteractiveWindow {
     public class TestRInteractiveWorkflowProvider : IRInteractiveWorkflowProvider {
         private readonly IRSessionProvider _sessionProvider;
         private readonly IRHistoryProvider _historyProvider;
-        private readonly IInteractiveWindowComponentContainerFactory _componentContainerFactory;
         private readonly ICoreShell _shell;
         private readonly IRSettings _settings;
         private readonly IActiveWpfTextViewTracker _activeTextViewTracker;
@@ -25,7 +23,6 @@ namespace Microsoft.R.Components.Test.Fakes.InteractiveWindow {
         [ImportingConstructor]
         public TestRInteractiveWorkflowProvider(IRSessionProvider sessionProvider
             , IRHistoryProvider historyProvider
-            , IInteractiveWindowComponentContainerFactory componentContainerFactory
             , IActiveWpfTextViewTracker activeTextViewTracker
             , IDebuggerModeTracker debuggerModeTracker
             , ICoreShell shell
@@ -33,7 +30,6 @@ namespace Microsoft.R.Components.Test.Fakes.InteractiveWindow {
 
             _sessionProvider = sessionProvider;
             _historyProvider = historyProvider;
-            _componentContainerFactory = componentContainerFactory;
             _activeTextViewTracker = activeTextViewTracker;
             _debuggerModeTracker = debuggerModeTracker;
             _shell = shell;
@@ -45,10 +41,6 @@ namespace Microsoft.R.Components.Test.Fakes.InteractiveWindow {
             return _instanceLazy.Value;
         }
         
-        public Task<IInteractiveWindowVisualComponent> CreateInteractiveWindowAsync(IRInteractiveWorkflow workflow, int instanceId = 0) {
-            return workflow.GetOrCreateVisualComponent(_componentContainerFactory, instanceId);
-        }
-
         private IRInteractiveWorkflow CreateRInteractiveWorkflow() {
             return new RInteractiveWorkflow(_sessionProvider, _historyProvider, _activeTextViewTracker, _debuggerModeTracker, null, _shell, _settings, DisposeInstance);
         }

--- a/src/R/Components/Test/InteractiveWorkflow/RInteractiveWorkflowOperationsTest.cs
+++ b/src/R/Components/Test/InteractiveWorkflow/RInteractiveWorkflowOperationsTest.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel.Composition.Hosting;
+using System.Threading.Tasks;
+using Microsoft.R.Components.InteractiveWorkflow;
+using Microsoft.UnitTests.Core.Threading;
+using Xunit;
+
+namespace Microsoft.R.Components.Test.InteractiveWorkflow {
+    public class RInteractiveWorkflowOperationsTest : IAsyncLifetime  {
+        private readonly ExportProvider _exportProvider;
+        private readonly IRInteractiveWorkflow _workflow;
+        private IInteractiveWindowVisualComponent _workflowComponent;
+
+        public RInteractiveWorkflowOperationsTest(RComponentsMefCatalogFixture catalog) {
+            _exportProvider = catalog.CreateExportProvider();
+            _workflow = _exportProvider.GetExportedValue<IRInteractiveWorkflowProvider>().GetOrCreate();
+        }
+
+        public async Task InitializeAsync() {
+            var componentFactory = _exportProvider.GetExportedValue<IInteractiveWindowComponentContainerFactory>();
+            _workflowComponent = await UIThreadHelper.Instance.Invoke(() => _workflow.GetOrCreateVisualComponent(componentFactory));
+        }
+
+        public Task DisposeAsync() {
+            _workflowComponent.Dispose();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/R/Components/Test/Microsoft.R.Components.Test.csproj
+++ b/src/R/Components/Test/Microsoft.R.Components.Test.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Fakes\VisualComponentFactories\TestRInteractiveWindowComponentContainerFactory.cs" />
     <Compile Include="History\RHistoryIntegrationTest.cs" />
     <Compile Include="History\RHistoryTests.cs" />
+    <Compile Include="InteractiveWorkflow\RInteractiveWorkflowOperationsTest.cs" />
     <Compile Include="MefCompositionTests.cs" />
     <Compile Include="RComponentsMefCatalogFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/UnitTests/Core/Impl/XUnit/DeployFilesFixture.cs
+++ b/src/UnitTests/Core/Impl/XUnit/DeployFilesFixture.cs
@@ -36,6 +36,7 @@ namespace Microsoft.UnitTests.Core.XUnit {
         public string SolutionRoot => SolutionRootLazy.Value;
         public string TestFilesRoot => TestFilesRootLazy.Value;
 
+        public string GetSourcePath(string fileName) => Path.Combine(SourcePath, fileName);
         public string GetDestinationPath(string fileName) => Path.Combine(DestinationPath, fileName);
 
         public string LoadDestinationFile(string fileName) {


### PR DESCRIPTION
Also:
- Remove CreateInteractiveWindowAsync(IRInteractiveWorkflow workflow, int instanceId = 0); as a duplicate method
- Merge changes from Preview_Public
- Change ReplCommandTest so it awaits on HostStarted rather than Task.Delay
