### PR TITLE
Several build related fixes

### DIFF
--- a/src/EditorTestApp/Microsoft.Languages.Editor.Application.csproj
+++ b/src/EditorTestApp/Microsoft.Languages.Editor.Application.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <BaseIntermediateOutputPath>$(RootDirectory)\obj\</BaseIntermediateOutputPath>
     <BaseOutputPath>$(RootDirectory)\bin\</BaseOutputPath>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\$(AssemblyName)\</IntermediateOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\Microsoft.Languages.Editor.Application\</IntermediateOutputPath>
     <OutputPath>$(BaseOutputPath)\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/SetupRHost/SetupRHost.wixproj
+++ b/src/SetupRHost/SetupRHost.wixproj
@@ -18,21 +18,19 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  <PropertyGroup>
     <BaseIntermediateOutputPath>..\..\obj\</BaseIntermediateOutputPath>
     <BaseOutputPath>..\..\bin\</BaseOutputPath>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\Setup\</IntermediateOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\SetupRHost\</IntermediateOutputPath>
     <OutputPath>$(BaseOutputPath)\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>Debug;MsiVersion=$(BuildVersion);ProductVersion=$(MajorVersion).$(MinorVersion)</DefineConstants>
     <Chip>x86</Chip>
     <SuppressSpecificWarnings>1076</SuppressSpecificWarnings>
     <SuppressPdbOutput>True</SuppressPdbOutput>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <BaseIntermediateOutputPath>..\..\obj\</BaseIntermediateOutputPath>
-    <BaseOutputPath>..\..\bin\</BaseOutputPath>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\Setup\</IntermediateOutputPath>
-    <OutputPath>$(BaseOutputPath)\$(Configuration)\</OutputPath>
     <Chip>x86</Chip>
     <DefineConstants>LabBuild=1;MsiVersion=$(BuildVersion);ProductVersion=$(MajorVersion).$(MinorVersion)</DefineConstants>
     <SuppressSpecificWarnings>1076</SuppressSpecificWarnings>

--- a/src/build.proj
+++ b/src/build.proj
@@ -13,7 +13,7 @@
     <WixBinSdkDirectory Condition="'$(WixBinSdkDirectory)' == ''">$(WixBinDirectory)sdk\</WixBinSdkDirectory>
 
     <Configuration Condition=" '$(Configuration)'=='' ">Release</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">any cpu</Platform>
     <Year Condition="'$(Year)' == ''">$([System.DateTime]::Now.Year)</Year>
     <Date Condition="'$(Date)' == ''">$([System.DateTime]::Now.ToString("MMdd"))</Date>
     <Time Condition="'$(Time)' == ''">$([System.DateTime]::Now.ToString("HHmm"))</Time>
@@ -25,14 +25,19 @@
    
     <WixTargetsPath Condition="'$(WixTargetsPath)' == ''">$(WixBinDirectory)wix.targets</WixTargetsPath>
     <WixCATargetsPath Condition="'$(WixCATargetsPath)' == ''">$(WixBinSdkDirectory)wix.ca.targets</WixCATargetsPath>
-    <RHostMSI Condition="'$(RHostMSI)' == ''">RHost_$(Year)$(Date)$(Time).msi</RHostMSI>
+    <RHostMsi Condition="'$(RHostMsi)' == ''">RHost_$(Year)$(Date)$(Time).msi</RHostMsi>
+    <RtvsExe Condition="'$(RtvsExe)' == ''">RTVS_$(Year)$(Date)$(Time).exe</RtvsExe>
 
     <SolutionProperties Condition="'$(SolutionProperties)' == ''">Configuration=$(Configuration);Platform=$(Platform);GenerateAssemblyVersionInfo=true;Year=$(Year);Date=$(Date);Time=$(Time);SolutionDir=$(SourceDirectory);WIX=$(WixDirectory);WixToolPath=$(WixBinSdkDirectory);WixTargetsPath=$(WixTargetsPath);WixCATargetsPath=$(WixCATargetsPath)</SolutionProperties>
     <SetupProperties Condition="'$(SetupProperties)' == ''">Configuration=$(Configuration);Platform=x86;GenerateAssemblyVersionInfo=true;SuppressValidation=true;Year=$(Year);Date=$(Date);Time=$(Time);WIX=$(WixDirectory);WixInstallPath=$(WixBinDirectory);WixToolPath=$(WixBinDirectory);WixSdkPath=$(WixBinSdkDirectory);WixTargetsPath=$(WixTargetsPath);WixCATargetsPath=$(WixCATargetsPath)</SetupProperties>
   </PropertyGroup>
 
   <Target Name="RenameRHostMSI">
-    <Move SourceFiles="$(OutputDirectory)$(Configuration)\RHost.msi" DestinationFiles="$(OutputDirectory)$(Configuration)\$(RHostMSI)" />
+    <Move SourceFiles="$(OutputDirectory)$(Configuration)\RHost.msi" DestinationFiles="$(OutputDirectory)$(Configuration)\$(RHostMsi)" />
+  </Target>
+
+  <Target Name="RenameSetupBundle">
+    <Move SourceFiles="$(OutputDirectory)$(Configuration)\RTVS.exe" DestinationFiles="$(OutputDirectory)$(Configuration)\$(RtvsExe)" />
   </Target>
 
   <Target Name="Clean">
@@ -48,13 +53,11 @@
     <Message Text="SolutionProperties: $(SolutionProperties)" Importance="high" />
     <Message Text="SetupProperties: $(SetupProperties)" Importance="high" />
     <MSBuild Targets="Build" Projects="$(Solution)" Properties="$(SolutionProperties)" BuildInParallel="true" />
-    <RemoveDir Directories="$(RootDirectory)\obj" />
     <MSBuild Targets="Build" Projects="$(SetupRHost)" Properties="$(SetupProperties)" />
-    <RemoveDir Directories="$(RootDirectory)\obj" />
     <MSBuild Targets="Build" Projects="$(Setup)" Properties="$(SetupProperties)" />
     <CallTarget Targets="RenameRHostMSI" />
-    <RemoveDir Directories="$(RootDirectory)\obj" />
-    <MSBuild Targets="Rebuild" Projects="$(SetupBundle)" Properties="RHostMsi=$(RHostMsi);$(SetupProperties)" />
+    <MSBuild Targets="Build" Projects="$(SetupBundle)" Properties="RHostMsi=$(RHostMsi);$(SetupProperties)" />
+    <CallTarget Targets="RenameSetupBundle" />
   </Target>
 
   <Target Name="Rebuild">
@@ -65,5 +68,6 @@
     <MSBuild Targets="Rebuild" Projects="$(Setup)" Properties="$(SetupProperties)" />
     <CallTarget Targets="RenameRHostMSI" />
     <MSBuild Targets="Rebuild" Projects="$(SetupBundle)" Properties="RHostMsi=$(RHostMsi);$(SetupProperties)" />
+    <CallTarget Targets="RenameSetupBundle" />
   </Target>
 </Project>


### PR DESCRIPTION
- Fix *proj files so that every project uses its own intermediate folder
- Remove intermediate folder cleanup from build.proj
- Add RenameSetupBundle step to the build.proj
- Change default platform to "any cpu"
- Update submodule reference