### PR TITLE
Fix #1338: DataTip for indexers is wrong

### DIFF
--- a/src/R/Core/Impl/DataTips/RDataTip.cs
+++ b/src/R/Core/Impl/DataTips/RDataTip.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Linq;
 using Microsoft.Languages.Core.Text;
 using Microsoft.R.Core.AST;
 using Microsoft.R.Core.AST.Definitions;
@@ -51,7 +52,9 @@ namespace Microsoft.R.Core.DataTips {
 
                 var op = parent.OperatorType;
                 if (op == OperatorType.Index) {
-                    if (parent.LeftOperand != node) {
+                    // This is a[b] or a[[b]], and the current node is either a or b. If it is a, then we want to continue
+                    // walking up; but if it is b, we want to stop here, so that only b is shown.
+                    if (parent.Children.FirstOrDefault() != node) {
                         break;
                     }
                 } else if (op != OperatorType.ListIndex && op != OperatorType.Namespace) {


### PR DESCRIPTION
Since indexer is an unary operator in AST now, use Children.First() instead of LeftOperand to determine which part of it the child node belongs to.