### PR TITLE
More and better debugger tests

### DIFF
--- a/src/Debugger/Engine/Impl/AD7Engine.cs
+++ b/src/Debugger/Engine/Impl/AD7Engine.cs
@@ -193,7 +193,7 @@ namespace Microsoft.R.Debugger.Engine {
 
         int IDebugEngine2.CauseBreak() {
             ThrowIfDisposed();
-            DebugSession.Break()
+            DebugSession.BreakAsync()
                 .SilenceException<MessageTransportException>()
                 .SilenceException<RException>()
                 .DoNotWait();
@@ -331,7 +331,7 @@ namespace Microsoft.R.Debugger.Engine {
                 lock (_browseLock) {
                     if (_sentContinue != true) {
                         _sentContinue = true;
-                        continueMethod = ct => DebugSession.Continue(ct);
+                        continueMethod = ct => DebugSession.ContinueAsync(ct);
                     }
                 }
 

--- a/src/Debugger/Impl/DebugSession.cs
+++ b/src/Debugger/Impl/DebugSession.cs
@@ -126,7 +126,7 @@ namespace Microsoft.R.Debugger {
                     }
                 }
 
-                if (IsBrowserContext(inter.Contexts)) {
+                if (inter.Contexts.IsBrowser()) {
                     await inter.RespondAsync(command + "\n");
                     return true;
                 }
@@ -190,14 +190,14 @@ namespace Microsoft.R.Debugger {
             return DebugEvaluationResult.Parse(stackFrame, name, jEvalResult);
         }
 
-        public async Task Break(CancellationToken ct = default(CancellationToken)) {
+        public async Task BreakAsync(CancellationToken ct = default(CancellationToken)) {
             await TaskUtilities.SwitchToBackgroundThread();
             using (var inter = await RSession.BeginInteractionAsync(true, ct)) {
                 await inter.RespondAsync("browser()\n");
             }
         }
 
-        public async Task Continue(CancellationToken cancellationToken = default(CancellationToken)) {
+        public async Task ContinueAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             await TaskUtilities.SwitchToBackgroundThread();
             ExecuteBrowserCommandAsync("c", null, cancellationToken)
                 .SilenceException<MessageTransportException>()
@@ -310,17 +310,12 @@ namespace Microsoft.R.Debugger {
             _breakpoints.Remove(breakpoint.Location);
         }
 
-        private bool IsBrowserContext(IReadOnlyList<IRContext> contexts) {
-            return contexts.SkipWhile(context => context.CallFlag.HasFlag(RContextType.Restart))
-                .FirstOrDefault()?.CallFlag.HasFlag(RContextType.Browser) == true;
-        }
-
         private void InterruptBreakpointHitProcessing() {
             _bpHitFrame = null;
         }
 
         private void ProcessBrowsePrompt(IReadOnlyList<IRContext> contexts) {
-            if (!IsBrowserContext(contexts)) {
+            if (!contexts.IsBrowser()) {
                 InterruptBreakpointHitProcessing();
                 return;
             }

--- a/src/Debugger/Test/BreakpointHitDetector.cs
+++ b/src/Debugger/Test/BreakpointHitDetector.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace Microsoft.R.Debugger.Test {
+    public class BreakpointHitDetector {
+        public DebugBreakpoint Breakpoint { get; }
+        public bool WasHit { get; private set; }
+
+        public BreakpointHitDetector(DebugBreakpoint bp) {
+            Breakpoint = bp;
+            Breakpoint.BreakpointHit += Breakpoint_BreakpointHit;
+        }
+
+        public void Reset() {
+            WasHit = false;
+        }
+
+        private void Breakpoint_BreakpointHit(object sender, EventArgs e) {
+            WasHit = true;
+            Breakpoint.BreakpointHit -= Breakpoint_BreakpointHit;
+        }
+
+        public async Task ShouldBeHitAtNextPromptAsync() {
+            await Breakpoint.Session.NextPromptShouldBeBrowseAsync();
+            Breakpoint.BreakpointHit -= Breakpoint_BreakpointHit;
+            WasHit.Should().BeTrue("Breakpoint must be hit at the next prompt.");
+        }
+    }
+}

--- a/src/Debugger/Test/CallStackTest.cs
+++ b/src/Debugger/Test/CallStackTest.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Common.Core.Test.Utility;
+using Microsoft.Languages.Editor.Shell;
+using Microsoft.R.Host.Client;
+using Microsoft.R.Host.Client.Session;
+using Microsoft.R.Host.Client.Test.Script;
+using Microsoft.UnitTests.Core.XUnit;
+using Xunit;
+
+namespace Microsoft.R.Debugger.Test {
+    [ExcludeFromCodeCoverage]
+    public class CallStackTest : IAsyncLifetime {
+        private readonly MethodInfo _testMethod;
+        private readonly RSessionProvider _sessionProvider;
+        private readonly IRSession _session;
+
+        public CallStackTest(TestMethodInfoFixture testMethodInfo) {
+            _testMethod = testMethodInfo.Method;
+            _sessionProvider = new RSessionProvider();
+            _session = _sessionProvider.GetOrCreate(Guid.NewGuid(), new RHostClientTestApp());
+        }
+
+        public async Task InitializeAsync() {
+            await _session.StartHostAsync(new RHostStartupInfo {
+                Name = _testMethod.Name,
+                RBasePath = RUtilities.FindExistingRBasePath()
+            }, 50000);
+        }
+
+        public async Task DisposeAsync() {
+            await _session.StopHostAsync();
+            _sessionProvider.Dispose();
+        }
+
+        [Test]
+        [Category.R.Debugger]
+        public async Task CallStack() {
+            using (var debugSession = new DebugSession(_session)) {
+                const string code1 =
+@"f <- function(n) {
+     if (n > 0) {
+        g(n - 1)
+     } else {
+        return()
+     }
+  }";
+
+                const string code2 =
+@"g <- function(n) {
+     if (n > 0) {
+        f(n - 1)
+     } else {
+        return()
+     }
+  }";
+
+                using (var sf1 = new SourceFile(code1))
+                using (var sf2 = new SourceFile(code2)) {
+                    await debugSession.EnableBreakpointsAsync(true);
+
+                    await sf1.Source(_session);
+                    await sf2.Source(_session);
+
+                    var bp = await debugSession.CreateBreakpointAsync(sf1, 5);
+                    var bpHit = new BreakpointHitDetector(bp);
+
+                    using (var inter = await _session.BeginInteractionAsync()) {
+                        await inter.RespondAsync("f(4)\n");
+                    }
+                    await bpHit.ShouldBeHitAtNextPromptAsync();
+
+                    (await debugSession.GetStackFramesAsync()).Should()
+                        .BeAt(sf1, 5, "f(n - 1)")
+                        .At(sf2, 3, "g(n - 1)")
+                        .At(sf1, 3, "f(n - 1)")
+                        .At(sf2, 3, "g(n - 1)")
+                        .At(sf1, 3, "f(4)")
+                        .At((string)null, null);
+                }
+            }
+        }
+    }
+}

--- a/src/Debugger/Test/DebugSessionExtensions.cs
+++ b/src/Debugger/Test/DebugSessionExtensions.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Common.Core;
+using Microsoft.R.Host.Client;
+
+namespace Microsoft.R.Debugger.Test {
+    internal static class DebugSessionExtensions {
+        public static async Task NextPromptShouldBeBrowseAsync(this DebugSession session) {
+            // Grab the next available prompt, and verify that it's Browse>
+            using (var inter = await session.RSession.BeginInteractionAsync()) {
+                inter.Contexts.IsBrowser().Should().BeTrue("Next available prompt should be a Browse> prompt");
+            }
+
+            // Now wait until session tells us that it has noticed the prompt and processed it.
+            // Note that even if we register the handler after it has already noticed, but
+            // before the interaction completed, it will still invoke the handler.
+            var browseTcs = new TaskCompletionSource<bool>();
+            EventHandler<DebugBrowseEventArgs> handler = null;
+            handler = (sender, e) => {
+                session.Browse -= handler;
+                browseTcs.SetResult(true);
+            };
+            session.Browse += handler;
+
+            // Spin until either Browse is raised, or we see a different non-Browse prompt.
+            // If the latter happens, we're not going to see Browse raised for that prompt that we've
+            // seen initially, because something had interfered asynchronously, which shouldn't happen
+            // in a test - and if it does, the test should be considered failed at that point, because
+            // the state is indeterminate.
+            while (true) {
+                var interTask = session.RSession.BeginInteractionAsync();
+                var completedTask = await Task.WhenAny(browseTcs.Task, interTask);
+
+                if (completedTask == browseTcs.Task) {
+                    interTask.ContinueWith(t => t.Result.Dispose(), TaskContinuationOptions.OnlyOnRanToCompletion).DoNotWait();
+                    return;
+                }
+
+                using (var inter = await interTask) {
+                    inter.Contexts.IsBrowser().Should().BeTrue();
+                }
+            }
+        }
+
+        public static Task<DebugBreakpoint> CreateBreakpointAsync(this DebugSession session, SourceFile sf, int lineNumber) {
+            return session.CreateBreakpointAsync(new DebugBreakpointLocation(sf.FilePath, lineNumber));
+        }
+
+        public static DebugStackFramesAssertions Should(this IEnumerable<DebugStackFrame> frames) {
+            return new DebugStackFramesAssertions(frames);
+        }
+    }
+}

--- a/src/Debugger/Test/DebugStackFrameAssertions.cs
+++ b/src/Debugger/Test/DebugStackFrameAssertions.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Collections;
+
+namespace Microsoft.R.Debugger.Test {
+    internal sealed class DebugStackFramesAssertions : GenericCollectionAssertions<DebugStackFrame> {
+        protected override string Context => "DebugSession.GetStackFramesAsync()";
+
+        private readonly IEnumerable<DebugStackFrame> _frames;
+
+        public DebugStackFramesAssertions(IEnumerable<DebugStackFrame> frames)
+            : base(frames) {
+            _frames = frames.Reverse();
+        }
+
+        public RemainingFrames BeAt(string fileName, int? lineNumber) {
+            return new RemainingFrames(_frames).At(fileName, lineNumber);
+        }
+
+        public RemainingFrames BeAt(string fileName, int? lineNumber, string call) {
+            return new RemainingFrames(_frames).At(fileName, lineNumber, call);
+        }
+
+        public RemainingFrames BeAt(SourceFile sourceFile, int? lineNumber) {
+            return new RemainingFrames(_frames).At(sourceFile, lineNumber);
+        }
+
+        public RemainingFrames BeAt(SourceFile sourceFile, int? lineNumber, string call) {
+            return new RemainingFrames(_frames).At(sourceFile, lineNumber, call);
+        }
+
+        public RemainingFrames BeAt(DebugBreakpointLocation location, int delta = 0) {
+            return new RemainingFrames(_frames).At(location, delta);
+        }
+
+        public RemainingFrames BeAt(DebugBreakpointLocation location, string call) {
+            return new RemainingFrames(_frames).At(location, call);
+        }
+
+        public RemainingFrames BeAt(DebugBreakpointLocation location, int delta, string call) {
+            return new RemainingFrames(_frames).At(location, delta, call);
+        }
+
+        public class RemainingFrames {
+            private readonly IEnumerable<DebugStackFrame> _frames;
+
+            public RemainingFrames(IEnumerable<DebugStackFrame> frames) {
+                _frames = frames;
+            }
+
+            public RemainingFrames At(string fileName, int? lineNumber) {
+                _frames.Should().NotBeEmpty();
+
+                var frame = _frames.First();
+                frame.FileName.Should().Be(fileName);
+                frame.LineNumber.Should().Be(lineNumber);
+
+                return new RemainingFrames(_frames.Skip(1));
+            }
+
+            public RemainingFrames At(string fileName, int? lineNumber, string call) {
+                _frames.Should().HaveCount(n => n >= 2);
+                var result = At(fileName, lineNumber);
+                _frames.ElementAt(1).Call.Should().Be(call);
+                return result;
+            }
+
+            public RemainingFrames At(SourceFile sourceFile, int? lineNumber) {
+                return At(sourceFile.FilePath, lineNumber);
+            }
+
+            public RemainingFrames At(SourceFile sourceFile, int? lineNumber, string call) {
+                return At(sourceFile.FilePath, lineNumber, call);
+            }
+
+            public RemainingFrames At(DebugBreakpointLocation location, int delta = 0) {
+                return At(location.FileName, location.LineNumber + delta);
+            }
+
+            public RemainingFrames At(DebugBreakpointLocation location, string call) {
+                return At(location.FileName, location.LineNumber, call);
+            }
+
+            public RemainingFrames At(DebugBreakpointLocation location, int delta, string call) {
+                return At(location.FileName, location.LineNumber + delta, call);
+            }
+        }
+    }
+}

--- a/src/Debugger/Test/Microsoft.R.Debugger.Test.csproj
+++ b/src/Debugger/Test/Microsoft.R.Debugger.Test.csproj
@@ -62,6 +62,10 @@
     <Compile Include="..\..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="BreakpointHitDetector.cs" />
+    <Compile Include="CallStackTest.cs" />
+    <Compile Include="DebugStackFrameAssertions.cs" />
+    <Compile Include="DebugSessionExtensions.cs" />
     <Compile Include="SourceFile.cs" />
     <Compile Include="DebugReplTest.cs" />
     <Compile Include="ValuesTest.cs" />

--- a/src/Host/Client/Impl/Definitions/IRContext.cs
+++ b/src/Host/Client/Impl/Definitions/IRContext.cs
@@ -1,11 +1,21 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Microsoft.R.Host.Client {
     /// <summary>
     /// Representation of <c>struct RCTXT</c> in R.
     /// </summary>
     public interface IRContext {
         RContextType CallFlag { get; }
+    }
+
+    public static class RContextExtensions {
+        public static bool IsBrowser(this IReadOnlyList<IRContext> contexts) {
+            return contexts.SkipWhile(context => context.CallFlag.HasFlag(RContextType.Restart))
+                .FirstOrDefault()?.CallFlag.HasFlag(RContextType.Browser) == true;
+        }
     }
 }


### PR DESCRIPTION
Add test and assertion helpers for debugger tests, and refactor existing tests to use those helpers to make them clearer and more concise.

Add some new tests for stepping, breakpoints, and call stack.
