### PR TITLE
New collection assertions

### DIFF
--- a/src/UnitTests/Core/Impl/FluentAssertions/CollectionAssertionsExtensions.cs
+++ b/src/UnitTests/Core/Impl/FluentAssertions/CollectionAssertionsExtensions.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Collections;
+using FluentAssertions.Execution;
+
+namespace Microsoft.UnitTests.Core.FluentAssertions {
+    public static class CollectionAssertionsExtensions {
+        public static AndConstraint<GenericCollectionAssertions<TActual>> Equal<TActual, TExpected>(
+            this GenericCollectionAssertions<TActual> assertions, IEnumerable<TExpected> expected, string because = "", params object[] reasonArgs)
+            where TExpected : IEquatable<TActual> {
+            return assertions.Equal(expected, (a, e) => e.Equals(a), because, reasonArgs);
+        }
+
+        public static AndConstraint<GenericCollectionAssertions<TActual>> StartWith<TActual, TExpected>(
+            this GenericCollectionAssertions<TActual> assertions, IEnumerable<TExpected> expected, string because = "", params object[] reasonArgs)
+            where TExpected : IEquatable<TActual> {
+            return assertions.StartWith(expected, (a, e) => e.Equals(a), because, reasonArgs);
+        }
+
+        public static AndConstraint<GenericCollectionAssertions<TActual>> StartWith<TActual, TExpected>(
+            this GenericCollectionAssertions<TActual> assertions, IEnumerable<TExpected> expectation, Func<TActual, TExpected, bool> predicate, string because = "", params object[] reasonArgs)
+            where TExpected : IEquatable<TActual> {
+
+
+            if (expectation == null) {
+                throw new ArgumentNullException(nameof(expectation), "Cannot compare collection with <null>.");
+            }
+
+            var actualItems = assertions.Subject?.ToArray();
+            var expectedItems = expectation.ToArray();
+
+            Execute.Assertion
+                .BecauseOf(because, reasonArgs)
+                .WithExpectation("Expected {context:collection} to start with {0}{reason}, ", expectedItems)
+                .ForCondition(!ReferenceEquals(actualItems, null))
+                .FailWith("but the collection is <null>.")
+                .Then
+                .Given(() => actualItems)
+                .AssertCollectionLength(actualItems, expectedItems)
+                .Then
+                .Given(items => items
+                    .Take(expectedItems.Length)
+                    .Select((item, i) => new { Actual = item, Expected = expectedItems[i], Index = i })
+                    .FirstOrDefault(c => !predicate(c.Actual, c.Expected)))
+                .ForCondition(diff => diff == null)
+                .FailWith("but {1} differs at index {2}.", c => new object[] { actualItems, c.Index });
+
+            return new AndConstraint<GenericCollectionAssertions<TActual>>(assertions);
+        }
+
+        private static ContinuationOfGiven<TActual[]> AssertCollectionLength<TActual, TExpected>(this GivenSelector<TActual[]> givenSelector, TActual[] actualItems, TExpected[] expectedItems) {
+            return givenSelector.ForCondition(items => items.Length > 0)
+                .FailWith("but the collection is empty.")
+                .Then
+                .ForCondition(items => items.Length >= expectedItems.Length)
+                .FailWith("but {0} contains {1} item(s) less.", actualItems, expectedItems.Length - actualItems.Length);
+        }
+    }
+}

--- a/src/UnitTests/Core/Impl/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/src/UnitTests/Core/Impl/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Linq;
 using FluentAssertions;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;

--- a/src/UnitTests/Core/Impl/Microsoft.UnitTests.Core.csproj
+++ b/src/UnitTests/Core/Impl/Microsoft.UnitTests.Core.csproj
@@ -81,6 +81,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FluentAssertions\CollectionAssertionsExtensions.cs" />
     <Compile Include="FluentAssertions\FluentAssertionExtensions.cs" />
     <Compile Include="FluentAssertions\ObjectAssertionsExtensions.cs" />
     <Compile Include="Mef\CatalogFactory.cs" />


### PR DESCRIPTION
- `StartWith` for a enumerable
- `Equal` & `StartWith` for `TExpected : IEquatable<TActual>` to support enumerable of expected objects that can compare themselves to the actual input of different type
