### PR TITLE
Fix #915: Allow user to specify CRAN mirror via .Rprofile

### DIFF
--- a/src/Debugger/Impl/Microsoft.R.Debugger.csproj
+++ b/src/Debugger/Impl/Microsoft.R.Debugger.csproj
@@ -108,6 +108,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>True</IncludeInVSIX>
     </None>
+    <EmbeddedResource Include="rtvs\R\mirror.R">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/src/Debugger/Impl/rtvs/R/mirror.R
+++ b/src/Debugger/Impl/rtvs/R/mirror.R
@@ -10,13 +10,19 @@ set_mirror <- function(url) {
 
   if (is.null(url)) {
     if (!is.null(original_mirror$url)) {
-      repos['CRAN'] <- original_mirror$url
+      repos[['CRAN']] <- original_mirror$url
+	}
+
+	# If the only mirror on the list is @CRAN@, it will trigger the mirror selector UI every time.
+	# To avoid that, override it to point to the automatic mirror redirection service that will pick the right one by itself. 
+    if (identical(repos[['CRAN']], '@CRAN@')) {
+	  repos[['CRAN']] <- 'https://cloud.r-project.org/'
 	}
   } else {
 	if (is.null(original_mirror$url)) {
-       original_mirror$url <- repos['CRAN']
+       original_mirror$url <- repos[['CRAN']]
 	}
-    repos['CRAN'] <- url
+    repos[['CRAN']] <- url
   }
 
   options(repos = repos)

--- a/src/Debugger/Impl/rtvs/R/mirror.R
+++ b/src/Debugger/Impl/rtvs/R/mirror.R
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for license information.
+
+original_mirror <- as.environment(list(url = NULL))
+
+# If url is not NULL, set CRAN mirror to that URL.
+# If it is NULL, restore CRAN mirror URL to the original value that it had before the first call to set_mirror.
+set_mirror <- function(url) {
+  repos <- getOption('repos')
+
+  if (is.null(url)) {
+    if (!is.null(original_mirror$url)) {
+      repos['CRAN'] <- original_mirror$url
+	}
+  } else {
+	if (is.null(original_mirror$url)) {
+       original_mirror$url <- repos['CRAN']
+	}
+    repos['CRAN'] <- url
+  }
+
+  options(repos = repos)
+}

--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using static System.FormattableString;
 using Microsoft.R.Host.Client;
 
 namespace Microsoft.R.Host.Client.Session {
@@ -106,14 +107,8 @@ grDevices::deviceIsInteractive('ide')
             return evaluation.EvaluateAsync(script);
         }
 
-        public static Task<REvaluationResult> SetVsCranSelection(this IRSessionEvaluation evaluation, string mirrorUrl) {
-            var script =
-@"    local({
-        r <- getOption('repos')
-        r['CRAN'] <- '" + mirrorUrl + @"'
-        options(repos = r)})";
-
-            return evaluation.EvaluateAsync(script);
+        public static async Task SetVsCranSelection(this IRSessionEvaluation evaluation, string mirrorUrl) {
+            await evaluation.EvaluateAsync(Invariant($"rtvs:::set_mirror({mirrorUrl.ToRStringLiteral()})"));
         }
 
         public static Task<REvaluationResult> SetVsHelpRedirection(this IRSessionEvaluation evaluation) {

--- a/src/Package/Impl/Options/R/RToolsOptionsPage.cs
+++ b/src/Package/Impl/Options/R/RToolsOptionsPage.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.R.Package.Options.R {
         [CustomLocDisplayName("Settings_CranMirror")]
         [LocDescription("Settings_CranMirror_Description")]
         [TypeConverter(typeof(CranMirrorTypeConverter))]
-        [DefaultValue("0-Cloud [https]")]
+        [DefaultValue(null)]
         public string CranMirror {
             get { return RToolsSettings.Current.CranMirror; }
             set { RToolsSettings.Current.CranMirror = value; }

--- a/src/Package/Impl/Options/R/Tools/CranMirrorTypeConverter.cs
+++ b/src/Package/Impl/Options/R/Tools/CranMirrorTypeConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using Microsoft.VisualStudio.R.Package.RPackages.Mirrors;
@@ -13,8 +14,9 @@ namespace Microsoft.VisualStudio.R.Package.Options.R.Tools {
         }
 
         public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context) {
-            StandardValuesCollection coll = new StandardValuesCollection(CranMirrorList.MirrorNames);
-            return coll;
+            var mirrors = new List<string> { null };
+            mirrors.AddRange(CranMirrorList.MirrorNames);
+            return new StandardValuesCollection(mirrors);
         }
 
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) {
@@ -22,7 +24,16 @@ namespace Microsoft.VisualStudio.R.Package.Options.R.Tools {
         }
 
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
-            return value as string;
+            string s = value as string;
+            return s == Resources.CranMirror_UseRProfile ? null : s;
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) {
+            return destinationType == typeof(string);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType) {
+            return value ?? Resources.CranMirror_UseRProfile;
         }
     }
 }

