### PR TITLE
Fix #943: Remote Hadoop data sources cause Variable Explorer and debugger to refresh very slowly

### DIFF
--- a/src/Debugger/Engine/Impl/AD7Expression.cs
+++ b/src/Debugger/Engine/Impl/AD7Expression.cs
@@ -34,7 +34,7 @@ namespace Microsoft.R.Debugger.Engine {
             _cts = new CancellationTokenSource();
             Task.Run(async () => {
                 try {
-                    var res = await StackFrame.StackFrame.EvaluateAsync(_expression, reprMaxLength: AD7Property.ReprMaxLength);
+                    var res = await StackFrame.StackFrame.EvaluateAsync(_expression, AD7Property.PrefetchedFields, AD7Property.ReprMaxLength);
                     _cts.Token.ThrowIfCancellationRequested();
                     var prop = new AD7Property(StackFrame, res);
                     StackFrame.Engine.Send(new AD7ExpressionEvaluationCompleteEvent(this, prop), AD7ExpressionEvaluationCompleteEvent.IID);
@@ -48,7 +48,7 @@ namespace Microsoft.R.Debugger.Engine {
         }
 
         int IDebugExpression2.EvaluateSync(enum_EVALFLAGS dwFlags, uint dwTimeout, IDebugEventCallback2 pExprCallback, out IDebugProperty2 ppResult) {
-            var res = TaskExtensions.RunSynchronouslyOnUIThread(ct => StackFrame.StackFrame.EvaluateAsync(_expression, reprMaxLength: AD7Property.ReprMaxLength, cancellationToken:ct));
+            var res = TaskExtensions.RunSynchronouslyOnUIThread(ct => StackFrame.StackFrame.EvaluateAsync(_expression, AD7Property.PrefetchedFields, AD7Property.ReprMaxLength, ct));
             ppResult = new AD7Property(StackFrame, res);
             return VSConstants.S_OK;
         }

--- a/src/Debugger/Engine/Impl/AD7Property.cs
+++ b/src/Debugger/Engine/Impl/AD7Property.cs
@@ -15,7 +15,7 @@ namespace Microsoft.R.Debugger.Engine {
         internal const int ChildrenMaxLength = 100;
         internal const int ReprMaxLength = 100;
 
-        private const DebugEvaluationResultFields _prefetchedFields =
+        internal const DebugEvaluationResultFields PrefetchedFields =
             DebugEvaluationResultFields.Expression |
             DebugEvaluationResultFields.Kind |
             DebugEvaluationResultFields.Repr |
@@ -56,7 +56,7 @@ namespace Microsoft.R.Debugger.Engine {
         }
 
         private IReadOnlyList<DebugEvaluationResult> CreateChildren() {
-            return TaskExtensions.RunSynchronouslyOnUIThread(ct => (EvaluationResult as DebugValueEvaluationResult)?.GetChildrenAsync(_prefetchedFields, ChildrenMaxLength, ReprMaxLength, ct))
+            return TaskExtensions.RunSynchronouslyOnUIThread(ct => (EvaluationResult as DebugValueEvaluationResult)?.GetChildrenAsync(PrefetchedFields, ChildrenMaxLength, ReprMaxLength, ct))
                 ?? new DebugEvaluationResult[0];
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.R.Debugger.Engine {
             var valueResult = EvaluationResult as DebugValueEvaluationResult;
             if (valueResult != null && valueResult.HasAttributes == true) {
                 string attrExpr = Invariant($"base::attributes({valueResult.Expression})");
-                var attrResult = TaskExtensions.RunSynchronouslyOnUIThread(ct => StackFrame.StackFrame.EvaluateAsync(attrExpr, "attributes()", reprMaxLength: ReprMaxLength, cancellationToken:ct));
+                var attrResult = TaskExtensions.RunSynchronouslyOnUIThread(ct => StackFrame.StackFrame.EvaluateAsync(attrExpr, "attributes()", PrefetchedFields, ReprMaxLength, ct));
                 if (!(attrResult is DebugErrorEvaluationResult)) {
                     var attrInfo = new AD7Property(this, attrResult, isSynthetic: true).GetDebugPropertyInfo(dwRadix, dwFields);
                     infos = new[] { attrInfo }.Concat(infos);

--- a/src/Debugger/Impl/DebugBreakpoint.cs
+++ b/src/Debugger/Impl/DebugBreakpoint.cs
@@ -81,7 +81,8 @@ namespace Microsoft.R.Debugger {
             if (--UseCount == 0) {
                 Session.RemoveBreakpoint(this);
 
-                var res = await Session.EvaluateAsync(Invariant($"rtvs:::remove_breakpoint({fileName.ToRStringLiteral()}, {Location.LineNumber})"), cancellationToken);
+                var code = Invariant($"rtvs:::remove_breakpoint({fileName.ToRStringLiteral()}, {Location.LineNumber})");
+                var res = await Session.EvaluateAsync(code, DebugEvaluationResultFields.None, cancellationToken);
                 if (res is DebugErrorEvaluationResult) {
                     throw new InvalidOperationException(Invariant($"{res.Expression}: {res}"));
                 }

--- a/src/Debugger/Impl/DebugEvaluationResult.cs
+++ b/src/Debugger/Impl/DebugEvaluationResult.cs
@@ -20,10 +20,9 @@ namespace Microsoft.R.Debugger {
         Expression = 1 << 1,
         Kind = 1 << 2,
         Repr = 1 << 3,
-        ReprDeparse = 1 << 4,
-        ReprToString = 1 << 5,
-        ReprStr = 1 << 6,
-        ReprAll = Repr | ReprDeparse | ReprStr | ReprToString,
+        ReprDeparse = Repr | (1 << 4),
+        ReprToString = Repr | (1 << 5),
+        ReprStr = Repr | (1 << 6),
         TypeName = 1 << 7,
         Classes = 1 << 8,
         Length = 1 << 9,
@@ -33,7 +32,6 @@ namespace Microsoft.R.Debugger {
         Dim = 1 << 13,
         EnvName = 1 << 14,
         Flags = 1 << 15,
-        All = ulong.MaxValue,
     }
 
     internal static class DebugEvaluationResultFieldsExtensions {
@@ -56,10 +54,6 @@ namespace Microsoft.R.Debugger {
         };
 
         public static string ToRVector(this DebugEvaluationResultFields fields) {
-            if (fields == DebugEvaluationResultFields.All) {
-                return null;
-            }
-
             var fieldNames = _mapping.Where(kv => fields.HasFlag(kv.Key)).Select(kv => "'" + kv.Value + "'");
             return Invariant($"base::c({string.Join(", ", fieldNames)})");
         }
@@ -102,11 +96,11 @@ namespace Microsoft.R.Debugger {
                 throw new InvalidOperationException(Invariant($"{nameof(SetValueAsync)} is not supported for this {nameof(DebugEvaluationResult)} because it doesn't have an associated {nameof(Expression)}."));
             }
 
-            return StackFrame.EvaluateAsync(Invariant($"{Expression} <- {value}"), reprMaxLength: 0, cancellationToken: cancellationToken);
+            return StackFrame.EvaluateAsync(Invariant($"{Expression} <- {value}"), DebugEvaluationResultFields.None, reprMaxLength: 0, cancellationToken: cancellationToken);
         }
 
         public Task<DebugEvaluationResult> EvaluateAsync(
-            DebugEvaluationResultFields fields = DebugEvaluationResultFields.All,
+            DebugEvaluationResultFields fields,
             int? reprMaxLength = null,
             CancellationToken cancellationToken = default(CancellationToken)
         ) {
@@ -247,7 +241,7 @@ namespace Microsoft.R.Debugger {
         }
 
         public async Task<IReadOnlyList<DebugEvaluationResult>> GetChildrenAsync(
-            DebugEvaluationResultFields fields = DebugEvaluationResultFields.All,
+            DebugEvaluationResultFields fields,
             int? maxLength = null,
             int? reprMaxLength = null,
             CancellationToken cancellationToken = default(CancellationToken)

--- a/src/Debugger/Impl/DebugSession.cs
+++ b/src/Debugger/Impl/DebugSession.cs
@@ -165,17 +165,29 @@ namespace Microsoft.R.Debugger {
 
             return token;
         }
+        public Task<DebugEvaluationResult> EvaluateAsync(
+            string expression,
+            DebugEvaluationResultFields fields,
+            CancellationToken cancellationToken = default(CancellationToken)
+        ) {
+            return EvaluateAsync(null, expression, null, null, fields, null, cancellationToken);
+        }
 
-        public Task<DebugEvaluationResult> EvaluateAsync(string expression, CancellationToken cancellationToken = default(CancellationToken)) {
-            return EvaluateAsync(null, expression, cancellationToken: cancellationToken);
+        public Task<DebugEvaluationResult> EvaluateAsync(
+            string expression,
+            DebugEvaluationResultFields fields,
+            int? reprMaxLength,
+            CancellationToken cancellationToken = default(CancellationToken)
+        ) {
+            return EvaluateAsync(null, expression, null, null, fields, reprMaxLength, cancellationToken);
         }
 
         public async Task<DebugEvaluationResult> EvaluateAsync(
             DebugStackFrame stackFrame,
             string expression,
-            string name = null,
-            string env = null,
-            DebugEvaluationResultFields fields = DebugEvaluationResultFields.All,
+            string name,
+            string env,
+            DebugEvaluationResultFields fields,
             int? reprMaxLength = null,
             CancellationToken cancellationToken = default(CancellationToken)
         ) {

--- a/src/Debugger/Impl/DebugStackFrame.cs
+++ b/src/Debugger/Impl/DebugStackFrame.cs
@@ -64,12 +64,21 @@ namespace Microsoft.R.Debugger {
 
         public Task<DebugEvaluationResult> EvaluateAsync(
             string expression,
-            string name = null,
-            DebugEvaluationResultFields fields = DebugEvaluationResultFields.All,
+            string name,
+            DebugEvaluationResultFields fields,
             int? reprMaxLength = null,
             CancellationToken cancellationToken = default(CancellationToken)
         ) {
             return Session.EvaluateAsync(this, expression, name, null, fields, reprMaxLength, cancellationToken);
+        }
+
+        public Task<DebugEvaluationResult> EvaluateAsync(
+            string expression,
+            DebugEvaluationResultFields fields,
+            int? reprMaxLength = null,
+            CancellationToken cancellationToken = default(CancellationToken)
+        ) {
+            return EvaluateAsync(expression, null, fields, reprMaxLength, cancellationToken);
         }
 
         public Task<DebugEvaluationResult> GetEnvironmentAsync(

--- a/src/Debugger/Test/BreakpointsTest.cs
+++ b/src/Debugger/Test/BreakpointsTest.cs
@@ -188,7 +188,7 @@ namespace Microsoft.R.Debugger.Test {
 
                 await sf.Source(_session);
 
-                var res = (await debugSession.EvaluateAsync("is.function(f)")).As<DebugValueEvaluationResult>();
+                var res = (await debugSession.EvaluateAsync("is.function(f)", DebugEvaluationResultFields.ReprDeparse)).As<DebugValueEvaluationResult>();
                 res.GetRepresentation().Deparse
                     .Should().Be("TRUE");
             }

--- a/src/Debugger/Test/ValuesTest.cs
+++ b/src/Debugger/Test/ValuesTest.cs
@@ -66,7 +66,7 @@ eval(substitute(f(P, x), list(P = x)))
                 stackFrames.Should().NotBeEmpty();
 
                 var frame = (await stackFrames.Last().GetEnvironmentAsync()).As<DebugValueEvaluationResult>();
-                var children = (await frame.GetChildrenAsync()).ToDictionary(er => er.Name);
+                var children = (await frame.GetChildrenAsync(DebugEvaluationResultFields.ReprDeparse)).ToDictionary(er => er.Name);
 
                 var p = children.Should().ContainKey("p").WhichValue.As<DebugPromiseEvaluationResult>();
                 var d = children.Should().ContainKey("d").WhichValue.As<DebugValueEvaluationResult>();
@@ -115,7 +115,8 @@ eval(substitute(f(P, x), list(P = x)))
         [InlineData(@"sQuote(dQuote('x'))", @"""‘“x”’""", @"""‘“x”’""", "‘“x”’")]
         public async Task Representation(string expr, string deparse, string str, string toString) {
             using (var debugSession = new DebugSession(_session)) {
-                var res = (await debugSession.EvaluateAsync(expr)).Should().BeAssignableTo<DebugValueEvaluationResult>().Which;
+                var res = (await debugSession.EvaluateAsync(expr, DebugEvaluationResultFields.ReprDeparse | DebugEvaluationResultFields.ReprStr | DebugEvaluationResultFields.ReprToString))
+                    .Should().BeAssignableTo<DebugValueEvaluationResult>().Which;
                 var repr = res.GetRepresentation();
 
                 repr.Deparse.Should().Be(deparse);

--- a/src/Package/Impl/DataInspect/EvaluationWrapper.cs
+++ b/src/Package/Impl/DataInspect/EvaluationWrapper.cs
@@ -81,10 +81,17 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             if (valueEvaluation.HasChildren) {
                 await TaskUtilities.SwitchToBackgroundThread();
 
-                var fields = (DebugEvaluationResultFields.All & ~DebugEvaluationResultFields.ReprAll) |
-                        DebugEvaluationResultFields.Repr | DebugEvaluationResultFields.ReprStr;
-
-                // assumption: DebugEvaluationResult returns children in ascending order
+                const DebugEvaluationResultFields fields =
+                    DebugEvaluationResultFields.Expression |
+                    DebugEvaluationResultFields.Kind |
+                    DebugEvaluationResultFields.ReprStr |
+                    DebugEvaluationResultFields.TypeName |
+                    DebugEvaluationResultFields.Classes |
+                    DebugEvaluationResultFields.Length |
+                    DebugEvaluationResultFields.SlotCount |
+                    DebugEvaluationResultFields.AttrCount |
+                    DebugEvaluationResultFields.Dim |
+                    DebugEvaluationResultFields.Flags;
                 IReadOnlyList<DebugEvaluationResult> children = await valueEvaluation.GetChildrenAsync(fields, MaxChildrenCount, 100);
 
                 result = new List<IRSessionDataObject>();

--- a/src/R/Editor/Impl/Data/RSessionDataObject.cs
+++ b/src/R/Editor/Impl/Data/RSessionDataObject.cs
@@ -104,10 +104,17 @@ namespace Microsoft.R.Editor.Data {
             if (valueEvaluation.HasChildren) {
                 await TaskUtilities.SwitchToBackgroundThread();
 
-                var fields = (DebugEvaluationResultFields.All & ~DebugEvaluationResultFields.ReprAll) |
-                        DebugEvaluationResultFields.Repr | DebugEvaluationResultFields.ReprStr;
-
-                // assumption: DebugEvaluationResult returns children in ascending order
+                const DebugEvaluationResultFields fields =
+                    DebugEvaluationResultFields.Expression |
+                    DebugEvaluationResultFields.Kind |
+                    DebugEvaluationResultFields.ReprStr |
+                    DebugEvaluationResultFields.TypeName |
+                    DebugEvaluationResultFields.Classes |
+                    DebugEvaluationResultFields.Length |
+                    DebugEvaluationResultFields.SlotCount |
+                    DebugEvaluationResultFields.AttrCount |
+                    DebugEvaluationResultFields.Dim |
+                    DebugEvaluationResultFields.Flags;
                 IReadOnlyList<DebugEvaluationResult> children = await valueEvaluation.GetChildrenAsync(fields, MaxChildrenCount, MaxReprLength);
                 result = EvaluateChildren(children);
             }

--- a/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
+++ b/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
@@ -139,7 +139,18 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
                             var globalStackFrame = stackFrames.FirstOrDefault(s => s.IsGlobal);
                             if (globalStackFrame != null) {
-                                DebugEvaluationResult evaluation = await globalStackFrame.EvaluateAsync("base::environment()", "Global Environment");
+                                const DebugEvaluationResultFields fields =
+                                    DebugEvaluationResultFields.Expression |
+                                    DebugEvaluationResultFields.Kind |
+                                    DebugEvaluationResultFields.ReprStr |
+                                    DebugEvaluationResultFields.TypeName |
+                                    DebugEvaluationResultFields.Classes |
+                                    DebugEvaluationResultFields.Length |
+                                    DebugEvaluationResultFields.SlotCount |
+                                    DebugEvaluationResultFields.AttrCount |
+                                    DebugEvaluationResultFields.Dim |
+                                    DebugEvaluationResultFields.Flags;
+                                DebugEvaluationResult evaluation = await globalStackFrame.EvaluateAsync("base::environment()", "Global Environment", fields);
                                 var e = new RSessionDataObject(evaluation);  // root level doesn't truncate children and return every variables
 
                                 _topLevelVariables.Clear();


### PR DESCRIPTION
Remove `DebugEvaluationResultFields.All`, requiring callers to always explicitly specify the fields that they need.

(Computing `DebugEvaluationResult.NameCount` was triggering this behavior, but it wasn't actually used anywhere.)