### PR TITLE
Fix issue when publish operation was using wrong file name

### DIFF
--- a/src/Package/Impl/Publishing/Commands/PreviewCommand.cs
+++ b/src/Package/Impl/Publishing/Commands/PreviewCommand.cs
@@ -20,6 +20,7 @@ using Microsoft.R.Support.Settings;
 using Microsoft.VisualStudio.R.Package.Interop;
 using Microsoft.VisualStudio.R.Package.Publishing.Definitions;
 using Microsoft.VisualStudio.R.Package.Shell;
+using Microsoft.VisualStudio.R.Package.Workspace;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 


### PR DESCRIPTION
Fix issue when file name retrieved from the VS running document table was incorrect. Use IVsTextBuffer/IPersistFileFormat instead.
