### PR TITLE
Fix #1318, #1432

### DIFF
--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -527,8 +527,11 @@ namespace Microsoft.R.Host.Client {
                 UseShellExecute = false
             };
 
-            psi.EnvironmentVariables["R_HOME"] = rHome;
-            psi.EnvironmentVariables["PATH"] = Environment.GetEnvironmentVariable("PATH") + ";" + rBinPath;
+            var shortHome = new StringBuilder(NativeMethods.MAX_PATH);
+            NativeMethods.GetShortPathName(rHome, shortHome, shortHome.Capacity);
+            psi.EnvironmentVariables["R_HOME"] = shortHome.ToString();
+
+            psi.EnvironmentVariables["PATH"] = rBinPath + ";" + Environment.GetEnvironmentVariable("PATH");
 
             if (_name != null) {
                 psi.Arguments += " --rhost-name " + _name;

--- a/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
+++ b/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
@@ -62,6 +62,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Definitions\IRSessionContext.cs" />
+    <Compile Include="NativeMethods.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Definitions\GuidList.cs" />
     <Compile Include="Definitions\IRHostClientApp.cs" />

--- a/src/Host/Client/Impl/NativeMethods.cs
+++ b/src/Host/Client/Impl/NativeMethods.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.R.Host.Client {
+    internal static class NativeMethods {
+        public const int MAX_PATH = 260;
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        public static extern int GetShortPathName(string lpszLongPath, StringBuilder lpszShortPath, int cchBuffer);
+    }
+}


### PR DESCRIPTION
Fix #1318: cxxfunction: Error in system(cmd, intern = !verbose) : 'C:/Program' not found

Shorten path when setting R_HOME.

Fix #1432: If R\bin is in PATH, wrong R.dll is loaded

When adding R\bin to PATH when launching host, insert it at the beginning rather than at the end.