### PR TITLE
Remove paper parameter from graphics.ide.exportpdf.

### DIFF
--- a/src/Debugger/Impl/rtvs/R/graphics.R
+++ b/src/Debugger/Impl/rtvs/R/graphics.R
@@ -18,8 +18,8 @@ graphics.ide.exportimage <- function(filename, device, width, height) {
     dev.off()
 }
 
-graphics.ide.exportpdf <- function(filename, width, height, paper) {
-    dev.copy(device=pdf,file=filename,width=width,height=height,paper=paper)
+graphics.ide.exportpdf <- function(filename, width, height) {
+    dev.copy(device=pdf,file=filename,width=width,height=height)
     dev.off()
 }
 

--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -85,8 +85,8 @@ grDevices::deviceIsInteractive('ide')
             return evaluation.EvaluateAsync(script);
         }
 
-        public static Task<REvaluationResult> ExportToPdf(this IRSessionEvaluation evaluation, string outputFilePath, double widthInInches, double heightInInches, string paper) {
-            string script = string.Format("rtvs:::graphics.ide.exportpdf(\"{0}\", {1}, {2}, '{3}')", outputFilePath.Replace("\\", "/"), widthInInches, heightInInches, paper);
+        public static Task<REvaluationResult> ExportToPdf(this IRSessionEvaluation evaluation, string outputFilePath, double widthInInches, double heightInInches) {
+            string script = string.Format("rtvs:::graphics.ide.exportpdf(\"{0}\", {1}, {2})", outputFilePath.Replace("\\", "/"), widthInInches, heightInInches);
             return evaluation.EvaluateAsync(script);
         }
 

--- a/src/Host/Client/Test/IdeGraphicsDeviceTest.cs
+++ b/src/Host/Client/Test/IdeGraphicsDeviceTest.cs
@@ -264,12 +264,11 @@ rtvs:::graphics.ide.exportimage({0}, bmp, {1}, {2})
 
             var code = string.Format(@"
 plot(0:10)
-rtvs:::graphics.ide.exportpdf({0}, {1}, {2}, '{3}')
+rtvs:::graphics.ide.exportpdf({0}, {1}, {2})
 ",
                 QuotedRPath(exportedFilePath),
                 7,
-                7,
-                "special"
+                7
             );
 
             var inputs = Interactive(code);

--- a/src/Package/Impl/Plots/PlotContentProvider.cs
+++ b/src/Package/Impl/Plots/PlotContentProvider.cs
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.R.Package.Plots {
         private async System.Threading.Tasks.Task ExportAsPdfAsync(string fileName) {
             if (_rSession != null) {
                 using (IRSessionEvaluation eval = await _rSession.BeginEvaluationAsync()) {
-                    await eval.ExportToPdf(fileName, PixelsToInches(_lastPixelWidth), PixelsToInches(_lastPixelHeight), "special");
+                    await eval.ExportToPdf(fileName, PixelsToInches(_lastPixelWidth), PixelsToInches(_lastPixelHeight));
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/RTVS/issues/907 Error on export plot to pdf

Turns out if you don't specify a value for the paper parameter, it behaves the same as if you pass in 'special' (passing that in is problematic in certain machine configurations).
