### PR TITLE
Unittest visual tree tests only when control is not collapsed

### DIFF
--- a/src/Package/Test/DataInspect/EvaluationWrapperTest.cs
+++ b/src/Package/Test/DataInspect/EvaluationWrapperTest.cs
@@ -350,7 +350,7 @@ namespace Microsoft.VisualStudio.R.Package.Test.DataInspect {
             }
         }
 
-        [Test(Skip = "https://github.com/Microsoft/RTVS/issues/1284")]
+        [Test]
         [Category.Variable.Explorer]
         public async Task MatrixLargeCellTest() {
             var script = "matrix.largecell <- matrix(list(as.double(1:5000), 2, 3, 4), nrow = 2, ncol = 2);";

--- a/src/Package/TestApp/Data/VariableExplorerTest.cs
+++ b/src/Package/TestApp/Data/VariableExplorerTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Data {
             }
         }
 
-        [Test(Skip = "https://github.com/Microsoft/RTVS/issues/1283")]
+        [Test]
         [Category.Interactive]
         public void VariableExplorer_SimpleDataTest() {
             VisualTreeObject actual = null;

--- a/src/Package/TestApp/Utility/ViewTreeDump.cs
+++ b/src/Package/TestApp/Utility/ViewTreeDump.cs
@@ -17,8 +17,7 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Utility {
         private static bool _regenerateBaselineFiles = false;
 
         public static void CompareVisualTrees(DeployFilesFixture fixture, VisualTreeObject actual, string fileName) {
-            Action a = () => CompareVisualTreesImplementation(fixture, actual, fileName);
-            a.ShouldNotThrow();
+            CompareVisualTreesImplementation(fixture, actual, fileName);
         }
 
         private static void CompareVisualTreesImplementation(DeployFilesFixture fixture, VisualTreeObject actual, string fileName) {
@@ -36,27 +35,36 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Utility {
         }
 
         private static void CompareVisualTree(VisualTreeObject actual, VisualTreeObject expected, bool compareProperty = true) {
+            bool visible = true;
+            
             // compare
-            actual.Name.ShouldBeEquivalentTo(expected.Name);
+            actual.Name.Should().BeEquivalentTo(expected.Name);
 
-            if (compareProperty) {
+            var visibility = actual.Properties.FirstOrDefault(p => p.Name == "Visibility");
+            if (visibility != null) {
+                visible = (visibility.Value != "Collapsed");
+            }
+
+            if (compareProperty && visible) {
                 var filteredActual = actual.Properties.Where(p => SupportedWpfProperties.IsSupported(p.Name));
                 var filteredExpected = expected.Properties.Where(p => SupportedWpfProperties.IsSupported(p.Name));
 
                 var onlyInActual = filteredActual.Except(filteredExpected);
                 var onlyInExpected = filteredExpected.Except(filteredActual);
 
-                onlyInActual.Count().ShouldBeEquivalentTo(0);
-                onlyInExpected.Count().ShouldBeEquivalentTo(0);
+                onlyInActual.Count().Should().Be(0);
+                onlyInExpected.Count().Should().Be(0);
             }
 
             actual.Children.Count.ShouldBeEquivalentTo(expected.Children.Count);
 
-            var sortedActualChildren = actual.Children.OrderBy(c => c.Name);
-            var sortedExpectedChildren = expected.Children.OrderBy(c => c.Name);
+            if (visible) {
+                var sortedActualChildren = actual.Children.OrderBy(c => c.Name);
+                var sortedExpectedChildren = expected.Children.OrderBy(c => c.Name);
 
-            for (int i = 0; i < actual.Children.Count; i++) {
-                CompareVisualTree(sortedActualChildren.ElementAt(i), sortedExpectedChildren.ElementAt(i), compareProperty);
+                for (int i = 0; i < actual.Children.Count; i++) {
+                    CompareVisualTree(sortedActualChildren.ElementAt(i), sortedExpectedChildren.ElementAt(i), compareProperty);
+                }
             }
         }
 

--- a/src/Package/TestApp/Utility/ViewTreeDump.cs
+++ b/src/Package/TestApp/Utility/ViewTreeDump.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Utility {
             bool visible = true;
             
             // compare
-            actual.Name.Should().BeEquivalentTo(expected.Name);
+            actual.Name.Should().Be(expected.Name);
 
             var visibility = actual.Properties.FirstOrDefault(p => p.Name == "Visibility");
             if (visibility != null) {
@@ -49,21 +49,19 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Utility {
                 var filteredActual = actual.Properties.Where(p => SupportedWpfProperties.IsSupported(p.Name));
                 var filteredExpected = expected.Properties.Where(p => SupportedWpfProperties.IsSupported(p.Name));
 
-                var onlyInActual = filteredActual.Except(filteredExpected);
-                var onlyInExpected = filteredExpected.Except(filteredActual);
-
-                onlyInActual.Count().Should().Be(0);
-                onlyInExpected.Count().Should().Be(0);
+                filteredActual.Should().BeEquivalentTo(filteredExpected);
             }
 
             actual.Children.Count.ShouldBeEquivalentTo(expected.Children.Count);
 
             if (visible) {
-                var sortedActualChildren = actual.Children.OrderBy(c => c.Name);
-                var sortedExpectedChildren = expected.Children.OrderBy(c => c.Name);
+                var sortedActualChildren = actual.Children.OrderBy(c => c.Name).ToList();
+                var sortedExpectedChildren = expected.Children.OrderBy(c => c.Name).ToList();
+
+                sortedActualChildren.Count.Should().Be(sortedExpectedChildren.Count);
 
                 for (int i = 0; i < actual.Children.Count; i++) {
-                    CompareVisualTree(sortedActualChildren.ElementAt(i), sortedExpectedChildren.ElementAt(i), compareProperty);
+                    CompareVisualTree(sortedActualChildren[i], sortedExpectedChildren[i], compareProperty);
                 }
             }
         }

--- a/src/Package/TestApp/Utility/VisualTreeObject.cs
+++ b/src/Package/TestApp/Utility/VisualTreeObject.cs
@@ -3,8 +3,10 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Windows;
 using System.Windows.Media;
+using Microsoft.Common.Core.Test.Utility;
 using Microsoft.UnitTests.Core.Threading;
 
 namespace Microsoft.VisualStudio.R.Interactive.Test.Utility {
@@ -28,7 +30,7 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Utility {
                 visualTreeObj = new VisualTreeObject();
 
                 visualTreeObj.Name = o.GetType().Name;
-                visualTreeObj.Properties = VisualTreeProperty.GetProperties(o);
+                visualTreeObj.Properties = VisualTreeProperty.GetProperties(o).Where(p => SupportedWpfProperties.IsSupported(p.Name)).ToList();
                 visualTreeObj.Children = GetChildren(o);
             });
 


### PR DESCRIPTION
- Visual tree dump saves after filter
- Compare properties only when not collapsed