--- a/src/Package/Impl/Options/R/Tools/RToolsSettingsImplementation.cs
+++ b/src/Package/Impl/Options/R/Tools/RToolsSettingsImplementation.cs
@@ -88,7 +88,6 @@ namespace Microsoft.VisualStudio.R.Package.Options.R {
         public RToolsSettingsImplementation() {
             // Default settings. Will be overwritten with actual
             // settings (if any) when settings are loaded from storage
-            _cranMirror = "0-Cloud [https]";
             RBasePath = RInstallation.GetCompatibleEnginePathFromRegistry();
             _workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
         }

--- a/src/Package/Impl/RPackages/Mirrors/CranMirrorList.cs
+++ b/src/Package/Impl/RPackages/Mirrors/CranMirrorList.cs
@@ -40,12 +40,9 @@ namespace Microsoft.VisualStudio.R.Package.RPackages.Mirrors {
 
         /// <summary>
         /// Given CRAN mirror name returns its URL.
-        /// If no mirror found, returns default URL
-        /// of RStudio CRAN redirector.
         /// </summary>
         public static string UrlFromName(string name) {
-            CranMirrorEntry e = _mirrors.FirstOrDefault((x) => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
-            return e != null ? e.Url : "https://cran.rstudio.com";
+            return _mirrors.FirstOrDefault((x) => x.Name.EqualsIgnoreCase(name))?.Url;
         }
 
         /// <summary>

--- a/src/Package/Impl/Resources.Designer.cs
+++ b/src/Package/Impl/Resources.Designer.cs
@@ -151,6 +151,15 @@ namespace Microsoft.VisualStudio.R.Package {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (Use .Rprofile).
+        /// </summary>
+        public static string CranMirror_UseRProfile {
+            get {
+                return ResourceManager.GetString("CranMirror_UseRProfile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to download CRAN mirror list. The request has been canceled..
         /// </summary>
         public static string CranMirrorListRequestCanceled {

--- a/src/Package/Impl/Resources.resx
+++ b/src/Package/Impl/Resources.resx
@@ -646,4 +646,7 @@ Additional information:
   <data name="Error_CannotOpenCsv" xml:space="preserve">
     <value>Unable to open CSV file. Exception: {0}.</value>
   </data>
+  <data name="CranMirror_UseRProfile" xml:space="preserve">
+    <value>(Use .Rprofile)</value>
+  </data>
 </root>

--- a/src/Package/Test/Cran/CranMirrorListTest.cs
+++ b/src/Package/Test/Cran/CranMirrorListTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.R.Package.Test.Repl {
                 eventCount++;
                 CranMirrorList.MirrorNames.Should().NotBeEmpty();
                 CranMirrorList.MirrorUrls.Should().NotBeEmpty();
-                CranMirrorList.UrlFromName("0 - Cloud[https]").Should().Be("https://cran.rstudio.com");
+                CranMirrorList.UrlFromName(null).Should().Be(null);
                 evt.Set();
             };
 


### PR DESCRIPTION
Provide a way to not set any CRAN mirror via R Tools | Options at all, using whatever is set by R itself (e.g. via .Rprofile or other startup code) instead.