### PR TITLE
R evaluation API unification

### DIFF
--- a/src/Debugger/Impl/DebugBreakpoint.cs
+++ b/src/Debugger/Impl/DebugBreakpoint.cs
@@ -62,13 +62,13 @@ namespace Microsoft.R.Debugger {
 
         internal async Task ReapplyBreakpointAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             TaskUtilities.AssertIsOnBackgroundThread();
-            await Session.RSession.EvaluateAsync(GetAddBreakpointExpression(false), true, REvaluationKind.Normal, cancellationToken);
+            await Session.RSession.EvaluateAsync(GetAddBreakpointExpression(false), REvaluationKind.Mutating, cancellationToken);
             // TODO: mark breakpoint as invalid if this fails.
         }
 
         internal async Task SetBreakpointAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             TaskUtilities.AssertIsOnBackgroundThread();
-            await Session.RSession.EvaluateAsync(GetAddBreakpointExpression(true), true, REvaluationKind.Normal, cancellationToken);
+            await Session.RSession.EvaluateAsync(GetAddBreakpointExpression(true), REvaluationKind.Mutating, cancellationToken);
             ++UseCount;
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.R.Debugger {
                 Session.RemoveBreakpoint(this);
 
                 var code = Invariant($"rtvs:::remove_breakpoint({fileName.ToRStringLiteral()}, {Location.LineNumber})");
-                var res = await Session.RSession.EvaluateAsync(code, true, REvaluationKind.Normal, cancellationToken);
+                var res = await Session.RSession.EvaluateAsync(code, REvaluationKind.Mutating, cancellationToken);
                 if (res.ParseStatus != RParseStatus.OK || res.Error != null) {
                     throw new InvalidOperationException(res.ToString());
                 }

--- a/src/Debugger/Impl/DebugSession.cs
+++ b/src/Debugger/Impl/DebugSession.cs
@@ -91,7 +91,7 @@ namespace Microsoft.R.Debugger {
                         await bp.ReapplyBreakpointAsync(cancellationToken);
                     }
 
-                    await eval.EvaluateAsync("rtvs:::reapply_breakpoints()"); // TODO: mark all breakpoints as invalid if this fails.
+                    await eval.EvaluateAsync("rtvs:::reapply_breakpoints()", REvaluationKind.Mutating); // TODO: mark all breakpoints as invalid if this fails.
                 }
 
                 // Attach might happen when session is already at the Browse prompt, in which case we have
