### PR TITLE
Fix #1205: Stop attaching logs to send a frown email

### DIFF
--- a/src/Package/Impl/Feedback/SendFrownCommand.cs
+++ b/src/Package/Impl/Feedback/SendFrownCommand.cs
@@ -1,18 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.IO;
 using Microsoft.VisualStudio.R.Package.Commands;
 using Microsoft.VisualStudio.R.Package.Logging;
 using Microsoft.VisualStudio.R.Packages.R;
 
 namespace Microsoft.VisualStudio.R.Package.Feedback {
     internal sealed class SendFrownCommand : SendMailCommand {
-        //TODO: localize
-        private const string _disclaimer =
-"Please briefly describe what you were doing that led to the issue if applicable.\r\n\r\n" +
-"Note that the data contained in the attached logs includes " +
-"your command history as well as all output displayed in the R Interactive Window.";
-
         public SendFrownCommand() :
             base(RGuidList.RCmdSetGuid, RPackageCommandId.icmdSendFrown) {
         }
@@ -23,7 +18,11 @@ namespace Microsoft.VisualStudio.R.Package.Feedback {
 
         protected override void Handle() {
             string zipPath = DiagnosticLogs.Collect();
-            SendMail(_disclaimer, "RTVS Frown", zipPath);
+
+            var generalData = new StringWriter();
+            DiagnosticLogs.WriteGeneralData(generalData, detailed: false);
+
+            SendMail(string.Format(Resources.SendFrownEmailBody, zipPath, generalData.ToString(), zipPath), "RTVS Frown", zipPath);
         }
     }
 }

--- a/src/Package/Impl/Feedback/SendFrownCommand.cs
+++ b/src/Package/Impl/Feedback/SendFrownCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.R.Package.Feedback {
             var generalData = new StringWriter();
             DiagnosticLogs.WriteGeneralData(generalData, detailed: false);
 
-            SendMail(string.Format(Resources.SendFrownEmailBody, zipPath, generalData.ToString(), zipPath), "RTVS Frown", zipPath);
+            SendMail(string.Format(Resources.SendFrownEmailBody, zipPath, generalData.ToString()), "RTVS Frown", zipPath);
         }
     }
 }

