### PR TITLE
Package manager backend

### DIFF
--- a/src/Debugger/Impl/rtvs/R/packages.R
+++ b/src/Debugger/Impl/rtvs/R/packages.R
@@ -11,7 +11,7 @@ matrix.as.lists <- function(matrix.data) {
 }
 
 packages.installed <- function() {
-    matrix.as.lists(installed.packages(fields = c('Title', 'Author')))
+    matrix.as.lists(installed.packages(fields = c('Title', 'Author', 'Description')))
 }
 
 packages.available <- function() {

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -41,6 +41,7 @@ namespace Microsoft.R.Host.Client.Session {
         private IReadOnlyList<IRContext> _contexts;
         private RHost _host;
         private Task _hostRunTask;
+        private TaskCompletionSource<object> _afterHostStartedTcs = new TaskCompletionSource<object>();
         private TaskCompletionSource<object> _initializationTcs;
         private RSessionRequestSource _currentRequestSource;
         private readonly IRHostClientApp _hostClientApp;
@@ -130,6 +131,8 @@ namespace Microsoft.R.Host.Client.Session {
                 return await CanceledEvaluateTask;
             }
 
+            await _afterHostStartedTcs.Task;
+
             try {
                 var result = await _host.EvaluateAsync(expression, kind, ct);
                 if (kind.HasFlag(REvaluationKind.Mutating)) {
@@ -176,6 +179,9 @@ namespace Microsoft.R.Host.Client.Session {
 
             var initializationTask = _initializationTcs.Task;
             _hostRunTask = CreateAndRunHost(startupInfo, timeout);
+
+            Interlocked.Exchange(ref _afterHostStartedTcs, new TaskCompletionSource<object>());
+
             ScheduleAfterHostStarted(startupInfo);
 
             await initializationTask;
@@ -248,25 +254,33 @@ namespace Microsoft.R.Host.Client.Session {
         }
 
         private async Task AfterHostStarted(RSessionEvaluationSource evaluationSource, RHostStartupInfo startupInfo) {
-            using (var evaluation = await evaluationSource.Task) {
-                // Load RTVS R package before doing anything in R since the calls
-                // below calls may depend on functions exposed from the RTVS package
-                await LoadRtvsPackage(evaluation);
-                if (startupInfo.WorkingDirectory != null) {
-                    await evaluation.SetWorkingDirectory(startupInfo.WorkingDirectory);
-                } else {
-                    await evaluation.SetDefaultWorkingDirectory();
+            try {
+                using (var evaluation = await evaluationSource.Task) {
+                    // Load RTVS R package before doing anything in R since the calls
+                    // below calls may depend on functions exposed from the RTVS package
+                    await LoadRtvsPackage(evaluation);
+                    if (startupInfo.WorkingDirectory != null) {
+                        await evaluation.SetWorkingDirectory(startupInfo.WorkingDirectory);
+                    } else {
+                        await evaluation.SetDefaultWorkingDirectory();
+                    }
+
+                    if (_hostClientApp != null) {
+                        await evaluation.SetVsGraphicsDevice();
+
+                        string mirrorUrl = _hostClientApp.CranUrlFromName(startupInfo.CranMirrorName);
+                        await evaluation.SetVsCranSelection(mirrorUrl);
+
+                        await evaluation.SetVsHelpRedirection();
+                        await evaluation.SetChangeDirectoryRedirection();
+                    }
+
+                    _afterHostStartedTcs.SetResult(null);
                 }
-
-                if (_hostClientApp != null) {
-                    await evaluation.SetVsGraphicsDevice();
-
-                    string mirrorUrl = _hostClientApp.CranUrlFromName(startupInfo.CranMirrorName);
-                    await evaluation.SetVsCranSelection(mirrorUrl);
-
-                    await evaluation.SetVsHelpRedirection();
-                    await evaluation.SetChangeDirectoryRedirection();
-                }
+            } catch (OperationCanceledException oce) {
+                _afterHostStartedTcs.TrySetCanceled(oce.CancellationToken);
+            } catch (Exception ex) {
+                _afterHostStartedTcs.TrySetException(ex);
             }
         }
 

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
 
             RSession = sessionProvider.GetOrCreate(GuidList.InteractiveWindowRSessionGuid, hostClientApp);
             History = historyProvider.CreateRHistory(this);
-            Packages = packagesProvider.CreateRPackageManager(this);
+            Packages = packagesProvider.CreateRPackageManager(sessionProvider, settings, this);
             _operations = new RInteractiveWorkflowOperations(this, _debuggerModeTracker, _coreShell);
 
             _activeTextViewTracker.LastActiveTextViewChanged += LastActiveTextViewChanged;

--- a/src/R/Components/Impl/PackageManager/IRPackageManagerProvider.cs
+++ b/src/R/Components/Impl/PackageManager/IRPackageManagerProvider.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.R.Components.InteractiveWorkflow;
+using Microsoft.R.Components.Settings;
+using Microsoft.R.Host.Client;
 
 namespace Microsoft.R.Components.PackageManager {
     public interface IRPackageManagerProvider {
-        IRPackageManager CreateRPackageManager(IRInteractiveWorkflow interactiveWorkflow);
+        IRPackageManager CreateRPackageManager(IRSessionProvider sessionProvider, IRSettings settings, IRInteractiveWorkflow interactiveWorkflow);
     }
 }

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManagerProvider.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManagerProvider.cs
@@ -3,13 +3,15 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.R.Components.InteractiveWorkflow;
+using Microsoft.R.Components.Settings;
+using Microsoft.R.Host.Client;
 
 namespace Microsoft.R.Components.PackageManager.Implementation {
     [Export(typeof(IRPackageManagerProvider))]
     internal class RPackageManagerProvider : IRPackageManagerProvider {
 
-        public IRPackageManager CreateRPackageManager(IRInteractiveWorkflow interactiveWorkflow) {
-            var pm = new RPackageManager(interactiveWorkflow, () => {});
+        public IRPackageManager CreateRPackageManager(IRSessionProvider sessionProvider, IRSettings settings, IRInteractiveWorkflow interactiveWorkflow) {
+            var pm = new RPackageManager(sessionProvider, settings, interactiveWorkflow, () => {});
             return pm;
         }
     }

--- a/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
+++ b/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
@@ -72,6 +72,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
             rtvslib1Expected.Title = null;
             rtvslib1Expected.Built = null;
             rtvslib1Expected.Author = null;
+            rtvslib1Expected.Description = null;
             rtvslib1Expected.Repository = $"file:///{_repo1Path.ToRPath()}/src/contrib";
 
             var rtvslib1Actual = result.SingleOrDefault(pkg => pkg.Package == TestPackages.RtvsLib1Description.Package);

--- a/src/R/Components/Test/PackageManager/TestPackages.cs
+++ b/src/R/Components/Test/PackageManager/TestPackages.cs
@@ -14,6 +14,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
             Author = TestPackages.RtvsLib1Description.Author,
             Title = TestPackages.RtvsLib1Description.Title,
             NeedsCompilation = "no",
+            Description = TestPackages.RtvsLib1Description.DescriptionFromInstalled,
         };
 
         public static readonly RPackage RtvsLib1Additional = new RPackage {
@@ -42,6 +43,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
             public const string Author = "RTVS Team";
             public const string Title = "The title for rtvslib1";
             public const string Description = "This is a library that is used only for testing package installation. It doesn't do anything.";
+            public const string DescriptionFromInstalled = "This is a library that is used only for testing package installation.  It doesn't do anything.";
             public const string Published = "2016-03-28";
             public const string Maintainer = "RTVS Team <rtvsuserfeedback@microsoft.com>";
         }


### PR DESCRIPTION
Fix #1439 Package Manager: GetInstalledPackagesAsync doesn't contain package description
Fix #1431 Package Manager: REPL (and all dependent code) is frozen while available packages are loaded

When dealing with the REPL session, EvaluateAsync is used so that code can execute even if the REPL is busy.

To avoid making the REPL busy while querying list of available and installed packages, the query is done in a separate session, which is initialized with the same (repo+libpath) options as the REPL session.  This is based on similar code in FunctionRdDataProvider, which uses its own host session.

Make EvaluateAsync wait for the AfterHostStarted initialization to be completed.  This is the code that loads rtvs package, among other things, which is where i was running into issues.