@@ -207,7 +207,7 @@ namespace Microsoft.R.Debugger {
 
             // Evaluation will not end until after Browse> is responded to, but this method must indicate completion
             // as soon as the prompt appears. So don't wait for this, but wait for the prompt instead.
-            RSession.EvaluateAsync("browser()", false, REvaluationKind.Reentrant, ct)
+            RSession.EvaluateAsync("browser()", REvaluationKind.Reentrant, ct)
                 .SilenceException<MessageTransportException>().DoNotWait();
 
             // Wait until prompt appears, but don't actually respond to it.
@@ -236,7 +236,7 @@ namespace Microsoft.R.Debugger {
                     // EvaluateAsync will push a new toplevel context on the context stack before
                     // evaluating the expression, so tell browser_set_debug to skip 1 toplevel context
                     // before locating the target context for step-out.
-                    var res = await eval.EvaluateAsync("rtvs:::browser_set_debug(1, 1)");
+                    var res = await eval.EvaluateAsync("rtvs:::browser_set_debug(1, 1)", REvaluationKind.Mutating);
                     Trace.Assert(res.ParseStatus == RParseStatus.OK);
 
                     if (res.ParseStatus != RParseStatus.OK || res.Error != null) {
@@ -304,7 +304,7 @@ namespace Microsoft.R.Debugger {
             ThrowIfDisposed();
             await TaskUtilities.SwitchToBackgroundThread();
             using (var eval = await RSession.BeginEvaluationAsync(true, ct)) {
-                await eval.EvaluateAsync(Invariant($"rtvs:::enable_breakpoints({(enable ? "TRUE" : "FALSE")})"));
+                await eval.EvaluateAsync($"rtvs:::enable_breakpoints({(enable ? "TRUE" : "FALSE")})", REvaluationKind.Mutating);
             }
         }
 

--- a/src/Debugger/Impl/DebugSession.cs
+++ b/src/Debugger/Impl/DebugSession.cs
@@ -140,7 +140,7 @@ namespace Microsoft.R.Debugger {
             ThrowIfDisposed();
 
             REvaluationResult res;
-            using (var eval = await RSession.BeginEvaluationAsync(false, cancellationToken)) {
+            using (var eval = await RSession.BeginEvaluationAsync(cancellationToken)) {
                 res = await eval.EvaluateAsync(expression, json ? REvaluationKind.Json : REvaluationKind.Normal);
                 if (res.ParseStatus != RParseStatus.OK || res.Error != null || (json && res.JsonResult == null)) {
                     Trace.Fail(Invariant($"Internal debugger evaluation {expression} failed: {res}"));
@@ -232,11 +232,11 @@ namespace Microsoft.R.Debugger {
 
         public Task<bool> StepOutAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             return StepAsync(cancellationToken, "c", async inter => {
-                using (var eval = await RSession.BeginEvaluationAsync(false, cancellationToken)) {
+                using (var eval = await RSession.BeginEvaluationAsync(cancellationToken)) {
                     // EvaluateAsync will push a new toplevel context on the context stack before
                     // evaluating the expression, so tell browser_set_debug to skip 1 toplevel context
                     // before locating the target context for step-out.
-                    var res = await eval.EvaluateAsync("rtvs:::browser_set_debug(1, 1)", REvaluationKind.Mutating);
+                    var res = await eval.EvaluateAsync("rtvs:::browser_set_debug(1, 1)", REvaluationKind.Normal);
                     Trace.Assert(res.ParseStatus == RParseStatus.OK);
 
                     if (res.ParseStatus != RParseStatus.OK || res.Error != null) {
@@ -303,7 +303,7 @@ namespace Microsoft.R.Debugger {
         public async Task EnableBreakpointsAsync(bool enable, CancellationToken ct = default(CancellationToken)) {
             ThrowIfDisposed();
             await TaskUtilities.SwitchToBackgroundThread();
-            using (var eval = await RSession.BeginEvaluationAsync(true, ct)) {
+            using (var eval = await RSession.BeginEvaluationAsync(ct)) {
                 await eval.EvaluateAsync($"rtvs:::enable_breakpoints({(enable ? "TRUE" : "FALSE")})", REvaluationKind.Mutating);
             }
         }

--- a/src/Debugger/Test/BreakpointsTest.cs
+++ b/src/Debugger/Test/BreakpointsTest.cs
@@ -340,7 +340,7 @@ namespace Microsoft.R.Debugger.Test {
                 await Task.Delay(100);
 
                 await bp.DeleteAsync();
-                await _session.EvaluateAsync("b <- TRUE", true);
+                await _session.EvaluateAsync("b <- TRUE", REvaluationKind.Mutating);
 
                 await debugSession.NextPromptShouldBeBrowseAsync();
                 (await debugSession.GetStackFramesAsync()).Should().HaveTail(new MatchDebugStackFrames {

--- a/src/Debugger/Test/DebugReplTest.cs
+++ b/src/Debugger/Test/DebugReplTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.R.Debugger.Test {
 
                     REvaluationResult x;
                     using (var eval = await _session.BeginEvaluationAsync()) {
-                        x = await eval.EvaluateAsync("x");
+                        x = await eval.EvaluateAsync("x", REvaluationKind.Normal);
                     }
 
                     x.StringResult.Should().Be("new");

--- a/src/Debugger/Test/SteppingTest.cs
+++ b/src/Debugger/Test/SteppingTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.R.Debugger.Test {
                     { sf, new MatchRange<int>(1, 3) }
                 });
 
-                await _session.EvaluateAsync("x <- -42", true, REvaluationKind.Normal);
+                await _session.EvaluateAsync("x <- -42", REvaluationKind.Mutating);
                 await debugSession.ContinueAsync();
 
                 await debugSession.NextPromptShouldBeBrowseAsync();

--- a/src/Host/Client/Impl/Definitions/IRExpressionEvaluator.cs
+++ b/src/Host/Client/Impl/Definitions/IRExpressionEvaluator.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using static System.FormattableString;
 
 namespace Microsoft.R.Host.Client {
     [Flags]
@@ -18,10 +19,17 @@ namespace Microsoft.R.Host.Client {
         EmptyEnv = 1 << 4,
         Cancelable = 1 << 5,
         NewEnv = 1 << 6,
+        Mutating = 1 << 7,
     }
 
     public interface IRExpressionEvaluator {
-        Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind, CancellationToken ct);
+        Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind, CancellationToken cancellationToken = default(CancellationToken));
+    }
+
+    public static class RExpressionEvaluatorExtensions {
+        public static Task<REvaluationResult> EvaluateAsync(this IRExpressionEvaluator evaluator, FormattableString expression, REvaluationKind kind, CancellationToken cancellationToken = default(CancellationToken)) {
+            return evaluator.EvaluateAsync(Invariant(expression), kind, cancellationToken);
+        }
     }
 
     public enum RParseStatus {

--- a/src/Host/Client/Impl/Definitions/IRSession.cs
+++ b/src/Host/Client/Impl/Definitions/IRSession.cs
@@ -22,7 +22,7 @@ namespace Microsoft.R.Host.Client {
         Task HostStarted { get; }
 
         Task<IRSessionInteraction> BeginInteractionAsync(bool isVisible = true, CancellationToken cancellationToken = default(CancellationToken));
-        Task<IRSessionEvaluation> BeginEvaluationAsync(bool isMutating = true, CancellationToken cancellationToken = default(CancellationToken));
+        Task<IRSessionEvaluation> BeginEvaluationAsync(CancellationToken cancellationToken = default(CancellationToken));
         Task CancelAllAsync();
         Task StartHostAsync(RHostStartupInfo startupInfo, int timeout = 3000);
         Task StopHostAsync();

--- a/src/Host/Client/Impl/Definitions/IRSession.cs
+++ b/src/Host/Client/Impl/Definitions/IRSession.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Client {
-    public interface IRSession : IDisposable {
+    public interface IRSession : IRExpressionEvaluator, IDisposable {
         event EventHandler<RRequestEventArgs> BeforeRequest;
         event EventHandler<RRequestEventArgs> AfterRequest;
         event EventHandler<EventArgs> Mutated;
@@ -23,7 +23,6 @@ namespace Microsoft.R.Host.Client {
 
         Task<IRSessionInteraction> BeginInteractionAsync(bool isVisible = true, CancellationToken cancellationToken = default(CancellationToken));
         Task<IRSessionEvaluation> BeginEvaluationAsync(bool isMutating = true, CancellationToken cancellationToken = default(CancellationToken));
-        Task<REvaluationResult> EvaluateAsync(string expression, bool isMutating, REvaluationKind kind = REvaluationKind.Normal, CancellationToken ct = default(CancellationToken));
         Task CancelAllAsync();
         Task StartHostAsync(RHostStartupInfo startupInfo, int timeout = 3000);
         Task StopHostAsync();

--- a/src/Host/Client/Impl/Definitions/IRSessionContext.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionContext.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Client {
-    public interface IRSessionInteraction : IRSessionContext, IDisposable {
-        string Prompt { get; }
-        int MaxLength { get; }
-
-        Task RespondAsync(string messageText);
+    public interface IRSessionContext {
+        IReadOnlyList<IRContext> Contexts { get; }
     }
 }

--- a/src/Host/Client/Impl/Definitions/IRSessionEvaluation.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionEvaluation.cs
@@ -3,11 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Client {
-    public interface IRSessionEvaluation : IDisposable {
-        IReadOnlyList<IRContext> Contexts { get; }
-        Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind = REvaluationKind.Normal);
+    public interface IRSessionEvaluation : IRSessionContext, IRExpressionEvaluator, IDisposable {
+        bool IsMutating { get; }
     }
 }

--- a/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
+++ b/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
@@ -61,6 +61,7 @@
     <Compile Include="..\..\..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Definitions\IRSessionContext.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Definitions\GuidList.cs" />
     <Compile Include="Definitions\IRHostClientApp.cs" />

--- a/src/Host/Client/Impl/Session/RSessionEvaluation.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluation.cs
@@ -7,18 +7,18 @@ using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Client.Session {
     internal sealed class RSessionEvaluation : IRSessionEvaluation {
+        private readonly RSessionEvaluationSource _source;
         private readonly IRExpressionEvaluator _evaluator;
         private readonly TaskCompletionSource<object> _tcs;
         private readonly CancellationToken _ct;
 
         public IReadOnlyList<IRContext> Contexts { get; }
-        public bool IsMutating { get; }
+        public bool IsMutating { get; private set; }
         public Task Task => _tcs.Task;
 
-        public RSessionEvaluation(IReadOnlyList<IRContext> contexts, IRExpressionEvaluator evaluator, bool isMutating, CancellationToken ct) {
+        public RSessionEvaluation(IReadOnlyList<IRContext> contexts, IRExpressionEvaluator evaluator, CancellationToken ct) {
             Contexts = contexts;
             _evaluator = evaluator;
-            IsMutating = isMutating;
             _tcs = new TaskCompletionSource<object>();
             _ct = ct;
             ct.Register(() => _tcs.TrySetCanceled());
@@ -29,9 +29,10 @@ namespace Microsoft.R.Host.Client.Session {
         }
 
         public Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind, CancellationToken ct) {
-            if (IsMutating) {
-                kind |= REvaluationKind.Mutating;
+            if (kind.HasFlag(REvaluationKind.Mutating)) {
+                IsMutating = true;
             }
+
             ct.Register(() => _tcs.TrySetCanceled());
             var cts = CancellationTokenSource.CreateLinkedTokenSource(_ct, ct);
             return _evaluator.EvaluateAsync(expression, kind, cts.Token);

--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -9,7 +9,7 @@ using Microsoft.R.Host.Client;
 namespace Microsoft.R.Host.Client.Session {
     public static class RSessionEvaluationCommands {
         public static Task OptionsSetWidth(this IRExpressionEvaluator evaluation, int width) {
-            return evaluation.EvaluateAsync($"options(width=as.integer({width}))\n", REvaluationKind.Normal);
+            return evaluation.EvaluateAsync($"options(width=as.integer({width}))\n", REvaluationKind.Mutating);
         }
 
         public static async Task<string> GetRUserDirectory(this IRExpressionEvaluator evaluation) {
@@ -89,7 +89,7 @@ grDevices::deviceIsInteractive('ide')
 
         public static Task<REvaluationResult> InstallPackage(this IRExpressionEvaluator evaluation, string packageName) {
             var script = string.Format("install.packages(\"{0}\")", packageName);
-            return evaluation.EvaluateAsync(script, REvaluationKind.Json);
+            return evaluation.EvaluateAsync(script, REvaluationKind.Mutating);
         }
 
         public static Task<REvaluationResult> ExportToBitmap(this IRExpressionEvaluator evaluation, string deviceName, string outputFilePath, int widthInPixels, int heightInPixels) {

--- a/src/Host/Client/Impl/Session/RSessionEvaluationSource.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationSource.cs
@@ -19,7 +19,9 @@ namespace Microsoft.R.Host.Client.Session {
 
         public async Task<bool> BeginEvaluationAsync(IReadOnlyList<IRContext> contexts, IRExpressionEvaluator evaluator, CancellationToken ct) {
             var evaluation = new RSessionEvaluation(contexts, evaluator, ct);
-            await (_tcs.TrySetResult(evaluation) ? evaluation.Task : System.Threading.Tasks.Task.CompletedTask);
+            if (_tcs.TrySetResult(evaluation)) {
+                await evaluation.Task;
+            }
             return evaluation.IsMutating;
         }
 

--- a/src/Host/Client/Impl/Session/RSessionEvaluationSource.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationSource.cs
@@ -10,19 +10,17 @@ namespace Microsoft.R.Host.Client.Session {
     internal sealed class RSessionEvaluationSource {
         private readonly TaskCompletionSource<IRSessionEvaluation> _tcs;
 
-        public bool IsMutating { get; }
-
-        public RSessionEvaluationSource(bool isMutating, CancellationToken ct) {
+        public RSessionEvaluationSource(CancellationToken ct) {
             _tcs = new TaskCompletionSource<IRSessionEvaluation>();
             ct.Register(() => _tcs.TrySetCanceled(ct), false);
-            IsMutating = isMutating;
         }
 
         public Task<IRSessionEvaluation> Task => _tcs.Task;
 
-        public Task BeginEvaluationAsync(IReadOnlyList<IRContext> contexts, IRExpressionEvaluator evaluator, CancellationToken ct) {
-            var evaluation = new RSessionEvaluation(contexts, evaluator, IsMutating, ct);
-            return _tcs.TrySetResult(evaluation) ? evaluation.Task : System.Threading.Tasks.Task.CompletedTask;
+        public async Task<bool> BeginEvaluationAsync(IReadOnlyList<IRContext> contexts, IRExpressionEvaluator evaluator, CancellationToken ct) {
+            var evaluation = new RSessionEvaluation(contexts, evaluator, ct);
+            await (_tcs.TrySetResult(evaluation) ? evaluation.Task : System.Threading.Tasks.Task.CompletedTask);
+            return evaluation.IsMutating;
         }
 
         public bool TryCancel() {

--- a/src/Host/Client/Impl/Session/RSessionEvaluationSource.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationSource.cs
@@ -21,7 +21,7 @@ namespace Microsoft.R.Host.Client.Session {
         public Task<IRSessionEvaluation> Task => _tcs.Task;
 
         public Task BeginEvaluationAsync(IReadOnlyList<IRContext> contexts, IRExpressionEvaluator evaluator, CancellationToken ct) {
-            var evaluation = new RSessionEvaluation(contexts, evaluator, ct);
+            var evaluation = new RSessionEvaluation(contexts, evaluator, IsMutating, ct);
             return _tcs.TrySetResult(evaluation) ? evaluation.Task : System.Threading.Tasks.Task.CompletedTask;
         }
 

--- a/src/Host/Client/Impl/Session/RSessionExtensions.cs
+++ b/src/Host/Client/Impl/Session/RSessionExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.R.Host.Client.Session {
             if (session.IsHostRunning) {
                 await TaskUtilities.SwitchToBackgroundThread();
                 try {
-                    using (var evaluation = await session.BeginEvaluationAsync(false)) {
+                    using (var evaluation = await session.BeginEvaluationAsync()) {
                         return await evaluation.GetWorkingDirectory();
                     }
                 } catch (OperationCanceledException) { }
@@ -42,7 +42,7 @@ namespace Microsoft.R.Host.Client.Session {
             if (session.IsHostRunning) {
                 await TaskUtilities.SwitchToBackgroundThread();
                 try {
-                    using (var evaluation = await session.BeginEvaluationAsync(false)) {
+                    using (var evaluation = await session.BeginEvaluationAsync()) {
                         return await evaluation.GetRUserDirectory();
                     }
                 } catch (OperationCanceledException) { }

--- a/src/Host/Client/Test/Mocks/RSessionEvaluationMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionEvaluationMock.cs
@@ -13,16 +13,15 @@ namespace Microsoft.R.Host.Client.Test.Mocks {
             }
         }
 
-        public bool IsMutating { get; }
-
-        public RSessionEvaluationMock(bool isMutating) {
-            IsMutating = isMutating;
-        }
+        public bool IsMutating { get; private set; }
 
         public void Dispose() {
         }
 
         public Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind = REvaluationKind.Normal, CancellationToken ct = default(CancellationToken)) {
+            if (kind.HasFlag(REvaluationKind.Mutating)) {
+                IsMutating = true;
+            }
             return Task.FromResult(new REvaluationResult());
         }
     }

--- a/src/Host/Client/Test/Mocks/RSessionEvaluationMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionEvaluationMock.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Client.Test.Mocks {
@@ -12,10 +13,16 @@ namespace Microsoft.R.Host.Client.Test.Mocks {
             }
         }
 
+        public bool IsMutating { get; }
+
+        public RSessionEvaluationMock(bool isMutating) {
+            IsMutating = isMutating;
+        }
+
         public void Dispose() {
         }
 
-        public Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind = REvaluationKind.Normal) {
+        public Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind = REvaluationKind.Normal, CancellationToken ct = default(CancellationToken)) {
             return Task.FromResult(new REvaluationResult());
         }
     }

--- a/src/Host/Client/Test/Mocks/RSessionMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionMock.cs
@@ -26,11 +26,10 @@ namespace Microsoft.R.Host.Client.Test.Mocks {
             return Task.FromResult(new REvaluationResult());
         }
 
-        public Task<IRSessionEvaluation> BeginEvaluationAsync(bool isMutating = true, CancellationToken cancellationToken = default(CancellationToken)) {
-            _eval = new RSessionEvaluationMock(isMutating);
-
+        public Task<IRSessionEvaluation> BeginEvaluationAsync(CancellationToken cancellationToken = default(CancellationToken)) {
+            _eval = new RSessionEvaluationMock();
             BeforeRequest?.Invoke(this, new RRequestEventArgs(_eval.Contexts, Prompt, 4096, true));
-            if (isMutating) {
+            if (_eval.IsMutating) {
                 Mutated?.Invoke(this, EventArgs.Empty);
             }
             return Task.FromResult(_eval);

--- a/src/Host/Client/Test/Mocks/RSessionMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionMock.cs
@@ -19,15 +19,15 @@ namespace Microsoft.R.Host.Client.Test.Mocks {
 
         public string Prompt { get; set; } = ">";
 
-        public Task<REvaluationResult> EvaluateAsync(string expression, bool isMutating, REvaluationKind kind, CancellationToken ct = default(CancellationToken)) {
-            if (isMutating) {
+        public Task<REvaluationResult> EvaluateAsync(string expression, REvaluationKind kind, CancellationToken ct = default(CancellationToken)) {
+            if (kind.HasFlag(REvaluationKind.Mutating)) {
                 Mutated?.Invoke(this, EventArgs.Empty);
             }
             return Task.FromResult(new REvaluationResult());
         }
 
         public Task<IRSessionEvaluation> BeginEvaluationAsync(bool isMutating = true, CancellationToken cancellationToken = default(CancellationToken)) {
-            _eval = new RSessionEvaluationMock();
+            _eval = new RSessionEvaluationMock(isMutating);
 
             BeforeRequest?.Invoke(this, new RRequestEventArgs(_eval.Contexts, Prompt, 4096, true));
             if (isMutating) {

--- a/src/Package/Impl/DataInspect/DataSource/GridDataSource.cs
+++ b/src/Package/Impl/DataInspect/DataSource/GridDataSource.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataSource {
             string columns = gridRange?.Columns.ToRString();
 
             REvaluationResult? result = null;
-            using (var evaluator = await rSession.BeginEvaluationAsync(false)) {
+            using (var evaluator = await rSession.BeginEvaluationAsync()) {
                 result = await evaluator.EvaluateAsync($"rtvs:::grid.dput(rtvs:::grid.data({expression}, {rows}, {columns}))", REvaluationKind.Normal);
 
                 if (result.Value.ParseStatus != RParseStatus.OK || result.Value.Error != null) {

--- a/src/Package/Impl/DataInspect/Office/CsvAppFileIO.cs
+++ b/src/Package/Impl/DataInspect/Office/CsvAppFileIO.cs
@@ -13,6 +13,7 @@ using Microsoft.Common.Core;
 using Microsoft.R.Components.ContentTypes;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Debugger;
+using Microsoft.R.Host.Client;
 using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.R.Package.Utilities;
 using Microsoft.VisualStudio.Shell;
@@ -54,7 +55,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Office {
             try {
                 await SetStatusTextAsync(Resources.Status_WritingCSV);
                 using (var e = await session.BeginEvaluationAsync()) {
-                    await e.EvaluateAsync(Invariant($"write.csv({result.Expression}, file='{rfile}')") + Environment.NewLine);
+                    await e.EvaluateAsync($"write.csv({result.Expression}, file='{rfile}')", REvaluationKind.Normal);
                 }
 
                 if (File.Exists(file)) {

--- a/src/Package/Impl/DataInspect/REnvironmentProvider.cs
+++ b/src/Package/Impl/DataInspect/REnvironmentProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             await TaskUtilities.SwitchToBackgroundThread();
 
             REvaluationResult result;
-            using (var evaluation = await _rSession.BeginEvaluationAsync(false)) {
+            using (var evaluation = await _rSession.BeginEvaluationAsync()) {
                 result = await evaluation.EvaluateAsync("rtvs:::getEnvironments(sys.frame(sys.nframe()))", REvaluationKind.Json);
             }
 

--- a/src/Package/Impl/Help/HelpHomeCommand.cs
+++ b/src/Package/Impl/Help/HelpHomeCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.R.Package.Help {
             if (session.IsHostRunning) {
                 try {
                     using (IRSessionEvaluation evaluation = await session.BeginEvaluationAsync(isMutating: false)) {
-                        await evaluation.EvaluateAsync("help.start()" + Environment.NewLine);
+                        await evaluation.EvaluateAsync("help.start()", REvaluationKind.Normal);
                     }
                 } catch (RException) { } catch (OperationCanceledException) { }
             }

--- a/src/Package/Impl/Help/HelpHomeCommand.cs
+++ b/src/Package/Impl/Help/HelpHomeCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.R.Package.Help {
             var session = rSessionProvider.GetInteractiveWindowRSession();
             if (session.IsHostRunning) {
                 try {
-                    using (IRSessionEvaluation evaluation = await session.BeginEvaluationAsync(isMutating: false)) {
+                    using (IRSessionEvaluation evaluation = await session.BeginEvaluationAsync()) {
                         await evaluation.EvaluateAsync("help.start()", REvaluationKind.Normal);
                     }
                 } catch (RException) { } catch (OperationCanceledException) { }

--- a/src/Package/Impl/Help/ShowHelpOnCurrentCommand.cs
+++ b/src/Package/Impl/Help/ShowHelpOnCurrentCommand.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.R.Package.Help {
 
         private async Task ShowHelpOnCurrentAsync(string prefix, string item) {
             try {
-                using (IRSessionEvaluation evaluation = await _workflow.RSession.BeginEvaluationAsync(isMutating: false)) {
+                using (IRSessionEvaluation evaluation = await _workflow.RSession.BeginEvaluationAsync()) {
                     REvaluationResult result = await evaluation.EvaluateAsync(prefix + item, REvaluationKind.Normal);
                     if (result.ParseStatus == RParseStatus.OK &&
                         string.IsNullOrEmpty(result.Error)) {

--- a/src/Package/Impl/Help/ShowHelpOnCurrentCommand.cs
+++ b/src/Package/Impl/Help/ShowHelpOnCurrentCommand.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.R.Package.Help {
         private async Task ShowHelpOnCurrentAsync(string prefix, string item) {
             try {
                 using (IRSessionEvaluation evaluation = await _workflow.RSession.BeginEvaluationAsync(isMutating: false)) {
-                    REvaluationResult result = await evaluation.EvaluateAsync(prefix + item + Environment.NewLine);
+                    REvaluationResult result = await evaluation.EvaluateAsync(prefix + item, REvaluationKind.Normal);
                     if (result.ParseStatus == RParseStatus.OK &&
                         string.IsNullOrEmpty(result.Error)) {
                         if (string.IsNullOrEmpty(result.StringResult) ||

--- a/src/Package/Test/DataInspect/VariableRHostScript.cs
+++ b/src/Package/Test/DataInspect/VariableRHostScript.cs
@@ -59,8 +59,8 @@ namespace Microsoft.VisualStudio.R.Package.Test.DataInspect {
                 _globalEnv = null;
                 subscription = _variableProvider.Subscribe(0, "base::environment()", OnGlobalEnvironmentEvaluated);
 
-                using (var evaluation = await base.Session.BeginEvaluationAsync()) {
-                    await evaluation.EvaluateAsync(rScript);
+                using (var evaluation = await Session.BeginEvaluationAsync()) {
+                    await evaluation.EvaluateAsync(rScript, REvaluationKind.Normal);
                 }
 
                 if (System.Diagnostics.Debugger.IsAttached) {

--- a/src/Package/Test/DataInspect/VariableRHostScript.cs
+++ b/src/Package/Test/DataInspect/VariableRHostScript.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.R.Package.Test.DataInspect {
                 subscription = _variableProvider.Subscribe(0, "base::environment()", OnGlobalEnvironmentEvaluated);
 
                 using (var evaluation = await Session.BeginEvaluationAsync()) {
-                    await evaluation.EvaluateAsync(rScript, REvaluationKind.Normal);
+                    await evaluation.EvaluateAsync(rScript, REvaluationKind.Mutating);
                 }
 
                 if (System.Diagnostics.Debugger.IsAttached) {

--- a/src/Package/TestApp/Data/VariableExplorerTest.cs
+++ b/src/Package/TestApp/Data/VariableExplorerTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.Common.Core.Test.Controls;
+using Microsoft.R.Host.Client;
 using Microsoft.UnitTests.Core.XUnit;
 using Microsoft.VisualStudio.R.Interactive.Test.Utility;
 using Microsoft.VisualStudio.R.Package.DataInspect;
@@ -41,7 +42,7 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Data {
                     DoIdle(100);
                     Task.Run(async () => {
                         using (var eval = await hostScript.Session.BeginEvaluationAsync()) {
-                            await eval.EvaluateAsync("x <- c(1:10)");
+                            await eval.EvaluateAsync("x <- c(1:10)", REvaluationKind.Mutating);
                         }
                     }).Wait();
 

--- a/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
+++ b/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
@@ -181,17 +181,17 @@ namespace Microsoft.R.Components.Test.PackageManager {
 
         private async Task SetLocalRepoAsync(IRSessionEvaluation eval, string localRepoPath) {
             var code = string.Format("options(repos=list(LOCAL=\"file:///{0}\"))", localRepoPath.ToRPath());
-            var evalResult = await eval.EvaluateAsync(code);
+            var evalResult = await eval.EvaluateAsync(code, REvaluationKind.Mutating);
         }
 
         private async Task SetLocalLibAsync(IRSessionEvaluation eval, string libPath) {
             var code = string.Format(".libPaths(\"{0}\")", libPath.ToRPath());
-            var evalResult = await eval.EvaluateAsync(code);
+            var evalResult = await eval.EvaluateAsync(code, REvaluationKind.Normal);
         }
 
         private async Task InstallPackageAsync(IRSessionEvaluation eval, string packageName, string libPath) {
             var code = string.Format("install.packages(\"{0}\", verbose=FALSE, quiet=TRUE)", packageName);
-            var evalResult = await eval.EvaluateAsync(code);
+            var evalResult = await eval.EvaluateAsync(code, REvaluationKind.Normal);
             WaitForPackageInstalled(libPath, packageName);
         }
 

--- a/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
+++ b/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
@@ -129,7 +129,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
                     rSession.Should().NotBeNull();
 
                     using (var eval = rSession.BeginEvaluationAsync().Result) {
-                        result = eval.EvaluateAsync("library('tools')", REvaluationKind.Normal).Result;
+                        result = eval.EvaluateAsync("library('tools')", REvaluationKind.Mutating).Result;
                     }
 
                     script.DoIdle(1000);

--- a/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
+++ b/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
@@ -129,7 +129,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
                     rSession.Should().NotBeNull();
 
                     using (var eval = rSession.BeginEvaluationAsync().Result) {
-                        result = eval.EvaluateAsync("library('tools')").Result;
+                        result = eval.EvaluateAsync("library('tools')", REvaluationKind.Normal).Result;
                     }
 
                     script.DoIdle(1000);

--- a/src/R/Editor/Impl/Completion/RCompletionController.cs
+++ b/src/R/Editor/Impl/Completion/RCompletionController.cs
@@ -408,7 +408,7 @@ namespace Microsoft.R.Editor.Completion {
             var sessionProvider = EditorShell.Current.ExportProvider.GetExportedValue<IRSessionProvider>();
             IRSession session = sessionProvider.GetOrCreate(GuidList.InteractiveWindowRSessionGuid, null);
             if (session != null) {
-                using (IRSessionEvaluation eval = await session.BeginEvaluationAsync(isMutating: false)) {
+                using (IRSessionEvaluation eval = await session.BeginEvaluationAsync()) {
                     REvaluationResult result = await eval.EvaluateAsync(expression, REvaluationKind.Normal);
                     if (result.ParseStatus == RParseStatus.OK &&
                         !string.IsNullOrEmpty(result.StringResult) &&

--- a/src/R/Editor/Impl/Completion/RCompletionController.cs
+++ b/src/R/Editor/Impl/Completion/RCompletionController.cs
@@ -409,7 +409,7 @@ namespace Microsoft.R.Editor.Completion {
             IRSession session = sessionProvider.GetOrCreate(GuidList.InteractiveWindowRSessionGuid, null);
             if (session != null) {
                 using (IRSessionEvaluation eval = await session.BeginEvaluationAsync(isMutating: false)) {
-                    REvaluationResult result = await eval.EvaluateAsync(expression);
+                    REvaluationResult result = await eval.EvaluateAsync(expression, REvaluationKind.Normal);
                     if (result.ParseStatus == RParseStatus.OK &&
                         !string.IsNullOrEmpty(result.StringResult) &&
                          (result.StringResult == "T" || result.StringResult == "TRUE")) {

--- a/src/R/Editor/Impl/Data/LoadedPackagesProvider.cs
+++ b/src/R/Editor/Impl/Data/LoadedPackagesProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.R.Editor.Data {
         }
 
         private async Task UpdateListOfLoadedPackagesAsync() {
-            using (var e = await Session.BeginEvaluationAsync(isMutating: false)) {
+            using (var e = await Session.BeginEvaluationAsync()) {
                 REvaluationResult result = await e.EvaluateAsync("paste0(.packages(), collapse = ' ')", REvaluationKind.Normal);
                 if (result.ParseStatus == RParseStatus.OK && result.Error == null && result.StringResult != null) {
                     ParseSearchResponse(result.StringResult);

--- a/src/R/Editor/Impl/Data/LoadedPackagesProvider.cs
+++ b/src/R/Editor/Impl/Data/LoadedPackagesProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.R.Editor.Data {
 
         private async Task UpdateListOfLoadedPackagesAsync() {
             using (var e = await Session.BeginEvaluationAsync(isMutating: false)) {
-                REvaluationResult result = await e.EvaluateAsync("paste0(.packages(), collapse = ' ')");
+                REvaluationResult result = await e.EvaluateAsync("paste0(.packages(), collapse = ' ')", REvaluationKind.Normal);
                 if (result.ParseStatus == RParseStatus.OK && result.Error == null && result.StringResult != null) {
                     ParseSearchResponse(result.StringResult);
                 }

--- a/src/R/Support/Impl/Help/FunctionRdDataProvider.cs
+++ b/src/R/Support/Impl/Help/FunctionRdDataProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.R.Host.Client.Signatures {
                 await CreateSessionAsync();
                 using (var eval = await _session.BeginEvaluationAsync()) {
                     string command = GetCommandText(functionName, packageName);
-                    REvaluationResult result = await eval.EvaluateAsync(command);
+                    REvaluationResult result = await eval.EvaluateAsync(command, REvaluationKind.Normal);
                     if (result.ParseStatus == RParseStatus.OK && result.StringResult != null && result.StringResult.Length > 2) {
                         rdDataAvailableCallback(result.StringResult);
                     }


### PR DESCRIPTION
R evaluation API unification - everything that can eval R code now implements `IRExpressionEvaluator`.

Require `REvaluationKind` to be specified to avoid bugs when not-mutating eval is inappropriate, and force callers to specify it explicitly either way. Fix existing callers accordingly.

Remove `isMutating` parameter from `BeginEvaluationAsync` - all evaluations now begin as non-mutating, and change if `REvaluationKind.Mutating` is used on any `EvaluateAsync` call for that evaluation.