### PR TITLE
Fix  #1408: Evaluation children with names that are not identifiers do not work correctly

### DIFF
--- a/src/Debugger/Impl/rtvs/R/eval.R
+++ b/src/Debugger/Impl/rtvs/R/eval.R
@@ -174,7 +174,7 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
     }
     
     for (name in names) {
-	  name <- force_toString(name);
+      name <- force_toString(name);
       # If a binding has an empty name, or it wasn't a string, it cannot be accessed, so ignore it.
       if (name == '') {
         next;
@@ -239,7 +239,7 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
     }
   
     for (name in names) {
-	  name <- force_toString(name);
+      name <- force_toString(name);
       # If a binding has an empty name, or it wasn't a string, it cannot be accessed, so ignore it.
       if (name == '') {
         next;

--- a/src/Debugger/Impl/rtvs/R/eval.R
+++ b/src/Debugger/Impl/rtvs/R/eval.R
@@ -174,12 +174,13 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
     }
     
     for (name in names) {
-      name <- force_toString(name);
-
+	  name <- force_toString(name);
       # If a binding has an empty name, or it wasn't a string, it cannot be accessed, so ignore it.
       if (name == '') {
         next;
       }
+
+      name_sym <- symbol_token(name);
 
       # Check if it's a promise, and retrieve the promise expression if it is.
       code <- tryCatch({
@@ -190,9 +191,9 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
 
       item_expr <-
         if (expr == 'base::environment()') {
-          deparse_symbol(name)
+          name_sym
         } else {
-          paste0(expr, '$', deparse_symbol(name), collapse = '')
+          paste0(expr, '$', name_sym, collapse = '')
         };
 
       if (!is.null(code)) {
@@ -218,7 +219,7 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
       }
       
       child <- list(value);
-      names(child) <- name;
+      names(child) <- name_sym;
       last_child <<- last_child + 1;
       children[[last_child]] <<- child;
     }
@@ -238,16 +239,17 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
     }
   
     for (name in names) {
-      name <- force_toString(name);
-      
-      # If the name is not a string or blank, it cannot be accessed, so ignore it.
+	  name <- force_toString(name);
+      # If a binding has an empty name, or it wasn't a string, it cannot be accessed, so ignore it.
       if (name == '') {
         next;
       }
+
+      name_sym <- symbol_token(name);
       
       # For S4 objects, slots can be accessed with '@'. For other objects, we have to
       # use slot(). Still, always use '@' as accessor name to show to the user.
-      accessor <- paste0('@', deparse_symbol(name), collapse = '');
+      accessor <- paste0('@', name_sym, collapse = '');
       if (is_S4) {
         slot_expr <- paste0('(', expr, ')', accessor, collapse = '')
       } else {
@@ -305,7 +307,7 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
           kind <- '$';
           # Named items can be accessed with '$' in lists, but other types require brackets.
           if (is.list(obj)) {
-            accessor <- paste0('$', deparse_symbol(name), collapse = '');
+            accessor <- paste0('$', symbol_token(name), collapse = '');
           } else {
             accessor <- paste0('[[', deparse_str(name), ']]', collapse = '');
           }

--- a/src/Debugger/Impl/rtvs/R/util.R
+++ b/src/Debugger/Impl/rtvs/R/util.R
@@ -10,11 +10,11 @@ external_embedded <- function(name, ...) {
 }
 
 send_message <- function(name, ...) {
-	call_embedded('send_message', name, list(...))
+    call_embedded('send_message', name, list(...))
 }
 
 send_message_and_get_response <- function(name, ...) {
-	call_embedded('send_message_and_get_response', name, list(...))
+    call_embedded('send_message_and_get_response', name, list(...))
 }
 
 memory_connection <- function(max_length = NA, expected_length = NA, overflow_suffix = '', eof_marker = '') {
@@ -97,13 +97,13 @@ symbol_token <- function(name) {
 
   # If it's an empty string, it's not a valid symbol, even if quoted.
   if (identical(s, '')) {
-  	  return(NULL);
+      return(NULL);
   }
 
   # If it's a valid identifier, it's good to go as is. Because the definition of identifier in R
   # is locale-dependent, be conservative and match ASCII only; excessive quoting is always safe.
   if (grepl('^[A-Za-z_.][A-Za-z0-9_.]*$', name)) {
-  	  return(s);
+      return(s);
   }
 
   # Deparse it - this will take care of all the necessary escaping for everything other than


### PR DESCRIPTION
Backtick-quote names as necessary.