### PR TITLE
Retrieve environment names

### DIFF
--- a/src/Debugger/Engine/Impl/AD7StackFrame.cs
+++ b/src/Debugger/Engine/Impl/AD7StackFrame.cs
@@ -109,7 +109,7 @@ namespace Microsoft.R.Debugger.Engine {
             }
 
             if (dwFieldSpec.HasFlag(enum_FRAMEINFO_FLAGS.FIF_FUNCNAME)) {
-                fi.m_bstrFuncName = StackFrame.CallingFrame?.Call ?? (StackFrame.IsGlobal ? "<global>" : "<unknown>");
+                fi.m_bstrFuncName = StackFrame.EnvironmentName ?? StackFrame.CallingFrame?.Call ?? "<unknown>";
                 fi.m_dwValidFields |= enum_FRAMEINFO_FLAGS.FIF_FUNCNAME;
 
                 if (dwFieldSpec.HasFlag(enum_FRAMEINFO_FLAGS.FIF_FUNCNAME_MODULE) && moduleName != null) {

--- a/src/Debugger/Engine/Impl/AD7Thread.cs
+++ b/src/Debugger/Engine/Impl/AD7Thread.cs
@@ -159,7 +159,7 @@ namespace Microsoft.R.Debugger.Engine {
         private void ResetStackFrames() {
             _stackFrames = Lazy.Create(() =>
                 (IReadOnlyList<DebugStackFrame>)
-                TaskExtensions.RunSynchronouslyOnUIThread(ct => Engine.DebugSession.GetStackFramesAsync(ct))
+                TaskExtensions.RunSynchronouslyOnUIThread(ct => Engine.DebugSession.GetStackFramesAsync(cancellationToken: ct))
                 .Reverse()
                 .ToArray());
         }

--- a/src/Debugger/Impl/DebugEvaluationResult.cs
+++ b/src/Debugger/Impl/DebugEvaluationResult.cs
@@ -258,7 +258,7 @@ namespace Microsoft.R.Debugger {
                 throw new InvalidOperationException("Cannot retrieve children of an evaluation result that does not have an associated expression.");
             }
 
-            var call = Invariant($@"rtvs:::describe_children({Expression.ToRStringLiteral()}, {StackFrame.SysFrame}, {fields.ToRVector()}, {maxLength}, {reprMaxLength})");
+            var call = Invariant($@"rtvs:::describe_children({Expression.ToRStringLiteral()}, {StackFrame.EnvironmentExpression}, {fields.ToRVector()}, {maxLength}, {reprMaxLength})");
             var jChildren = await StackFrame.Session.InvokeDebugHelperAsync<JArray>(call, cancellationToken);
             Trace.Assert(
                 jChildren.Children().All(t => t is JObject),

--- a/src/Debugger/Impl/DebugStackFrame.cs
+++ b/src/Debugger/Impl/DebugStackFrame.cs
@@ -22,7 +22,9 @@ namespace Microsoft.R.Debugger {
 
         public int Index { get; }
 
-        internal string SysFrame => Invariant($"base::sys.frame({Index})");
+        public string EnvironmentExpression => Invariant($"base::sys.frame({Index})");
+
+        public string EnvironmentName { get; }
 
         public DebugStackFrame CallingFrame { get; }
 
@@ -32,7 +34,7 @@ namespace Microsoft.R.Debugger {
 
         public string Call { get; }
 
-        public bool IsGlobal { get; }
+        public bool IsGlobal => EnvironmentName == "<environment: R_GlobalEnv>";
 
         internal DebugStackFrameKind FrameKind { get; }
 
@@ -44,7 +46,7 @@ namespace Microsoft.R.Debugger {
             FileName = jFrame.Value<string>("filename");
             LineNumber = jFrame.Value<int?>("line_number");
             Call = jFrame.Value<string>("call");
-            IsGlobal = jFrame.Value<bool?>("is_global") ?? false;
+            EnvironmentName = jFrame.Value<string>("env_name");
 
             if (Call != null) {
                 var match = _doTraceRegex.Match(Call);

--- a/src/Debugger/Impl/rtvs/R/traceback.R
+++ b/src/Debugger/Impl/rtvs/R/traceback.R
@@ -10,6 +10,7 @@ describe_traceback <- function() {
   for (i in 1:nframe) {
     frame <- new.env();
     call <- sys.call(i);
+    env <- sys.frame(i - 1);
     
     frame$call <- if (is.null(call)) NULL else dput_str(call);
     frame$filename <- force_toString(getSrcFilename(call, full.names = TRUE));
@@ -18,11 +19,14 @@ describe_traceback <- function() {
     }
     
     frame$line_number <- force_number(getSrcLocation(call, which = 'line'));
-    
-    if (identical(globalenv(), sys.frame(i - 1))) {
-      frame$is_global <- TRUE;
-    }
-    
+
+	# For nameless environments like those of functions, it will be something useless like
+	# <environment: 0x0000000012aaabb0>, so omit it for them - callers are expected to use
+	# $call of the calling environment in that case if they need a UI label.
+	if (!identical(environmentName(env), '')) {
+	  frame$env_name <- format(env);
+	}
+   
     frames[[i]] <- frame;
   }
 

--- a/src/Debugger/Test/SourceFile.cs
+++ b/src/Debugger/Test/SourceFile.cs
@@ -17,9 +17,9 @@ namespace Microsoft.R.Debugger.Test {
             }
         }
 
-        public async Task Source(IRSession session) {
+        public async Task Source(IRSession session, bool debug = true) {
             using (IRSessionInteraction eval = await session.BeginInteractionAsync()) {
-                await eval.RespondAsync($"rtvs::debug_source({FilePath.ToRStringLiteral()})" + Environment.NewLine);
+                await eval.RespondAsync($"{(debug ? "rtvs::debug_source" : "source")}({FilePath.ToRStringLiteral()})" + Environment.NewLine);
             }
         }
 


### PR DESCRIPTION
When retrieving call stack, include formatted environment names for those environments that have them; and use those names in the Call Stack window when available.

Fix #702: Remove unnecessary stack frames from the call stack