--- a/src/Package/Impl/Feedback/SendMailCommand.cs
+++ b/src/Package/Impl/Feedback/SendMailCommand.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.R.Package.Feedback {
 
             Application outlookApp = null;
             try {
-                //outlookApp = new Application();
+                outlookApp = new Application();
             } catch (System.Exception ex) {
                 GeneralLog.Write("Unable to start Outlook (exception data follows)");
                 GeneralLog.Write(ex);

--- a/src/Package/Impl/Feedback/SendMailCommand.cs
+++ b/src/Package/Impl/Feedback/SendMailCommand.cs
@@ -47,8 +47,6 @@ namespace Microsoft.VisualStudio.R.Package.Feedback {
                     fallbackWindow.Show();
                 });
 
-                //VsAppShell.Current.ShowMessage(Resources.SendMailFallbackMessage + "\r\n\r\n" + body, MessageButtons.OK);
-
                 ProcessStartInfo psi = new ProcessStartInfo();
                 psi.UseShellExecute = true;
                 psi.FileName = string.Format(

--- a/src/Package/Impl/Feedback/SendMailCommand.cs
+++ b/src/Package/Impl/Feedback/SendMailCommand.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using Microsoft.Common.Core.Shell;
 using Microsoft.Office.Interop.Outlook;
 using Microsoft.R.Actions.Logging;
 using Microsoft.VisualStudio.R.Package.Commands;
@@ -40,12 +39,13 @@ namespace Microsoft.VisualStudio.R.Package.Feedback {
             }
 
             if (outlookApp == null) {
-                VsAppShell.Current.DispatchOnUIThread(() => {
+                VsAppShell.Current.DispatchOnMainThreadAsync(() => {
                     var fallbackWindow = new SendMailFallbackWindow {
                         MessageBody = body
                     };
                     fallbackWindow.Show();
-                });
+                    fallbackWindow.Activate();
+                }).Wait();
 
                 ProcessStartInfo psi = new ProcessStartInfo();
                 psi.UseShellExecute = true;

--- a/src/Package/Impl/Feedback/SendMailFallbackWindow.xaml
+++ b/src/Package/Impl/Feedback/SendMailFallbackWindow.xaml
@@ -17,7 +17,10 @@
             with the following information:
         </TextBlock>
         <DockPanel DockPanel.Dock="Bottom" LastChildFill="False" Margin="10,5,10,10">
-            <Button Name="copyToClipboardButton" DockPanel.Dock="Right" Padding="5" Click="copyToClipboardButton_Click">Copy to Clipboard</Button>
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                <Button Name="copyToClipboardButton" Padding="7,3" Margin="0,5,4,5" Click="copyToClipboardButton_Click">Copy to Clipboard</Button>
+                <Button Name="closeButton" Padding="7,3" Margin="4,5,0,5" Click="closeButton_Click">Close</Button>
+            </StackPanel>
         </DockPanel>
         <TextBox Name="messageBodyTextBox"
                  IsReadOnly="True"

--- a/src/Package/Impl/Feedback/SendMailFallbackWindow.xaml
+++ b/src/Package/Impl/Feedback/SendMailFallbackWindow.xaml
@@ -1,0 +1,29 @@
+﻿<!--
+    Copyright (c) Microsoft Corporation. All rights reserved.
+    Licensed under the MIT License. See LICENSE in the project root for license information.
+-->
+<Window x:Class="Microsoft.VisualStudio.R.Package.Feedback.SendMailFallbackWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Microsoft.VisualStudio.R.Package.Feedback"
+        mc:Ignorable="d"
+        Title="Send RTVS Feedback" Height="400" Width="600" WindowStartupLocation="CenterOwner">
+    <DockPanel LastChildFill="True">
+        <TextBlock x:Uid="Header" DockPanel.Dock="Top" Margin="10,10,10,5" TextWrapping="Wrap">
+            We will now try to open your email client with a pre-created feedback email. If the email client does not open in a few seconds,
+            please manually send an email message to <Hyperlink NavigateUri="mailto:rtvsuserfeedback@microsoft.com">rtvsuserfeedback@microsoft.com</Hyperlink>
+            with the following information:
+        </TextBlock>
+        <DockPanel DockPanel.Dock="Bottom" LastChildFill="False" Margin="10,5,10,10">
+            <Button Name="copyToClipboardButton" DockPanel.Dock="Right" Padding="5" Click="copyToClipboardButton_Click">Copy to Clipboard</Button>
+        </DockPanel>
+        <TextBox Name="messageBodyTextBox"
+                 IsReadOnly="True"
+                 Margin="10,5,10,5"
+                 HorizontalScrollBarVisibility="Auto"
+                 VerticalScrollBarVisibility="Auto"
+                 TextWrapping="Wrap"/>
+    </DockPanel>
+</Window>

--- a/src/Package/Impl/Feedback/SendMailFallbackWindow.xaml.cs
+++ b/src/Package/Impl/Feedback/SendMailFallbackWindow.xaml.cs
@@ -20,5 +20,9 @@ namespace Microsoft.VisualStudio.R.Package.Feedback {
         private void copyToClipboardButton_Click(object sender, RoutedEventArgs e) {
             Clipboard.SetText(MessageBody);
         }
+
+        private void closeButton_Click(object sender, RoutedEventArgs e) {
+            Close();
+        }
     }
 }

--- a/src/Package/Impl/Feedback/SendMailFallbackWindow.xaml.cs
+++ b/src/Package/Impl/Feedback/SendMailFallbackWindow.xaml.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Windows;
+
+namespace Microsoft.VisualStudio.R.Package.Feedback {
+    /// <summary>
+    /// Interaction logic for SendMailFallbackWindow.xaml
+    /// </summary>
+    public partial class SendMailFallbackWindow : Window {
+        public SendMailFallbackWindow() {
+            InitializeComponent();
+        }
+
+        public string MessageBody {
+            get { return messageBodyTextBox.Text; }
+            set { messageBodyTextBox.Text = value; }
+        }
+
+        private void copyToClipboardButton_Click(object sender, RoutedEventArgs e) {
+            Clipboard.SetText(MessageBody);
+        }
+    }
+}

--- a/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
+++ b/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
@@ -94,6 +94,9 @@
     <Compile Include="Documentation\DocumentationUrls.cs" />
     <Compile Include="Documentation\OpenDocumentationCommand.cs" />
     <Compile Include="Expansions\SnippetInformationSourceProvider.cs" />
+    <Compile Include="Feedback\SendMailFallbackWindow.xaml.cs">
+      <DependentUpon>SendMailFallbackWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Help\HelpWindowVisualComponent.cs" />
     <Compile Include="Help\IHelpWindowVisualComponent.cs" />
     <Compile Include="History\Commands\DeleteAllHistoryEntriesCommand.cs" />
@@ -1232,6 +1235,10 @@
     <Page Include="DataInspect\VisualGrid\MatrixView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Feedback\SendMailFallbackWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Plots\XamlPresenter.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/src/Package/Impl/Resources.Designer.cs
+++ b/src/Package/Impl/Resources.Designer.cs
@@ -503,15 +503,6 @@ namespace Microsoft.VisualStudio.R.Package {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If e-mail client does not open, please create an e-mail message to rtvsuserfeedback@microsoft.com and attach RTVSLogs.zip file that can be found in {0}. Briefly describe what you were doing that led to the issue if applicable.{1}Please be aware that the data contained in the attached logs contain your command history as well as all output displayed in the R Interactive Window..
-        /// </summary>
-        public static string MailToFrownMessage {
-            get {
-                return ResourceManager.GetString("MailToFrownMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Starting R Session....
         /// </summary>
         public static string MicrosoftRHostStarting {
@@ -813,6 +804,28 @@ namespace Microsoft.VisualStudio.R.Package {
         public static string SaveWorkspaceOnProjectUnload {
             get {
                 return ResourceManager.GetString("SaveWorkspaceOnProjectUnload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please briefly describe what you were doing that led to the issue, if applicable:
+        ///
+        ///...
+        ///
+        ///A detailed diagnostic log has been created at {0}, and a Windows Explorer window has been opened for that location with the log file selected. To improve our ability to diagnose the issue, you can attach that file to the email. However, be aware that the log may contain sensitive information, including information about installed packages and their contents, your complete R Interactive command history and outputs, an [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string SendFrownEmailBody {
+            get {
+                return ResourceManager.GetString("SendFrownEmailBody", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to We will now try to open your email client with a pre-created feedback email. If the email client does not open, please send an email message to rtvsuserfeedback@microsoft.com with the following information:.
+        /// </summary>
+        public static string SendMailFallbackMessage {
+            get {
+                return ResourceManager.GetString("SendMailFallbackMessage", resourceCulture);
             }
         }
         

--- a/src/Package/Impl/Resources.resx
+++ b/src/Package/Impl/Resources.resx
@@ -582,8 +582,8 @@ Supported formats are: jpg/jpeg, png, tif/tiff, bmp.</value>
   <data name="Settings_TriggerOnTab_Description" xml:space="preserve">
     <value>If set to on completion list can be invoked by typing one or more characters and pressing Tab.</value>
   </data>
-  <data name="MailToFrownMessage" xml:space="preserve">
-    <value>If e-mail client does not open, please create an e-mail message to rtvsuserfeedback@microsoft.com and attach RTVSLogs.zip file that can be found in {0}. Briefly describe what you were doing that led to the issue if applicable.{1}Please be aware that the data contained in the attached logs contain your command history as well as all output displayed in the R Interactive Window.</value>
+  <data name="SendMailFallbackMessage" xml:space="preserve">
+    <value>We will now try to open your email client with a pre-created feedback email. If the email client does not open, please send an email message to rtvsuserfeedback@microsoft.com with the following information:</value>
   </data>
   <data name="Error_ExcelCannotEvaluateExpression" xml:space="preserve">
     <value>Unable to evaluate expression and get data for Microsoft Excel</value>
@@ -605,5 +605,18 @@ Supported formats are: jpg/jpeg, png, tif/tiff, bmp.</value>
   </data>
   <data name="Warning_UncPath" xml:space="preserve">
     <value>The project appears to be on a network share. R Tools for Visual Studio may not work correctly when files are on a remote share. </value>
+  </data>
+  <data name="SendFrownEmailBody" xml:space="preserve">
+    <value>Please briefly describe what you were doing that led to the issue, if applicable:
+
+...
+
+A detailed diagnostic log has been created at {0}, and a Windows Explorer window has been opened for that location with the log file selected. To improve our ability to diagnose the issue, you can attach that file to the email. However, be aware that the log may contain sensitive information, including information about installed packages and their contents, your complete R Interactive command history and outputs, and values of variables in your present and past sessions.
+
+
+
+Additional information:
+
+{1}</value>
   </data>
 </root>


### PR DESCRIPTION
Always pop up Explorer with the log file selected, even when using Outlook.

Stop automatically attaching logs to email even when using Outlook, and change the text to give directions on how to do so manually.

Add basic diagnostic info (VS, RTVS and R versions) directly into the precomposed email body, so that it is present even if logs are not attached.

Use a custom non-modal window instead of the stock message box as a mailto: fallback, so that the entire body of the message is included there, and can be easily copy/pasted, in case mailto: handler didn't work for any reason.