### PR TITLE
Fix #541, #1191, 547

### DIFF
--- a/src/Debugger/Impl/DebugBreakpoint.cs
+++ b/src/Debugger/Impl/DebugBreakpoint.cs
@@ -62,13 +62,13 @@ namespace Microsoft.R.Debugger {
 
         internal async Task ReapplyBreakpointAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             TaskUtilities.AssertIsOnBackgroundThread();
-            await Session.RSession.EvaluateAsync(GetAddBreakpointExpression(false), REvaluationKind.Normal, cancellationToken);
+            await Session.RSession.EvaluateAsync(GetAddBreakpointExpression(false), true, REvaluationKind.Normal, cancellationToken);
             // TODO: mark breakpoint as invalid if this fails.
         }
 
         internal async Task SetBreakpointAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             TaskUtilities.AssertIsOnBackgroundThread();
-            await Session.RSession.EvaluateAsync(GetAddBreakpointExpression(true), REvaluationKind.Normal, cancellationToken);
+            await Session.RSession.EvaluateAsync(GetAddBreakpointExpression(true), true, REvaluationKind.Normal, cancellationToken);
             ++UseCount;
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.R.Debugger {
                 Session.RemoveBreakpoint(this);
 
                 var code = Invariant($"rtvs:::remove_breakpoint({fileName.ToRStringLiteral()}, {Location.LineNumber})");
-                var res = await Session.RSession.EvaluateAsync(code, REvaluationKind.Normal, cancellationToken);
+                var res = await Session.RSession.EvaluateAsync(code, true, REvaluationKind.Normal, cancellationToken);
                 if (res.ParseStatus != RParseStatus.OK || res.Error != null) {
                     throw new InvalidOperationException(res.ToString());
                 }

--- a/src/Debugger/Impl/DebugSession.cs
+++ b/src/Debugger/Impl/DebugSession.cs
@@ -207,7 +207,7 @@ namespace Microsoft.R.Debugger {
 
             // Evaluation will not end until after Browse> is responded to, but this method must indicate completion
             // as soon as the prompt appears. So don't wait for this, but wait for the prompt instead.
-            RSession.EvaluateAsync("browser()", REvaluationKind.Reentrant, ct)
+            RSession.EvaluateAsync("browser()", false, REvaluationKind.Reentrant, ct)
                 .SilenceException<MessageTransportException>().DoNotWait();
 
             // Wait until prompt appears, but don't actually respond to it.

--- a/src/Debugger/Test/BreakpointsTest.cs
+++ b/src/Debugger/Test/BreakpointsTest.cs
@@ -340,7 +340,7 @@ namespace Microsoft.R.Debugger.Test {
                 await Task.Delay(100);
 
                 await bp.DeleteAsync();
-                await _session.EvaluateAsync("b <- TRUE");
+                await _session.EvaluateAsync("b <- TRUE", true);
 
                 await debugSession.NextPromptShouldBeBrowseAsync();
                 (await debugSession.GetStackFramesAsync()).Should().HaveTail(new MatchDebugStackFrames {

--- a/src/Debugger/Test/DebugSessionExtensions.cs
+++ b/src/Debugger/Test/DebugSessionExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.R.Debugger.Test {
             EventHandler<DebugBrowseEventArgs> handler = null;
             handler = (sender, e) => {
                 session.Browse -= handler;
-                browseTcs.SetResult(true);
+                browseTcs.TrySetResult(true);
             };
             session.Browse += handler;
 

--- a/src/Debugger/Test/DebugSessionExtensions.cs
+++ b/src/Debugger/Test/DebugSessionExtensions.cs
@@ -19,13 +19,7 @@ namespace Microsoft.R.Debugger.Test {
             // Now wait until session tells us that it has noticed the prompt and processed it.
             // Note that even if we register the handler after it has already noticed, but
             // before the interaction completed, it will still invoke the handler.
-            var browseTcs = new TaskCompletionSource<bool>();
-            EventHandler<DebugBrowseEventArgs> handler = null;
-            handler = (sender, e) => {
-                session.Browse -= handler;
-                browseTcs.TrySetResult(true);
-            };
-            session.Browse += handler;
+            var browseTask = EventTaskSources.DebugSession.Browse.Create(session);
 
             // Spin until either Browse is raised, or we see a different non-Browse prompt.
             // If the latter happens, we're not going to see Browse raised for that prompt that we've
@@ -34,9 +28,9 @@ namespace Microsoft.R.Debugger.Test {
             // the state is indeterminate.
             while (true) {
                 var interTask = session.RSession.BeginInteractionAsync();
-                var completedTask = await Task.WhenAny(browseTcs.Task, interTask);
+                var completedTask = await Task.WhenAny(browseTask, interTask);
 
-                if (completedTask == browseTcs.Task) {
+                if (completedTask == browseTask) {
                     interTask.ContinueWith(t => t.Result.Dispose(), TaskContinuationOptions.OnlyOnRanToCompletion).DoNotWait();
                     return;
                 }

--- a/src/Debugger/Test/Match.cs
+++ b/src/Debugger/Test/Match.cs
@@ -47,6 +47,27 @@ namespace Microsoft.R.Debugger.Test {
         }
     }
 
+    internal class MatchRange<T> : IEquatable<T> where T : IComparable<T> {
+        private readonly T _from, _to;
+
+        public MatchRange(T from, T to) {
+            _from = from;
+            _to = to;
+        }
+
+        public bool Equals(T other) =>
+            other == null ? false : other.CompareTo(_from) >= 0 && other.CompareTo(_to) <= 0;
+
+        public override bool Equals(object other) =>
+            other is T ? Equals((T)other) : false;
+
+        public override int GetHashCode() =>
+            new { _from, _to }.GetHashCode();
+
+        public override string ToString() =>
+            Invariant($"[{_from} .. {_to}]");
+    }
+
     internal class MatchDebugStackFrame : IEquatable<DebugStackFrame> {
         public IEquatable<string> FileName { get; }
         public IEquatable<int> LineNumber { get; }

--- a/src/Debugger/Test/SteppingTest.cs
+++ b/src/Debugger/Test/SteppingTest.cs
@@ -74,7 +74,6 @@ namespace Microsoft.R.Debugger.Test {
                     { sf, 6 }
                 });
             }
-
         }
 
         [Test]

--- a/src/Debugger/Test/SteppingTest.cs
+++ b/src/Debugger/Test/SteppingTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.R.Debugger.Test {
                     { sf, new MatchRange<int>(1, 3) }
                 });
 
-                await _session.EvaluateAsync("x <- -42", REvaluationKind.Normal);
+                await _session.EvaluateAsync("x <- -42", true, REvaluationKind.Normal);
                 await debugSession.ContinueAsync();
 
                 await debugSession.NextPromptShouldBeBrowseAsync();

--- a/src/Debugger/Test/SteppingTest.cs
+++ b/src/Debugger/Test/SteppingTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Common.Core;
 using Microsoft.Common.Core.Test.Utility;
 using Microsoft.R.Host.Client;
 using Microsoft.R.Host.Client.Session;
@@ -38,6 +39,42 @@ namespace Microsoft.R.Debugger.Test {
         public async Task DisposeAsync() {
             await _session.StopHostAsync();
             _sessionProvider.Dispose();
+        }
+
+        [Test]
+        [Category.R.Debugger]
+        public async Task BreakContinue() {
+            const string code =
+@"browser()
+  x <- 0
+  while (x >= 0) {
+    x <- x + 1
+  }
+  browser()";
+
+            using (var debugSession = new DebugSession(_session))
+            using (var sf = new SourceFile(code)) {
+                await sf.Source(_session);
+                await debugSession.NextPromptShouldBeBrowseAsync();
+
+                await debugSession.ContinueAsync();
+                await Task.Delay(100);
+                await debugSession.BreakAsync();
+
+                await debugSession.NextPromptShouldBeBrowseAsync();
+                (await debugSession.GetStackFramesAsync()).Should().HaveTail(new MatchDebugStackFrames {
+                    { sf, new MatchRange<int>(1, 3) }
+                });
+
+                await _session.EvaluateAsync("x <- -42", REvaluationKind.Normal);
+                await debugSession.ContinueAsync();
+
+                await debugSession.NextPromptShouldBeBrowseAsync();
+                (await debugSession.GetStackFramesAsync()).Should().HaveTail(new MatchDebugStackFrames {
+                    { sf, 6 }
+                });
+            }
+
         }
 
         [Test]

--- a/src/Host/Client/Impl/Definitions/IRCallbacks.cs
+++ b/src/Host/Client/Impl/Definitions/IRCallbacks.cs
@@ -15,16 +15,16 @@ namespace Microsoft.R.Host.Client {
         /// Called as a result of R calling R API 'YesNoCancel' callback
         /// </summary>
         /// <returns>Codes that match constants in RApi.h</returns>
-        Task<YesNoCancel> YesNoCancel(IReadOnlyList<IRContext> contexts, string s, bool isEvaluationAllowed, CancellationToken ct);
+        Task<YesNoCancel> YesNoCancel(IReadOnlyList<IRContext> contexts, string s, CancellationToken ct);
 
         /// <summary>
         /// Called when R wants to display generic Windows MessageBox. 
         /// Graph app may call Win32 API directly rather than going via R API callbacks.
         /// </summary>
         /// <returns>Pressed button code</returns>
-        Task<MessageButtons> ShowDialog(IReadOnlyList<IRContext> contexts, string s, bool isEvaluationAllowed, MessageButtons buttons, CancellationToken ct);
+        Task<MessageButtons> ShowDialog(IReadOnlyList<IRContext> contexts, string s, MessageButtons buttons, CancellationToken ct);
 
-        Task<string> ReadConsole(IReadOnlyList<IRContext> contexts, string prompt, int len, bool addToHistory, bool isEvaluationAllowed, CancellationToken ct);
+        Task<string> ReadConsole(IReadOnlyList<IRContext> contexts, string prompt, int len, bool addToHistory, CancellationToken ct);
 
         Task WriteConsoleEx(string buf, OutputType otype, CancellationToken ct);
 

--- a/src/Host/Client/Impl/Definitions/IRSession.cs
+++ b/src/Host/Client/Impl/Definitions/IRSession.cs
@@ -23,7 +23,7 @@ namespace Microsoft.R.Host.Client {
 
         Task<IRSessionInteraction> BeginInteractionAsync(bool isVisible = true, CancellationToken cancellationToken = default(CancellationToken));
         Task<IRSessionEvaluation> BeginEvaluationAsync(bool isMutating = true, CancellationToken cancellationToken = default(CancellationToken));
-        Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind, CancellationToken ct = default(CancellationToken));
+        Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind = REvaluationKind.Normal, CancellationToken ct = default(CancellationToken));
         Task CancelAllAsync();
         Task StartHostAsync(RHostStartupInfo startupInfo, int timeout = 3000);
         Task StopHostAsync();

--- a/src/Host/Client/Impl/Definitions/IRSession.cs
+++ b/src/Host/Client/Impl/Definitions/IRSession.cs
@@ -23,7 +23,7 @@ namespace Microsoft.R.Host.Client {
 
         Task<IRSessionInteraction> BeginInteractionAsync(bool isVisible = true, CancellationToken cancellationToken = default(CancellationToken));
         Task<IRSessionEvaluation> BeginEvaluationAsync(bool isMutating = true, CancellationToken cancellationToken = default(CancellationToken));
-        Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind = REvaluationKind.Normal, CancellationToken ct = default(CancellationToken));
+        Task<REvaluationResult> EvaluateAsync(string expression, bool isMutating, REvaluationKind kind = REvaluationKind.Normal, CancellationToken ct = default(CancellationToken));
         Task CancelAllAsync();
         Task StartHostAsync(RHostStartupInfo startupInfo, int timeout = 3000);
         Task StopHostAsync();

--- a/src/Host/Client/Impl/Definitions/IRSession.cs
+++ b/src/Host/Client/Impl/Definitions/IRSession.cs
@@ -23,6 +23,7 @@ namespace Microsoft.R.Host.Client {
 
         Task<IRSessionInteraction> BeginInteractionAsync(bool isVisible = true, CancellationToken cancellationToken = default(CancellationToken));
         Task<IRSessionEvaluation> BeginEvaluationAsync(bool isMutating = true, CancellationToken cancellationToken = default(CancellationToken));
+        Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind, CancellationToken ct = default(CancellationToken));
         Task CancelAllAsync();
         Task StartHostAsync(RHostStartupInfo startupInfo, int timeout = 3000);
         Task StopHostAsync();

--- a/src/Host/Client/Impl/Definitions/IRSessionEvaluation.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionEvaluation.cs
@@ -8,10 +8,6 @@ using System.Threading.Tasks;
 namespace Microsoft.R.Host.Client {
     public interface IRSessionEvaluation : IDisposable {
         IReadOnlyList<IRContext> Contexts { get; }
-        /// <param name="reentrant">
-        /// If <c>true</c>, nested evaluations are possible if R transitions to the state allowing evaluation
-        /// while evaluating this expression. Otherwise, no nested evaluations are possible.
-        /// </param>
         Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind = REvaluationKind.Normal);
     }
 }

--- a/src/Host/Client/Impl/Definitions/IRSessionInteraction.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionInteraction.cs
@@ -9,6 +9,7 @@ namespace Microsoft.R.Host.Client {
     public interface IRSessionInteraction : IDisposable {
         string Prompt { get; }
         int MaxLength { get; }
+
         IReadOnlyList<IRContext> Contexts { get; }
         Task RespondAsync(string messageText);
     }

--- a/src/Host/Client/Impl/Host/RHost.EvaluationRequest.cs
+++ b/src/Host/Client/Impl/Host/RHost.EvaluationRequest.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;

--- a/src/Host/Client/Impl/Host/RHost.EvaluationRequest.cs
+++ b/src/Host/Client/Impl/Host/RHost.EvaluationRequest.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.R.Host.Client {
+    partial class RHost {
+        private class EvaluationRequest {
+            public readonly string Id;
+            public readonly string MessageName;
+            public readonly string Expression;
+            public readonly REvaluationKind Kind;
+            public readonly TaskCompletionSource<REvaluationResult> CompletionSource = new TaskCompletionSource<REvaluationResult>();
+
+            public EvaluationRequest(RHost host, string expression, REvaluationKind kind, out JArray message) {
+                Expression = expression;
+                Kind = kind;
+
+                var nameBuilder = new StringBuilder("=");
+                if (kind.HasFlag(REvaluationKind.Reentrant)) {
+                    nameBuilder.Append('@');
+                }
+                if (kind.HasFlag(REvaluationKind.Cancelable)) {
+                    nameBuilder.Append('/');
+                }
+                if (kind.HasFlag(REvaluationKind.Json)) {
+                    nameBuilder.Append('j');
+                }
+                if (kind.HasFlag(REvaluationKind.BaseEnv)) {
+                    nameBuilder.Append('B');
+                }
+                if (kind.HasFlag(REvaluationKind.EmptyEnv)) {
+                    nameBuilder.Append('E');
+                }
+                if (kind.HasFlag(REvaluationKind.NewEnv)) {
+                    nameBuilder.Append("N");
+                }
+                MessageName = nameBuilder.ToString();
+
+                expression = expression.Replace("\r\n", "\n");
+
+                message = host.CreateMessage(out Id, MessageName, expression);
+            }
+        }
+    }
+}

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -42,9 +43,9 @@ namespace Microsoft.R.Host.Client {
         private readonly FileLogWriter _fileLogWriter;
         private Process _process;
         private volatile Task _runTask;
-        private bool _canEval;
         private int _rLoopDepth;
         private long _nextMessageId = 1;
+        private readonly ConcurrentDictionary<string, EvaluationRequest> _evalRequests = new ConcurrentDictionary<string, EvaluationRequest>();
 
         private TaskCompletionSource<object> _cancelAllTcs;
         private CancellationTokenSource _cancelAllCts = new CancellationTokenSource();
@@ -99,7 +100,7 @@ namespace Microsoft.R.Host.Client {
             return new Message(token);
         }
 
-        private JArray CreateMessage(CancellationToken ct, out string id, string name, params object[] args) {
+        private JArray CreateMessage(out string id, string name, params object[] args) {
             id = "#" + _nextMessageId + "#";
             _nextMessageId += 2;
             return new JArray(id, name, args);
@@ -121,7 +122,7 @@ namespace Microsoft.R.Host.Client {
 
         private async Task<string> SendAsync(string name, CancellationToken ct, params object[] args) {
             string id;
-            var message = CreateMessage(ct, out id, name, args);
+            var message = CreateMessage(out id, name, args);
             await SendAsync(message, ct);
             return id;
         }
@@ -130,7 +131,7 @@ namespace Microsoft.R.Host.Client {
             TaskUtilities.AssertIsOnBackgroundThread();
 
             string id;
-            var message = CreateMessage(ct, out id, ":", request.Id, request.Name, args);
+            var message = CreateMessage(out id, ":", request.Id, request.Name, args);
             await SendAsync(message, ct);
             return id;
         }
@@ -154,21 +155,14 @@ namespace Microsoft.R.Host.Client {
             }
         }
 
-        private async Task ShowDialog(Message request, bool allowEval, MessageButtons buttons, CancellationToken ct) {
+        private async Task ShowDialog(Message request, MessageButtons buttons, CancellationToken ct) {
             TaskUtilities.AssertIsOnBackgroundThread();
 
             request.ExpectArguments(2);
             var contexts = GetContexts(request);
             var s = request.GetString(1, "s", allowNull: true);
 
-            MessageButtons input;
-            try {
-                _canEval = allowEval;
-                input = await _callbacks.ShowDialog(contexts, s, _canEval, buttons, ct);
-            } finally {
-                _canEval = false;
-            }
-
+            MessageButtons input = await _callbacks.ShowDialog(contexts, s, buttons, ct);
             ct.ThrowIfCancellationRequested();
 
             string response;
@@ -192,7 +186,7 @@ namespace Microsoft.R.Host.Client {
             await RespondAsync(request, ct, response);
         }
 
-        private async Task ReadConsole(Message request, bool allowEval, CancellationToken ct) {
+        private async Task ReadConsole(Message request, CancellationToken ct) {
             TaskUtilities.AssertIsOnBackgroundThread();
 
             request.ExpectArguments(5);
@@ -203,14 +197,7 @@ namespace Microsoft.R.Host.Client {
             var retryReason = request.GetString(3, "retry_reason", allowNull: true);
             var prompt = request.GetString(4, "prompt", allowNull: true);
 
-            string input;
-            try {
-                _canEval = allowEval;
-                input = await _callbacks.ReadConsole(contexts, prompt, len, addToHistory, _canEval, ct);
-            } finally {
-                _canEval = false;
-            }
-
+            string input = await _callbacks.ReadConsole(contexts, prompt, len, addToHistory, ct);
             ct.ThrowIfCancellationRequested();
 
             input = input.Replace("\r\n", "\n");
@@ -223,70 +210,41 @@ namespace Microsoft.R.Host.Client {
                 : EvaluateAsyncBackground(expression, kind, ct);
         }
 
-        private async Task<REvaluationResult> EvaluateAsyncBackground(string expression, REvaluationKind kind, CancellationToken ct) { 
+        private async Task<REvaluationResult> EvaluateAsyncBackground(string expression, REvaluationKind kind, CancellationToken ct) {
             await TaskUtilities.SwitchToBackgroundThread();
 
-            if (!_canEval) {
-                throw new InvalidOperationException("EvaluateAsync can only be called while ReadConsole or YesNoCancel is pending.");
+            JArray message;
+            var request = new EvaluationRequest(this, expression, kind, out message);
+            _evalRequests[request.Id] = request;
+
+            await SendAsync(message, ct);
+            return await request.CompletionSource.Task;
+        }
+
+        private void ProcessEvaluationResult(Message response) {
+            EvaluationRequest request; ;
+            if (!_evalRequests.TryRemove(response.RequestId, out request)) {
+                throw ProtocolError($"Unexpected response to evaluation request {response.RequestId} that is not pending.");
             }
 
-            bool reentrant = false, jsonResult = false;
-
-            var nameBuilder = new StringBuilder("=");
-            if (kind.HasFlag(REvaluationKind.Reentrant)) {
-                nameBuilder.Append('@');
-                reentrant = true;
+            response.ExpectArguments(1, 3);
+            var firstArg = response[0] as JValue;
+            if (firstArg != null && firstArg.Value == null) {
+                request.CompletionSource.SetCanceled();
             }
-            if (kind.HasFlag(REvaluationKind.Cancelable)) {
-                nameBuilder.Append('/');
-                reentrant = true;
+
+            if (response.Name != request.MessageName) {
+                throw ProtocolError($"Mismatched host response ['{response.Id}',':','{response.Name}',...] to evaluation request ['{request.Id}','{request.MessageName}','{request.Expression}']");
             }
-            if (kind.HasFlag(REvaluationKind.Json)) {
-                nameBuilder.Append('j');
-                jsonResult = true;
-            }
-            if (kind.HasFlag(REvaluationKind.BaseEnv)) {
-                nameBuilder.Append('B');
-            }
-            if (kind.HasFlag(REvaluationKind.EmptyEnv)) {
-                nameBuilder.Append('E');
-            }
-            if (kind.HasFlag(REvaluationKind.NewEnv)) {
-                nameBuilder.Append("N");
-            }
-            var name = nameBuilder.ToString();
 
-            _canEval = false;
-            try {
-                expression = expression.Replace("\r\n", "\n");
-                var id = await SendAsync(name, ct, expression);
+            response.ExpectArguments(3);
+            var parseStatus = response.GetEnum<RParseStatus>(0, "parseStatus", parseStatusNames);
+            var error = response.GetString(1, "error", allowNull: true);
 
-                var response = await RunLoop(ct, reentrant);
-                if (response == null) {
-                    throw new OperationCanceledException("Evaluation canceled because host process has been terminated.");
-                }
-
-                if (response.RequestId != id || response.Name != name) {
-                    throw ProtocolError($"Mismatched host response ['{response.Id}',':','{response.Name}',...] to evaluation request ['{id}','{name}','{expression}']");
-                }
-
-                response.ExpectArguments(1, 3);
-                var firstArg = response[0] as JValue;
-                if (firstArg != null && firstArg.Value == null) {
-                    throw new OperationCanceledException(Invariant($"Evaluation canceled: {expression}"));
-                }
-
-                response.ExpectArguments(3);
-                var parseStatus = response.GetEnum<RParseStatus>(0, "parseStatus", parseStatusNames);
-                var error = response.GetString(1, "error", allowNull: true);
-
-                if (jsonResult) {
-                    return new REvaluationResult(response[2], error, parseStatus);
-                } else {
-                    return new REvaluationResult(response.GetString(2, "value", allowNull: true), error, parseStatus);
-                }
-            } finally {
-                _canEval = true;
+            if (request.Kind.HasFlag(REvaluationKind.Json)) {
+                request.CompletionSource.SetResult(new REvaluationResult(response[2], error, parseStatus));
+            } else {
+                request.CompletionSource.SetResult(new REvaluationResult(response.GetString(2, "value", allowNull: true), error, parseStatus));
             }
         }
 
@@ -355,7 +313,7 @@ namespace Microsoft.R.Host.Client {
             }
         }
 
-        private async Task<Message> RunLoop(CancellationToken ct, bool allowEval) {
+        private async Task<Message> RunLoop(CancellationToken ct) {
             TaskUtilities.AssertIsOnBackgroundThread();
 
             try {
@@ -365,7 +323,12 @@ namespace Microsoft.R.Host.Client {
                     if (message == null) {
                         return null;
                     } else if (message.RequestId != null) {
-                        return message;
+                        if (message.Name.StartsWith("=")) {
+                            ProcessEvaluationResult(message);
+                            continue;
+                        } else {
+                            throw ProtocolError($"Unrecognized host response message name:", message);
+                        }
                     }
 
                     try {
@@ -375,19 +338,27 @@ namespace Microsoft.R.Host.Client {
                                 break;
 
                             case "?":
-                                await ShowDialog(message, allowEval, MessageButtons.YesNoCancel, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token);
+                                ShowDialog(message, MessageButtons.YesNoCancel, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token)
+                                    .SilenceException<MessageTransportException>()
+                                    .DoNotWait();
                                 break;
 
                             case "??":
-                                await ShowDialog(message, allowEval, MessageButtons.YesNo, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token);
+                                ShowDialog(message, MessageButtons.YesNo, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token)
+                                    .SilenceException<MessageTransportException>()
+                                    .DoNotWait();
                                 break;
 
                             case "???":
-                                await ShowDialog(message, allowEval, MessageButtons.OKCancel, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token);
+                                ShowDialog(message, MessageButtons.OKCancel, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token)
+                                    .SilenceException<MessageTransportException>()
+                                    .DoNotWait();
                                 break;
 
                             case ">":
-                                await ReadConsole(message, allowEval, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token);
+                                ReadConsole(message, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token)
+                                    .SilenceException<MessageTransportException>()
+                                    .DoNotWait();
                                 break;
 
                             case "!":
@@ -454,7 +425,7 @@ namespace Microsoft.R.Host.Client {
                 var rVersion = message.GetString(1, "R_version");
                 await _callbacks.Connected(rVersion);
 
-                message = await RunLoop(ct, allowEval: true);
+                message = await RunLoop(ct);
                 if (message != null) {
                     throw ProtocolError($"Unexpected host response message:", message);
                 }
@@ -506,7 +477,7 @@ namespace Microsoft.R.Host.Client {
         public async Task CreateAndRun(string rHome, string rhostDirectory = null, string rCommandLineArguments = null, int timeout = 3000, CancellationToken ct = default(CancellationToken)) {
             await TaskUtilities.SwitchToBackgroundThread();
 
-            rhostDirectory = rhostDirectory ?? Path.GetDirectoryName(typeof (RHost).Assembly.GetAssemblyPath());
+            rhostDirectory = rhostDirectory ?? Path.GetDirectoryName(typeof(RHost).Assembly.GetAssemblyPath());
             rCommandLineArguments = rCommandLineArguments ?? string.Empty;
 
             string rhostExe = Path.Combine(rhostDirectory, RHostExe);

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -44,7 +44,7 @@ namespace Microsoft.R.Host.Client {
         private Process _process;
         private volatile Task _runTask;
         private int _rLoopDepth;
-        private long _nextMessageId = 1;
+        private long _lastMessageId = -1;
         private readonly ConcurrentDictionary<string, EvaluationRequest> _evalRequests = new ConcurrentDictionary<string, EvaluationRequest>();
 
         private TaskCompletionSource<object> _cancelAllTcs;
@@ -101,8 +101,8 @@ namespace Microsoft.R.Host.Client {
         }
 
         private JArray CreateMessage(out string id, string name, params object[] args) {
-            id = "#" + _nextMessageId + "#";
-            _nextMessageId += 2;
+            long n = Interlocked.Add(ref _lastMessageId, 2);
+            id = "#" + n + "#";
             return new JArray(id, name, args);
         }
 
@@ -323,7 +323,7 @@ namespace Microsoft.R.Host.Client {
                     if (message == null) {
                         return null;
                     } else if (message.RequestId != null) {
-                        if (message.Name.StartsWith("=")) {
+                        if (message.Name.StartsWithIgnoreCase("=")) {
                             ProcessEvaluationResult(message);
                             continue;
                         } else {

--- a/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
+++ b/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Definitions\IRHostClientApp.cs" />
     <Compile Include="Definitions\RHostStartupInfo.cs" />
     <Compile Include="Extensions\RStringExtensions.cs" />
+    <Compile Include="Host\RHost.EvaluationRequest.cs" />
     <Compile Include="MessageTransportException.cs" />
     <Compile Include="Definitions\IMessageTransport.cs" />
     <Compile Include="Definitions\IRContext.cs" />

--- a/src/Host/Client/Impl/Program.cs
+++ b/src/Host/Client/Impl/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Common.Core;
 using Microsoft.Common.Core.Shell;
 
 namespace Microsoft.R.Host.Client {
@@ -75,13 +76,13 @@ namespace Microsoft.R.Host.Client {
             while (true) {
                 string r = await ReadLineAsync(" [yes/no/cancel]> ", ct);
 
-                if (r.StartsWith("y", StringComparison.InvariantCultureIgnoreCase)) {
+                if (r.StartsWithIgnoreCase("y")) {
                     return MessageButtons.Yes;
                 }
-                if (r.StartsWith("n", StringComparison.InvariantCultureIgnoreCase)) {
+                if (r.StartsWithIgnoreCase("n")) {
                     return MessageButtons.No;
                 }
-                if (r.StartsWith("c", StringComparison.InvariantCultureIgnoreCase)) {
+                if (r.StartsWithIgnoreCase("c")) {
                     return MessageButtons.Cancel;
                 }
 
@@ -108,13 +109,13 @@ namespace Microsoft.R.Host.Client {
                 try {
                     string s = await Console.In.ReadLineAsync();
 
-                    if (s.StartsWith("$$", StringComparison.OrdinalIgnoreCase)) {
+                    if (s.StartsWithIgnoreCase("$$")) {
                         s = s.Remove(0, 1);
-                    } else if (s.StartsWith("$", StringComparison.OrdinalIgnoreCase)) {
+                    } else if (s.StartsWithIgnoreCase("$")) {
                         s = s.Remove(0, 1);
 
                         var kind = REvaluationKind.Normal;
-                        if (s.StartsWith("!", StringComparison.OrdinalIgnoreCase)) {
+                        if (s.StartsWithIgnoreCase("!")) {
                             kind |= REvaluationKind.Reentrant;
                             s = s.Remove(0, 1);
                         }

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -125,13 +125,17 @@ namespace Microsoft.R.Host.Client.Session {
             return _isHostRunning ? source.Task : CanceledBeginEvaluationTask;
         }
 
-        public async Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind, CancellationToken ct = default(CancellationToken)) {
+        public async Task<REvaluationResult> EvaluateAsync(string expression, bool isMutating, REvaluationKind kind = REvaluationKind.Normal, CancellationToken ct = default(CancellationToken)) {
             if (!IsHostRunning) {
                 return await CanceledEvaluateTask;
             }
 
             try {
-                return await _host.EvaluateAsync(expression, kind, ct);
+                var result = await _host.EvaluateAsync(expression, kind, ct);
+                if (isMutating) {
+                    OnMutated();
+                }
+                return result;
             } catch (MessageTransportException) when (!IsHostRunning) {
                 return await CanceledEvaluateTask;
             }

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -251,7 +251,7 @@ namespace Microsoft.R.Host.Client.Session {
                 if (startupInfo.WorkingDirectory != null) {
                     await evaluation.SetWorkingDirectory(startupInfo.WorkingDirectory);
                 } else {
-                await evaluation.SetDefaultWorkingDirectory();
+                    await evaluation.SetDefaultWorkingDirectory();
                 }
 
                 if (_hostClientApp != null) {
@@ -464,7 +464,7 @@ namespace Microsoft.R.Host.Client.Session {
         async Task<MessageButtons> IRCallbacks.ShowDialog(IReadOnlyList<IRContext> contexts, string s, MessageButtons buttons, CancellationToken ct) {
             await TaskUtilities.SwitchToBackgroundThread();
 
-                await EvaluateAll(contexts, true, ct);
+            await EvaluateAll(contexts, true, ct);
 
             if (_hostClientApp != null) {
                 return await _hostClientApp.ShowMessage(s, buttons);

--- a/src/Host/Client/Test/Mocks/RSessionInteractionMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionInteractionMock.cs
@@ -16,6 +16,8 @@ namespace Microsoft.R.Host.Client.Test.Mocks {
 
         public string Prompt => ">";
 
+        public bool IsEvaluationAllowed => true;
+
         public void Dispose() {
         }
 

--- a/src/Host/Client/Test/Mocks/RSessionMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionMock.cs
@@ -19,7 +19,10 @@ namespace Microsoft.R.Host.Client.Test.Mocks {
 
         public string Prompt { get; set; } = ">";
 
-        public Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind, CancellationToken ct = default(CancellationToken)) {
+        public Task<REvaluationResult> EvaluateAsync(string expression, bool isMutating, REvaluationKind kind, CancellationToken ct = default(CancellationToken)) {
+            if (isMutating) {
+                Mutated?.Invoke(this, EventArgs.Empty);
+            }
             return Task.FromResult(new REvaluationResult());
         }
 

--- a/src/Host/Client/Test/Mocks/RSessionMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionMock.cs
@@ -19,6 +19,10 @@ namespace Microsoft.R.Host.Client.Test.Mocks {
 
         public string Prompt { get; set; } = ">";
 
+        public Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind, CancellationToken ct = default(CancellationToken)) {
+            return Task.FromResult(new REvaluationResult());
+        }
+
         public Task<IRSessionEvaluation> BeginEvaluationAsync(bool isMutating = true, CancellationToken cancellationToken = default(CancellationToken)) {
             _eval = new RSessionEvaluationMock();
 

--- a/src/Host/Client/Test/Session/RSessionTest.CancelAll.cs
+++ b/src/Host/Client/Test/Session/RSessionTest.CancelAll.cs
@@ -38,7 +38,7 @@ namespace Microsoft.R.Host.Client.Test.Session {
                 _session.Dispose();
             }
 
-            [Test/*(Skip = "https://github.com/Microsoft/RTVS/issues/1191")*/]
+            [Test]
             [Category.R.Session]
             public async Task CancelAllInParallel() {
                 Task responceTask;

--- a/src/Host/Client/Test/Session/RSessionTest.CancelAll.cs
+++ b/src/Host/Client/Test/Session/RSessionTest.CancelAll.cs
@@ -38,7 +38,7 @@ namespace Microsoft.R.Host.Client.Test.Session {
                 _session.Dispose();
             }
 
-            [Test(Skip = "https://github.com/Microsoft/RTVS/issues/1191")]
+            [Test/*(Skip = "https://github.com/Microsoft/RTVS/issues/1191")*/]
             [Category.R.Session]
             public async Task CancelAllInParallel() {
                 Task responceTask;


### PR DESCRIPTION
Fix #541: Debugger Break command can take a very long time to break
Fix #547: Breakpoints are not instantly updated
Fix #1191: R Host process stop: unexpected host response, Escape key after browse(), no debugger

Add support for async background evals in RHost and RSession, such that they do not require queueing requests and waiting for the next prompt to run; and use those new evals to implement debugger break.

Use async background evals to set and remove breakpoints.

Add test for debugger break/continue.

Fix OverlappingBreakpoints test to properly set/remove breakpoints while at prompt (previous behavior inadvertently relied on breakpoint creation/deletion implicitly waiting for next prompt).