### PR TITLE
Package Manager VM Fixes

### DIFF
--- a/src/Common/Core/Impl/Collections/ListExtensions.cs
+++ b/src/Common/Core/Impl/Collections/ListExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Common.Core.Collections {
     public static class ListExtensions {
@@ -66,6 +67,10 @@ namespace Microsoft.Common.Core.Collections {
             }
 
             return ~low;
+        }
+
+        public static bool Equals<T, TOther>(this IList<T> source, IList<TOther> other, Func<T, TOther, bool> predicate) {
+            return source.Count == other.Count && !source.Where((t, i) => !predicate(t, other[i])).Any();
         }
     }
 }

--- a/src/Common/Core/Impl/Extensions/StringExtensions.cs
+++ b/src/Common/Core/Impl/Extensions/StringExtensions.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Common.Core {
         public static int LastIndexOfIgnoreCase(this string s, string searchFor, int startIndex) {
             return s.LastIndexOf(searchFor, startIndex, StringComparison.OrdinalIgnoreCase);
         }
+        public static bool ContainsIgnoreCase(this string s, string prefix) {
+            return s.IndexOf(prefix, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
 
         public static string Replace(this string s, string oldValue, string newValue, int start, int length) {
             if (string.IsNullOrEmpty(oldValue)) {

--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -77,11 +77,46 @@ grDevices::deviceIsInteractive('ide')
             return evaluation.EvaluateAsync(script, REvaluationKind.Json);
         }
 
+        public static Task InstallPackage(this IRSessionInteraction interaction, string name) {
+            var script = $"install.packages({name.ToRStringLiteral()})\n";
+            return interaction.RespondAsync(script);
+        }
+        
+        public static Task InstallPackage(this IRSessionInteraction interaction, string name, string libraryPath) {
+            var script = $"install.packages({name.ToRStringLiteral()}, lib={libraryPath.ToRPath().ToRStringLiteral()})\n";
+            return interaction.RespondAsync(script);
+        }
+        
+        public static Task UninstallPackage(this IRSessionInteraction interaction, string name) {
+            var script = $"remove.packages({name.ToRStringLiteral()})\n";
+            return interaction.RespondAsync(script);
+        }
+
+        public static Task UninstallPackage(this IRSessionInteraction interaction, string name, string libraryPath) {
+            var script = $"remove.packages({name.ToRStringLiteral()}, lib={libraryPath.ToRPath().ToRStringLiteral()})\n";
+            return interaction.RespondAsync(script);
+        }
+
+        public static Task LoadPackage(this IRSessionInteraction interaction, string name) {
+            var script = $"library({name.ToRStringLiteral()})\n";
+            return interaction.RespondAsync(script);
+        }
+
+        public static Task LoadPackage(this IRSessionInteraction interaction, string name, string libraryPath) {
+            var script = $"library({name.ToRStringLiteral()}, lib.loc={libraryPath.ToRPath().ToRStringLiteral()})\n";
+            return interaction.RespondAsync(script);
+        }
+
+        public static Task UnloadPackage(this IRSessionInteraction interaction, string name) {
+            var script = $"unloadNamespace({name.ToRStringLiteral()})\n";
+            return interaction.RespondAsync(script);
+        }
+
         public static Task<REvaluationResult> InstalledPackages(this IRExpressionEvaluator evaluation) {
             var script = @"rtvs:::packages.installed()";
             return evaluation.EvaluateAsync(script, REvaluationKind.Json);
         }
-
+        
         public static Task<REvaluationResult> AvailablePackages(this IRExpressionEvaluator evaluation) {
             var script = @"rtvs:::packages.available()";
             return evaluation.EvaluateAsync(script, REvaluationKind.Json | REvaluationKind.Reentrant);

--- a/src/Package/Impl/PackageManager/PackageManagerWindowPane.cs
+++ b/src/Package/Impl/PackageManager/PackageManagerWindowPane.cs
@@ -8,6 +8,7 @@ using Microsoft.R.Components.PackageManager;
 using Microsoft.R.Components.PackageManager.Implementation;
 using Microsoft.R.Components.Search;
 using Microsoft.R.Components.Settings;
+using Microsoft.R.Host.Client;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.R.Package.Interop;
 using Microsoft.VisualStudio.R.Package.Shell;
@@ -17,6 +18,7 @@ using Constants = Microsoft.VisualStudio.OLE.Interop.Constants;
 namespace Microsoft.VisualStudio.R.Package.PackageManager {
     [Guid(WindowGuidString)]
     internal class PackageManagerWindowPane : VisualComponentToolWindow<IRPackageManagerVisualComponent>, IOleCommandTarget {
+        private readonly IRSession _session;
         private readonly IRPackageManager _packageManager;
         private readonly ISearchControlProvider _searchControlProvider;
         private readonly IRSettings _settings;
@@ -26,8 +28,9 @@ namespace Microsoft.VisualStudio.R.Package.PackageManager {
 
         private IOleCommandTarget _commandTarget;
 
-        public PackageManagerWindowPane(IRPackageManager packageManager, ISearchControlProvider searchControlProvider, IRSettings settings, ICoreShell coreShell) {
+        public PackageManagerWindowPane(IRPackageManager packageManager, IRSession session, ISearchControlProvider searchControlProvider, IRSettings settings, ICoreShell coreShell) {
             _packageManager = packageManager;
+            _session = session;
             _searchControlProvider = searchControlProvider;
             _settings = settings;
             _coreShell = coreShell;
@@ -35,7 +38,7 @@ namespace Microsoft.VisualStudio.R.Package.PackageManager {
         }
 
         protected override void OnCreate() {
-            Component = new RPackageManagerVisualComponent(_packageManager, this, _searchControlProvider, _settings, _coreShell);
+            Component = new RPackageManagerVisualComponent(_packageManager, this, _session, _searchControlProvider, _settings, _coreShell);
             // TODO: Implement RPackageManagerVisualComponent.Controller
             //_commandTarget = new CommandTargetToOleShim(null, Component.Controller);
 

--- a/src/Package/Impl/PackageManager/VsRPackageManagerVisualComponent.cs
+++ b/src/Package/Impl/PackageManager/VsRPackageManagerVisualComponent.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.Composition;
 using Microsoft.R.Components.PackageManager;
 using Microsoft.R.Components.Search;
 using Microsoft.R.Components.View;
+using Microsoft.R.Host.Client;
 using Microsoft.R.Support.Settings;
 using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.R.Package.Windows;
@@ -19,8 +20,8 @@ namespace Microsoft.VisualStudio.R.Package.PackageManager {
             _searchControlProvider = searchControlProvider;
         }
 
-        public IVisualComponentContainer<IRPackageManagerVisualComponent> GetOrCreate(IRPackageManager packageManager, int instanceId) {
-            return GetOrCreate(instanceId, i => new PackageManagerWindowPane(packageManager, _searchControlProvider, RToolsSettings.Current, VsAppShell.Current));
+        public IVisualComponentContainer<IRPackageManagerVisualComponent> GetOrCreate(IRPackageManager packageManager, IRSession session, int instanceId = 0) {
+            return GetOrCreate(instanceId, i => new PackageManagerWindowPane(packageManager, session, _searchControlProvider, RToolsSettings.Current, VsAppShell.Current));
         }
     }
 }

--- a/src/R/Components/Impl/PackageManager/IRPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/IRPackageManager.cs
@@ -69,36 +69,36 @@ namespace Microsoft.R.Components.PackageManager {
         /// </summary>
         /// <param name="name">Package name.</param>
         /// <param name="libraryPath">
-        /// Optional library path (in any format). Pass null to use the default
-        /// for the session ie. the first one in .libPaths().
+        ///     Optional library path (in any format). Pass null to use the default
+        ///     for the session ie. the first one in .libPaths().
         /// </param>
-        void InstallPackage(string name, string libraryPath);
+        Task InstallPackage(string name, string libraryPath);
 
         /// <summary>
         /// Uninstall a package by sending remove.packages() to the REPL.
         /// </summary>
         /// <param name="name">Package name.</param>
         /// <param name="libraryPath">
-        /// Optional library path (in any format) where the package is installed.
-        /// Pass null to use the defaults for the session ie. in .libPaths().
+        ///     Optional library path (in any format) where the package is installed.
+        ///     Pass null to use the defaults for the session ie. in .libPaths().
         /// </param>
-        void UninstallPackage(string name, string libraryPath);
+        Task UninstallPackage(string name, string libraryPath);
 
         /// <summary>
         /// Load a package by sending library() to the REPL.
         /// </summary>
         /// <param name="name">Package name.</param>
         /// <param name="libraryPath">
-        /// Optional library path (in any format). Pass null to use the defaults
-        /// for the session ie. in .libPaths().
+        ///     Optional library path (in any format). Pass null to use the defaults
+        ///     for the session ie. in .libPaths().
         /// </param>
-        void LoadPackage(string name, string libraryPath);
+        Task LoadPackage(string name, string libraryPath);
 
         /// <summary>
         /// Unload a package by sending detach() to the REPL.
         /// </summary>
         /// <param name="name">Package name.</param>
-        void UnloadPackage(string name);
+        Task UnloadPackage(string name);
 
         /// <summary>
         /// Package names that are currently loaded.

--- a/src/R/Components/Impl/PackageManager/IRPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/IRPackageManager.cs
@@ -72,7 +72,7 @@ namespace Microsoft.R.Components.PackageManager {
         ///     Optional library path (in any format). Pass null to use the default
         ///     for the session ie. the first one in .libPaths().
         /// </param>
-        Task InstallPackage(string name, string libraryPath);
+        Task InstallPackageAsync(string name, string libraryPath);
 
         /// <summary>
         /// Uninstall a package by sending remove.packages() to the REPL.
@@ -82,7 +82,7 @@ namespace Microsoft.R.Components.PackageManager {
         ///     Optional library path (in any format) where the package is installed.
         ///     Pass null to use the defaults for the session ie. in .libPaths().
         /// </param>
-        Task UninstallPackage(string name, string libraryPath);
+        Task UninstallPackageAsync(string name, string libraryPath);
 
         /// <summary>
         /// Load a package by sending library() to the REPL.
@@ -92,13 +92,13 @@ namespace Microsoft.R.Components.PackageManager {
         ///     Optional library path (in any format). Pass null to use the defaults
         ///     for the session ie. in .libPaths().
         /// </param>
-        Task LoadPackage(string name, string libraryPath);
+        Task LoadPackageAsync(string name, string libraryPath);
 
         /// <summary>
         /// Unload a package by sending detach() to the REPL.
         /// </summary>
         /// <param name="name">Package name.</param>
-        Task UnloadPackage(string name);
+        Task UnloadPackageAsync(string name);
 
         /// <summary>
         /// Package names that are currently loaded.

--- a/src/R/Components/Impl/PackageManager/IRPackageManagerVisualComponentContainerFactory.cs
+++ b/src/R/Components/Impl/PackageManager/IRPackageManagerVisualComponentContainerFactory.cs
@@ -2,9 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.R.Components.View;
+using Microsoft.R.Host.Client;
 
 namespace Microsoft.R.Components.PackageManager {
     public interface IRPackageManagerVisualComponentContainerFactory {
-        IVisualComponentContainer<IRPackageManagerVisualComponent> GetOrCreate(IRPackageManager packageManager, int instanceId = 0);
+        IVisualComponentContainer<IRPackageManagerVisualComponent> GetOrCreate(IRPackageManager packageManager, IRSession session, int instanceId = 0);
     }
 }

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -76,44 +76,74 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
                 throw new RPackageManagerException(ex.Message, ex);
             }
         }
-        
-        public void InstallPackage(string name, string libraryPath) {
-            string script;
-            if (string.IsNullOrEmpty(libraryPath)) {
-                script = $"install.packages({name.ToRStringLiteral()})";
-            } else {
-                script = $"install.packages({name.ToRStringLiteral()}, lib={libraryPath.ToRPath().ToRStringLiteral()})";
+
+        public async Task InstallPackage(string name, string libraryPath) {
+            if (!_interactiveWorkflow.RSession.IsHostRunning) {
+                throw new RPackageManagerException(Resources.PackageManager_EvalSessionNotAvailable);
             }
 
-            _interactiveWorkflow.Operations.EnqueueExpression(script, true);
+            try {
+                using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync()) {
+                    if (string.IsNullOrEmpty(libraryPath)) {
+                        await request.InstallPackage(name);
+                    } else {
+                        await request.InstallPackage(name, libraryPath);
+                    }
+                }
+            }
+            catch (MessageTransportException ex) {
+                throw new RPackageManagerException(Resources.PackageManager_TransportError, ex);
+            }
         }
 
-        public void UninstallPackage(string name, string libraryPath) {
-            string script;
-            if (string.IsNullOrEmpty(libraryPath)) {
-                script = string.Format("remove.packages({0})", name.ToRStringLiteral());
-            } else {
-                script = string.Format("remove.packages({0}, lib={1})", name.ToRStringLiteral(), libraryPath.ToRPath().ToRStringLiteral());
+        public async Task UninstallPackage(string name, string libraryPath) {
+            if (!_interactiveWorkflow.RSession.IsHostRunning) {
+                throw new RPackageManagerException(Resources.PackageManager_EvalSessionNotAvailable);
             }
 
-            _interactiveWorkflow.Operations.EnqueueExpression(script, true);
+            try {
+                using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync()) {
+                    if (string.IsNullOrEmpty(libraryPath)) {
+                        await request.UninstallPackage(name);
+                    } else {
+                        await request.UninstallPackage(name, libraryPath);
+                    }
+                }
+            } catch (MessageTransportException ex) {
+                throw new RPackageManagerException(Resources.PackageManager_TransportError, ex);
+            }
         }
 
-        public void LoadPackage(string name, string libraryPath) {
-            string script;
-            if (string.IsNullOrEmpty(libraryPath)) {
-                script = string.Format("library({0})", name.ToRStringLiteral());
-            } else {
-                script = string.Format("library({0}, lib.loc={1})", name.ToRStringLiteral(), libraryPath.ToRPath().ToRStringLiteral());
+        public async Task LoadPackage(string name, string libraryPath) {
+            if (!_interactiveWorkflow.RSession.IsHostRunning) {
+                throw new RPackageManagerException(Resources.PackageManager_EvalSessionNotAvailable);
             }
 
-            _interactiveWorkflow.Operations.EnqueueExpression(script, true);
+            try {
+                using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync()) {
+                    if (string.IsNullOrEmpty(libraryPath)) {
+                        await request.LoadPackage(name);
+                    } else {
+                        await request.LoadPackage(name, libraryPath);
+                    }
+                }
+            } catch (MessageTransportException ex) {
+                throw new RPackageManagerException(Resources.PackageManager_TransportError, ex);
+            }
         }
 
-        public void UnloadPackage(string name) {
-            string script = string.Format("unloadNamespace({0})", name.ToRStringLiteral());
+        public async Task UnloadPackage(string name) {
+            if (!_interactiveWorkflow.RSession.IsHostRunning) {
+                throw new RPackageManagerException(Resources.PackageManager_EvalSessionNotAvailable);
+            }
 
-            _interactiveWorkflow.Operations.EnqueueExpression(script, true);
+            try {
+                using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync()) {
+                    await request.UnloadPackage(name);
+                }
+            } catch (MessageTransportException ex) {
+                throw new RPackageManagerException(Resources.PackageManager_TransportError, ex);
+            }
         }
 
         public async Task<string[]> GetLoadedPackagesAsync() {

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -47,7 +47,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
                 return VisualComponent;
             }
 
-            VisualComponent = visualComponentContainerFactory.GetOrCreate(this, instanceId).Component;
+            VisualComponent = visualComponentContainerFactory.GetOrCreate(this, _interactiveWorkflow.RSession, instanceId).Component;
             return VisualComponent;
         }
 

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -77,7 +77,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             }
         }
 
-        public async Task InstallPackage(string name, string libraryPath) {
+        public async Task InstallPackageAsync(string name, string libraryPath) {
             if (!_interactiveWorkflow.RSession.IsHostRunning) {
                 throw new RPackageManagerException(Resources.PackageManager_EvalSessionNotAvailable);
             }
@@ -96,7 +96,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             }
         }
 
-        public async Task UninstallPackage(string name, string libraryPath) {
+        public async Task UninstallPackageAsync(string name, string libraryPath) {
             if (!_interactiveWorkflow.RSession.IsHostRunning) {
                 throw new RPackageManagerException(Resources.PackageManager_EvalSessionNotAvailable);
             }
@@ -114,7 +114,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             }
         }
 
-        public async Task LoadPackage(string name, string libraryPath) {
+        public async Task LoadPackageAsync(string name, string libraryPath) {
             if (!_interactiveWorkflow.RSession.IsHostRunning) {
                 throw new RPackageManagerException(Resources.PackageManager_EvalSessionNotAvailable);
             }
@@ -132,7 +132,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             }
         }
 
-        public async Task UnloadPackage(string name) {
+        public async Task UnloadPackageAsync(string name) {
             if (!_interactiveWorkflow.RSession.IsHostRunning) {
                 throw new RPackageManagerException(Resources.PackageManager_EvalSessionNotAvailable);
             }

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManagerVisualComponent.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManagerVisualComponent.cs
@@ -10,6 +10,7 @@ using Microsoft.R.Components.PackageManager.ViewModel;
 using Microsoft.R.Components.Search;
 using Microsoft.R.Components.Settings;
 using Microsoft.R.Components.View;
+using Microsoft.R.Host.Client;
 using Microsoft.R.Wpf;
 using PackageManagerControl = Microsoft.R.Components.PackageManager.Implementation.View.PackageManagerControl;
 
@@ -19,8 +20,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
         private readonly Guid SearchCategory = new Guid("B3A0CF4D-FC8A-47AB-8604-5D2EEF73872F");
         private readonly ISearchControl _searchControl;
 
-        public RPackageManagerVisualComponent(IRPackageManager packageManager, IVisualComponentContainer<IRPackageManagerVisualComponent> container, ISearchControlProvider searchControlProvider, IRSettings settings, ICoreShell coreShell) {
-            _viewModel = new RPackageManagerViewModel(packageManager, settings, coreShell);
+        public RPackageManagerVisualComponent(IRPackageManager packageManager, IVisualComponentContainer<IRPackageManagerVisualComponent> container, IRSession session, ISearchControlProvider searchControlProvider, IRSettings settings, ICoreShell coreShell) {
+            _viewModel = new RPackageManagerViewModel(packageManager, session, settings, coreShell);
             Container = container;
             Controller = null;
             var control = new PackageManagerControl {
@@ -37,6 +38,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
 
         public void Dispose() {
             _searchControl.Dispose();
+            _viewModel.Dispose();
         }
 
         public ICommandTarget Controller { get; }

--- a/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageManagerViewModel.cs
@@ -58,6 +58,9 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View.DesignTime {
         public Task<int> Search(string searchString, CancellationToken cancellationToken) {
             return Task.FromResult(0);
         }
+
+        public void Dispose() {
+        }
     }
 #endif
 }

--- a/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageManagerViewModel.cs
@@ -43,7 +43,16 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View.DesignTime {
         public void Install(IRPackageViewModel package) {
         }
 
+        public void Update(IRPackageViewModel package) {
+        }
+
         public void Uninstall(IRPackageViewModel package) {
+        }
+
+        public void Load(IRPackageViewModel package) {
+        }
+
+        public void Unload(IRPackageViewModel package) {
         }
 
         public Task<int> Search(string searchString, CancellationToken cancellationToken) {

--- a/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageViewModel.cs
@@ -69,6 +69,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View.DesignTime {
         public string Suggests { get; }
         public bool IsInstalled { get; set; }
         public bool IsLoaded { get; set; }
+        public bool IsChanging { get; set; }
 
         public bool IsUpdateAvailable { get; }
         public bool HasDetails { get; }

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
@@ -119,6 +119,7 @@
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
+                    <RowDefinition Height="16" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
@@ -65,7 +65,7 @@
 
                 <Button Grid.Row="0" Grid.Column="4" MinWidth="100" MinHeight="24" HorizontalAlignment="Left" Click="ButtonUninstall_Click"
                         Visibility="{Binding Path=IsInstalled, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"
-                        Content="{x:Static local:Resources.Uninstall}" />
+                        Content="{x:Static local:Resources.Uninstall}" IsEnabled="{Binding Path=IsChanging, Converter={x:Static wpf:Converters.Not}}" />
 
                 <!-- Row 2 -->
                 <TextBlock Grid.Row="3" Grid.Column="0" FontWeight="Bold" Margin="0,4,0,0" Text="{x:Static local:Resources.Package_LatestVersion}" />
@@ -75,9 +75,11 @@
 
                 <!-- install button and update button. They are in fact the same button. Which one is displayed depends on whether InstalledVersion is null. -->
                 <Button Grid.Row="3" Grid.Column="4" MinWidth="100" MinHeight="24" HorizontalAlignment="Left" Click="ButtonInstall_Click" Content="{x:Static local:Resources.Install}"
-                        Visibility="{Binding Path=IsInstalled, Converter={x:Static wpf:Converters.TrueIsCollapsed}}" />
+                        Visibility="{Binding Path=IsInstalled, Converter={x:Static wpf:Converters.TrueIsCollapsed}}"
+                        IsEnabled="{Binding Path=IsChanging, Converter={x:Static wpf:Converters.Not}}" />
 
-                <Button Grid.Row="3" Grid.Column="4" MinWidth="100" MinHeight="24" HorizontalAlignment="Left" Click="ButtonInstall_Click" Content="{x:Static local:Resources.Update}">
+                <Button Grid.Row="3" Grid.Column="4" MinWidth="100" MinHeight="24" HorizontalAlignment="Left" Click="ButtonInstall_Click" Content="{x:Static local:Resources.Update}"
+                        IsEnabled="{Binding Path=IsChanging, Converter={x:Static wpf:Converters.Not}}">
                     <Button.Visibility>
                         <MultiBinding Converter="{x:Static wpf:Converters.AllIsNotCollapsed}" Mode="OneWay">
                             <Binding Path="IsUpdateAvailable" />

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
@@ -49,6 +49,7 @@
                     <Grid Margin="16,8,7,8" MinHeight="32">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
@@ -57,9 +58,23 @@
                         <CheckBox Grid.Column="0" Margin="0,1,8,0" VerticalAlignment="Center" IsChecked="{Binding Path=IsSelected}"
                                   Visibility="{Binding Path=CheckBoxesEnabled, RelativeSource={RelativeSource AncestorType={x:Type view:PackageList}}, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
 
+                        <!-- Load button -->
+                        <Button x:Name="ButtonLoad" Grid.Column="1" Style="{StaticResource ButtonStyle}" Click="ButtonLoad_Click" 
+                                        Visibility="{Binding Path=IsLoaded, Converter={x:Static wpf:Converters.TrueIsCollapsed}}" VerticalAlignment="Center"
+                                        ToolTip="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_LoadButtonToolTip}}">
+                            <Rectangle Fill="{StaticResource IconLoad}" Width="16" Height="16" />
+                        </Button>
+
+                        <!-- Unload button -->
+                        <Button x:Name="ButtonUnload" Grid.Column="1" Style="{StaticResource ButtonStyle}" Click="ButtonUnload_Click" 
+                                        Visibility="{Binding Path=IsLoaded, Converter={x:Static wpf:Converters.FalseIsCollapsed}}" VerticalAlignment="Center"
+                                        ToolTip="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_UnloadButtonToolTip}}">
+                            <Rectangle Fill="{StaticResource IconUnload}" Width="16" Height="16" />
+                        </Button>
+
                         <!-- title & summary-->
-                        <TextBlock Grid.Column="1" FontWeight="Bold" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" VerticalAlignment="Center" Text="{Binding Path=Name, Mode=OneWay}"
-                                   FontSize="{Binding ElementName=_self, Path=FontSize, Converter={x:Static wpf:Converters.FontScale122}}">
+                        <TextBlock Grid.Column="2" FontWeight="Bold" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" VerticalAlignment="Center" Text="{Binding Path=Name, Mode=OneWay}"
+                                   FontSize="{Binding ElementName=_self, Path=FontSize, Converter={x:Static wpf:Converters.FontScale122}}" Margin="4,0,0,0">
                             <TextBlock.ToolTip>
                                 <TextBlock Style="{StaticResource TooltipStyle}" Visibility="{Binding Path=Title, Mode=OneWay, Converter={x:Static wpf:Converters.NullOrEmptyIsCollapsed}}">
                                     <Run Text="{Binding Path=Name, Mode=OneWay}" FontWeight="Bold" />
@@ -69,7 +84,7 @@
                             </TextBlock.ToolTip>
                         </TextBlock>
 
-                        <Grid Grid.Column="2" VerticalAlignment="Center" Margin="10,0,0,0">
+                        <Grid Grid.Column="3" VerticalAlignment="Center" Margin="10,0,0,0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="auto" />
                                 <ColumnDefinition Width="auto" />
@@ -77,21 +92,11 @@
                                 <ColumnDefinition Width="auto" />
                             </Grid.ColumnDefinitions>
 
-                            <Grid Grid.Column="0" HorizontalAlignment="Right" Visibility="{Binding Path=IsInstalled, Converter={x:Static wpf:Converters.FalseIsCollapsed}}">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="auto" />
-                                    <ColumnDefinition Width="auto" />
-                                </Grid.ColumnDefinitions>
-
-                                <!-- installed indicator -->
-                                <Rectangle x:Name="_installedIndicator" Grid.Column="0" Width="12" Height="12" VerticalAlignment="Center"
-                                           Fill="{StaticResource IconGrayInstalledIndicator}" />
-
-                                <!-- installed version -->
-                                <TextBlock x:Name="TextInstalledVersion" Grid.Column="1" Margin="4,0,4,0" VerticalAlignment="Center"
-                                           Text="{Binding Path=InstalledVersion, StringFormat={}v{0}}"
-                                           ToolTip="{Binding Path=InstalledVersion, StringFormat={x:Static components:Resources.PackageManager_InstalledVersionToolTip}}" />
-                            </Grid>
+                            <!-- installed version -->
+                            <TextBlock x:Name="TextInstalledVersion" Grid.Column="0" Margin="4,0,4,0" VerticalAlignment="Center"
+                                       Text="{Binding Path=InstalledVersion, StringFormat={}v{0}}" HorizontalAlignment="Right"
+                                       Visibility="{Binding Path=IsInstalled, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"
+                                       ToolTip="{Binding Path=InstalledVersion, StringFormat={x:Static components:Resources.PackageManager_InstalledVersionToolTip}}" />
 
                             <!-- version to install. It occupies the same position as the installed version -->
                             <TextBlock x:Name="_versionToInstall" Grid.Column="0" Margin="2,0,4,0" VerticalAlignment="Center" TextAlignment="Right"
@@ -101,7 +106,7 @@
                             </TextBlock>
 
                             <!-- uninstall button -->
-                            <Button x:Name="ButtonUninstall" Style="{StaticResource ButtonStyle}" Grid.Column="1" Click="ButtonUninstall_Click"
+                            <Button x:Name="ButtonUninstall" Grid.Column="1" Style="{StaticResource ButtonStyle}" Click="ButtonUninstall_Click"
                                     Visibility="{Binding Path=IsInstalled, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"
                                     ToolTip="{x:Static components:Resources.PackageManager_UninstallButtonToolTip}">
                                 <Rectangle Fill="{StaticResource IconUninstall}" Width="16" Height="16" />

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
@@ -46,7 +46,7 @@
 
             <DataTemplate x:Key="PackageInfoTemplate" DataType="{x:Type viewModel:IRPackageViewModel}">
                 <Border BorderThickness="0,0,0,0" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" Background="Transparent" x:Name="Container">
-                    <Grid Margin="16,8,7,8" MinHeight="32">
+                    <Grid Margin="8,8,7,8" MinHeight="32">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
@@ -59,9 +59,14 @@
                                   Visibility="{Binding Path=CheckBoxesEnabled, RelativeSource={RelativeSource AncestorType={x:Type view:PackageList}}, Converter={x:Static wpf:Converters.FalseIsCollapsed}}"/>
 
                         <!-- Load button -->
-                        <Button x:Name="ButtonLoad" Grid.Column="1" Style="{StaticResource ButtonStyle}" Click="ButtonLoad_Click" 
-                                        Visibility="{Binding Path=IsLoaded, Converter={x:Static wpf:Converters.TrueIsCollapsed}}" VerticalAlignment="Center"
-                                        ToolTip="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_LoadButtonToolTip}}">
+                        <Button x:Name="ButtonLoad" Grid.Column="1" Style="{StaticResource ButtonStyle}" Click="ButtonLoad_Click"
+                                VerticalAlignment="Center" ToolTip="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_LoadButtonToolTip}}">
+                            <Button.Visibility>
+                                <MultiBinding Converter="{x:Static wpf:Converters.AllIsNotHidden}">
+                                    <Binding Path="IsLoaded" Converter="{x:Static wpf:Converters.Not}" />
+                                    <Binding Path="IsInstalled" />
+                                </MultiBinding>
+                            </Button.Visibility>
                             <Rectangle Fill="{StaticResource IconLoad}" Width="16" Height="16" />
                         </Button>
 

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml.cs
@@ -42,7 +42,12 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View {
         }
 
         private void ButtonUpdate_Click(object sender, RoutedEventArgs e) {
-            throw new NotImplementedException();
+            var package = GetPackage(e);
+            Model?.Update(package);
+        }
+
+        private static IRPackageViewModel GetPackage(RoutedEventArgs e) {
+            return ((IRPackageViewModel)((FrameworkElement)e.Source).DataContext);
         }
 
         private void List_PreviewKeyUp(object sender, KeyEventArgs e) {
@@ -54,11 +59,23 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View {
         }
 
         private void ButtonUninstall_Click(object sender, RoutedEventArgs e) {
-            ((IRPackageViewModel)((FrameworkElement)e.Source).DataContext).Uninstall();
+            var package = GetPackage(e);
+            Model?.Uninstall(package);
         }
 
         private void ButtonInstall_Click(object sender, RoutedEventArgs e) {
-            ((IRPackageViewModel)((FrameworkElement)e.Source).DataContext).Install();
+            var package = GetPackage(e);
+            Model?.Install(package);
+        }
+
+        private void ButtonLoad_Click(object sender, RoutedEventArgs e) {
+            var package = GetPackage(e);
+            Model?.Load(package);
+        }
+
+        private void ButtonUnload_Click(object sender, RoutedEventArgs e) {
+            var package = GetPackage(e);
+            Model?.Unload(package);
         }
     }
 }

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageManagerControl.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageManagerControl.xaml
@@ -104,7 +104,7 @@
                     <Border Grid.Column="6" x:Name="SearchControlHost" VerticalAlignment="Center" HorizontalAlignment="Stretch" MinHeight="22" MinWidth="224" />
 
                     <!-- Settings button -->
-                    <Button Grid.Column="8" x:Name="ButtonSettings" VerticalAlignment="Center" Padding="0" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" IsEnabled="False" Click="ButtonSettings_Click">
+                    <Button Grid.Column="8" x:Name="ButtonSettings" VerticalAlignment="Center" Padding="0" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" Visibility="Hidden" Click="ButtonSettings_Click">
                         <Rectangle Width="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={x:Static rwpf:Converters.FontScale122}}"
                                    Height="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={x:Static rwpf:Converters.FontScale122}}"
                                    Fill="{StaticResource IconSettings}" />

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageManagerResources.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageManagerResources.xaml
@@ -77,24 +77,48 @@
         </DrawingBrush.Drawing>
     </DrawingBrush>
 
-    <DrawingBrush x:Key="IconInstalledIndicator">
+    <DrawingBrush x:Key="IconGrayLoad">
         <DrawingBrush.Drawing>
             <DrawingGroup>
                 <DrawingGroup.Children>
                     <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M0,8C0,3.582 3.582,0 8,0 12.418,0 16,3.582 16,8 16,12.418 12.418,16 8,16 3.582,16 0,12.418 0,8" />
-                    <GeometryDrawing Brush="#FF329932" Geometry="F1M8,12L6,12 4,8 6,8 7,10 10,4 12,4z M8,1C4.135,1 1,4.134 1,8 1,11.865 4.135,15 8,15 11.865,15 15,11.865 15,8 15,4.134 11.865,1 8,1" />
-                    <GeometryDrawing Brush="#FFFFFFFF" Geometry="F1M12,4L8,12 6,12 4,8 6,8 7,10 10,4z" />
+                    <GeometryDrawing Brush="Gray" Geometry="F1M8,1C4.135,1 1,4.134 1,8 1,11.865 4.135,15 8,15 11.865,15 15,11.865 15,8 15,4.134 11.865,1 8,1" />
+                    <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M8,2C4.6871429,2,2,4.6862857,2,8c0,3.312857,2.6871429,6,6,6,3.312857,0,6,-2.687143,6,-6 C14,4.6862857,11.312857,2,8,2" />
                 </DrawingGroup.Children>
             </DrawingGroup>
         </DrawingBrush.Drawing>
     </DrawingBrush>
 
-    <DrawingBrush x:Key="IconGrayInstalledIndicator">
+    <DrawingBrush x:Key="IconLoad">
+        <DrawingBrush.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M0,8C0,3.582 3.582,0 8,0 12.418,0 16,3.582 16,8 16,12.418 12.418,16 8,16 3.582,16 0,12.418 0,8" />
+                    <GeometryDrawing Brush="#FF329932" Geometry="F1M8,1C4.135,1 1,4.134 1,8 1,11.865 4.135,15 8,15 11.865,15 15,11.865 15,8 15,4.134 11.865,1 8,1" />
+                    <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M8,2C4.6871429,2,2,4.6862857,2,8c0,3.312857,2.6871429,6,6,6,3.312857,0,6,-2.687143,6,-6 C14,4.6862857,11.312857,2,8,2" />
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingBrush.Drawing>
+    </DrawingBrush>
+    
+    <DrawingBrush x:Key="IconGrayUnload">
         <DrawingBrush.Drawing>
             <DrawingGroup>
                 <DrawingGroup.Children>
                     <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M0,8C0,3.582 3.582,0 8,0 12.418,0 16,3.582 16,8 16,12.418 12.418,16 8,16 3.582,16 0,12.418 0,8" />
                     <GeometryDrawing Brush="Gray" Geometry="F1M8,12L6,12 4,8 6,8 7,10 10,4 12,4z M8,1C4.135,1 1,4.134 1,8 1,11.865 4.135,15 8,15 11.865,15 15,11.865 15,8 15,4.134 11.865,1 8,1" />
+                    <GeometryDrawing Brush="#FFFFFFFF" Geometry="F1M12,4L8,12 6,12 4,8 6,8 7,10 10,4z" />
+                </DrawingGroup.Children>
+            </DrawingGroup>
+        </DrawingBrush.Drawing>
+    </DrawingBrush>
+    
+    <DrawingBrush x:Key="IconUnload">
+        <DrawingBrush.Drawing>
+            <DrawingGroup>
+                <DrawingGroup.Children>
+                    <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M0,8C0,3.582 3.582,0 8,0 12.418,0 16,3.582 16,8 16,12.418 12.418,16 8,16 3.582,16 0,12.418 0,8" />
+                    <GeometryDrawing Brush="#FF329932" Geometry="F1M8,12L6,12 4,8 6,8 7,10 10,4 12,4z M8,1C4.135,1 1,4.134 1,8 1,11.865 4.135,15 8,15 11.865,15 15,11.865 15,8 15,4.134 11.865,1 8,1" />
                     <GeometryDrawing Brush="#FFFFFFFF" Geometry="F1M12,4L8,12 6,12 4,8 6,8 7,10 10,4z" />
                 </DrawingGroup.Children>
             </DrawingGroup>

--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Documents;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.Collections;
 using Microsoft.Common.Core.Shell;
@@ -21,6 +22,7 @@ using Microsoft.R.Host.Client;
 namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
     internal class RPackageManagerViewModel : BindableBase, IRPackageManagerViewModel {
         private readonly IRPackageManager _packageManager;
+        private readonly IRSession _session;
         private readonly IRSettings _settings;
         private readonly ICoreShell _coreShell;
         private readonly BinaryAsyncLock _availableLock;
@@ -37,8 +39,9 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
         private IRPackageViewModel _selectedPackage;
         private static readonly Comparer<IRPackageViewModel> _comparer = Comparer<IRPackageViewModel>.Create((p1, p2) => string.Compare(p1.Name, p2.Name, StringComparison.InvariantCultureIgnoreCase));
 
-        public RPackageManagerViewModel(IRPackageManager packageManager, IRSettings settings, ICoreShell coreShell) {
+        public RPackageManagerViewModel(IRPackageManager packageManager, IRSession session, IRSettings settings, ICoreShell coreShell) {
             _packageManager = packageManager;
+            _session = session;
             _settings = settings;
             _coreShell = coreShell;
             _selectedTab = SelectedTab.None;
@@ -49,6 +52,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             _installedAndLoadedLock = new BinaryAsyncLock();
             _items = new BatchObservableCollection<object>();
             Items = new ReadOnlyObservableCollection<object>(_items);
+
+            _session.Mutated += RSessionMutated;
         }
 
         public ReadOnlyObservableCollection<object> Items { get; }
@@ -88,7 +93,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
 
             _selectedTab = SelectedTab.InstalledPackages;
-            DispatchOnMainThread(RefreshInstalledPackagesAsync);
+            DispatchOnMainThread(SwitchToInstalledPackagesAsync);
         }
 
         public void SwitchToLoadedPackages() {
@@ -98,7 +103,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
 
             _selectedTab = SelectedTab.LoadedPackages;
-            DispatchOnMainThread(RefreshLoadedPackagesAsync);
+            DispatchOnMainThread(SwitchToLoadedPackagesAsync);
         }
 
         public void ReloadItems() {
@@ -148,15 +153,24 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                 return;
             }
 
+            package.IsChanging = true;
             DispatchOnMainThread(() => InstallAsync(package));
         }
 
         private async Task InstallAsync(IRPackageViewModel package) {
             _coreShell.AssertIsOnMainThread();
+            if (_selectedTab == SelectedTab.InstalledPackages) {
+                IsLoading = true;
+            }
 
             var libPath = await GetLibPath();
             await _packageManager.InstallPackage(package.Name, libPath);
-            await RefreshInstalledPackagesAsync();
+            await ReloadInstalledAndLoadedPackagesAsync();
+
+            if (_selectedTab == SelectedTab.InstalledPackages) {
+                IsLoading = false;
+                ReplaceItems(_installedPackages);
+            }
         }
 
         public void Uninstall(IRPackageViewModel package) {
@@ -164,13 +178,24 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                 return;
             }
 
+            package.IsChanging = true;
             DispatchOnMainThread(() => UninstallAsync(package));
         }
 
         private async Task UninstallAsync(IRPackageViewModel package) {
+            _coreShell.AssertIsOnMainThread();
+            if (_selectedTab == SelectedTab.InstalledPackages) {
+                IsLoading = true;
+            }
+
             var libPath = await GetLibPath();
             await _packageManager.UninstallPackage(package.Name, libPath);
-            await RefreshInstalledPackagesAsync();
+            await ReloadInstalledAndLoadedPackagesAsync();
+
+            if (_selectedTab == SelectedTab.InstalledPackages) {
+                IsLoading = false;
+                ReplaceItems(_installedPackages);
+            }
         }
 
         public void Load(IRPackageViewModel package) {
@@ -178,15 +203,18 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                 return;
             }
 
+            package.IsChanging = true;
             DispatchOnMainThread(() => LoadAsync(package));
         }
 
         private async Task LoadAsync(IRPackageViewModel package) {
             _coreShell.AssertIsOnMainThread();
+            BeforeLoadUnload();
 
-            var libPath = await GetLibPath();
-            await _packageManager.LoadPackage(package.Name, libPath);
-            await RefreshLoadedPackagesAsync();
+            await _packageManager.LoadPackage(package.Name, package.RepositoryUri?.AbsolutePath.ToRPath());
+            await ReloadLoadedPackagesAsync();
+
+            AfterLoadUnload();
         }
 
         public void Unload(IRPackageViewModel package) {
@@ -194,12 +222,31 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                 return;
             }
 
+            package.IsChanging = true;
             DispatchOnMainThread(() => UnloadAsync(package));
         }
 
         private async Task UnloadAsync(IRPackageViewModel package) {
+            _coreShell.AssertIsOnMainThread();
+            BeforeLoadUnload();
+
             await _packageManager.UnloadPackage(package.Name);
-            await RefreshLoadedPackagesAsync();
+            await ReloadLoadedPackagesAsync();
+
+            AfterLoadUnload();
+        }
+
+        private void BeforeLoadUnload() {
+            if (_selectedTab == SelectedTab.InstalledPackages || _selectedTab == SelectedTab.LoadedPackages) {
+                IsLoading = true;
+            }
+        }
+
+        private void AfterLoadUnload() {
+            if (_selectedTab == SelectedTab.InstalledPackages) {
+                IsLoading = false;
+                ReplaceItems(_installedPackages);
+            }
         }
 
         private async Task AddPackageDetailsAsync(IRPackageViewModel package) {
@@ -267,7 +314,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             _availablePackages = vmAvailablePackages.OrderBy(p => p.Name).ToList();
         }
 
-        private async Task RefreshInstalledPackagesAsync() {
+        private async Task SwitchToInstalledPackagesAsync() {
             _coreShell.AssertIsOnMainThread();
             if (_selectedTab == SelectedTab.InstalledPackages) {
                 IsLoading = true;
@@ -305,10 +352,13 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
 
             var installedPackages = getInstalledPackagesTask.Result;
             if (!_availableLock.IsCompleted) {
-                _installedPackages = installedPackages
+                var vmInstalledPackages = installedPackages
                     .Select(package => RPackageViewModel.CreateInstalled(package, this))
                     .OrderBy(p => p.Name)
                     .ToList<IRPackageViewModel>();
+
+                await UpdateLoadedPackages(vmInstalledPackages);
+                _installedPackages = vmInstalledPackages;
                 DispatchOnMainThread(EnsureAvailablePackagesLoadedAsync);
             } else {
                 var vmAvailablePackages = _availablePackages.ToDictionary(k => k.Name);
@@ -324,13 +374,44 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                     }
                 }
 
-                _installedPackages = vmInstalledPackages.OrderBy(p => p.Name).ToList();
-            }
+                vmInstalledPackages = vmInstalledPackages.OrderBy(p => p.Name).ToList();
 
-            var loadedPackageNames = await _packageManager.GetLoadedPackagesAsync();
-            var vmLoadedPackages = _installedPackages.Where(p => loadedPackageNames.Contains(p.Name)).ToList();
-            foreach (var package in vmLoadedPackages) {
-                package.IsLoaded = true;
+                await UpdateLoadedPackages(vmInstalledPackages);
+                _installedPackages = vmInstalledPackages;
+            }
+        }
+
+        private async Task ReloadLoadedPackagesAsync() {
+            await TaskUtilities.SwitchToBackgroundThread();
+            try {
+                var currentLoadedPackages = _loadedPackages;
+                var currentInstalledPackages = _installedPackages;
+                var loadedPackageNames = (await _packageManager.GetLoadedPackagesAsync()).OrderBy(n => n).ToList();
+
+                if (loadedPackageNames.Equals(currentLoadedPackages, (n, p) => n.EqualsIgnoreCase(p.Name))) {
+                    return;
+                }
+
+                await UpdateLoadedPackages(currentInstalledPackages, loadedPackageNames);
+                _coreShell.DispatchOnUIThread(() => {
+                    if (_selectedTab == SelectedTab.LoadedPackages) {
+                        IsLoading = false;
+                        ReplaceItems(_loadedPackages);
+                    }
+                });
+            } catch (RPackageManagerException ex) {
+            } 
+        }
+
+        private async Task UpdateLoadedPackages(IList<IRPackageViewModel> installedPackages, IList<string> loadedPackageNames = null) {
+            loadedPackageNames = loadedPackageNames ?? await _packageManager.GetLoadedPackagesAsync();
+
+            var vmLoadedPackages = new List<IRPackageViewModel>();
+            foreach (var package in installedPackages) {
+                package.IsLoaded = loadedPackageNames.Contains(package.Name);
+                if (package.IsLoaded) {
+                    vmLoadedPackages.Add(package);
+                }
             }
 
             _loadedPackages = vmLoadedPackages;
@@ -341,10 +422,11 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             foreach (var package in _installedPackages) {
                 package.IsInstalled = false;
                 package.IsLoaded = false;
+                package.IsChanging = false;
             }
         }
 
-        private async Task RefreshLoadedPackagesAsync() {
+        private async Task SwitchToLoadedPackagesAsync() {
             _coreShell.AssertIsOnMainThread();
             if (_installedAndLoadedLock.IsCompleted) {
                 ReplaceItems(_loadedPackages);
@@ -407,7 +489,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                     return filteredPackages.Count;
                 }
 
-                if (package.Name.StartsWithIgnoreCase(searchString)) {
+                if (package.Name.ContainsIgnoreCase(searchString)) {
                     filteredPackages.Add(package);
                 }
             }
@@ -423,6 +505,14 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
 
             _items.ReplaceWith(packages);
+        }
+
+        private void RSessionMutated(object sender, EventArgs e) {
+            ReloadLoadedPackagesAsync().DoNotWait();
+        }
+
+        public void Dispose() {
+            _session.Mutated -= RSessionMutated;
         }
 
         private enum SelectedTab {

--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
@@ -164,7 +164,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
 
             var libPath = await GetLibPath();
-            await _packageManager.InstallPackage(package.Name, libPath);
+            await _packageManager.InstallPackageAsync(package.Name, libPath);
             await ReloadInstalledAndLoadedPackagesAsync();
 
             if (_selectedTab == SelectedTab.InstalledPackages) {
@@ -189,7 +189,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
 
             var libPath = await GetLibPath();
-            await _packageManager.UninstallPackage(package.Name, libPath);
+            await _packageManager.UninstallPackageAsync(package.Name, libPath);
             await ReloadInstalledAndLoadedPackagesAsync();
 
             if (_selectedTab == SelectedTab.InstalledPackages) {
@@ -211,7 +211,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             _coreShell.AssertIsOnMainThread();
             BeforeLoadUnload();
 
-            await _packageManager.LoadPackage(package.Name, package.RepositoryUri?.AbsolutePath.ToRPath());
+            await _packageManager.LoadPackageAsync(package.Name, package.RepositoryUri?.AbsolutePath.ToRPath());
             await ReloadLoadedPackagesAsync();
 
             AfterLoadUnload(package);
@@ -230,7 +230,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             _coreShell.AssertIsOnMainThread();
             BeforeLoadUnload();
 
-            await _packageManager.UnloadPackage(package.Name);
+            await _packageManager.UnloadPackageAsync(package.Name);
             await ReloadLoadedPackagesAsync();
 
             AfterLoadUnload(package);

--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
@@ -214,7 +214,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             await _packageManager.LoadPackage(package.Name, package.RepositoryUri?.AbsolutePath.ToRPath());
             await ReloadLoadedPackagesAsync();
 
-            AfterLoadUnload();
+            AfterLoadUnload(package);
         }
 
         public void Unload(IRPackageViewModel package) {
@@ -233,7 +233,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             await _packageManager.UnloadPackage(package.Name);
             await ReloadLoadedPackagesAsync();
 
-            AfterLoadUnload();
+            AfterLoadUnload(package);
         }
 
         private void BeforeLoadUnload() {
@@ -242,7 +242,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
         }
 
-        private void AfterLoadUnload() {
+        private void AfterLoadUnload(IRPackageViewModel package) {
+            package.IsChanging = false;
             if (_selectedTab == SelectedTab.InstalledPackages) {
                 IsLoading = false;
                 ReplaceItems(_installedPackages);

--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageViewModel.cs
@@ -12,6 +12,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
         private readonly IRPackageManagerViewModel _owner;
         private bool _hasDetails;
         private bool _isSelected;
+        private bool _isChanging;
         private bool _isInstalled;
         private bool _isLoaded;
         private string _title;
@@ -145,6 +146,11 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
         public bool IsSelected {
             get { return _isSelected; }
             set { SetProperty(ref _isSelected, value); }
+        }
+
+        public bool IsChanging {
+            get { return _isChanging; }
+            set { SetProperty(ref _isChanging, value); }
         }
 
         public RPackageViewModel(string name, IRPackageManagerViewModel owner) {

--- a/src/R/Components/Impl/PackageManager/ViewModel/IRPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/ViewModel/IRPackageManagerViewModel.cs
@@ -17,6 +17,9 @@ namespace Microsoft.R.Components.PackageManager.ViewModel {
         void ReloadItems();
         void SelectPackage(IRPackageViewModel package);
         void Install(IRPackageViewModel package);
+        void Update(IRPackageViewModel package);
         void Uninstall(IRPackageViewModel package);
+        void Load(IRPackageViewModel package);
+        void Unload(IRPackageViewModel package);
     }
 }

--- a/src/R/Components/Impl/PackageManager/ViewModel/IRPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/ViewModel/IRPackageManagerViewModel.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.ObjectModel;
 using Microsoft.R.Components.Search;
 
 namespace Microsoft.R.Components.PackageManager.ViewModel {
-    public interface IRPackageManagerViewModel : ISearchHandler {
+    public interface IRPackageManagerViewModel : ISearchHandler, IDisposable {
         ReadOnlyObservableCollection<object> Items { get; } 
         IRPackageViewModel SelectedPackage { get; }
         bool IsLoading { get; }

--- a/src/R/Components/Impl/PackageManager/ViewModel/IRPackageViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/ViewModel/IRPackageViewModel.cs
@@ -30,6 +30,8 @@ namespace Microsoft.R.Components.PackageManager.ViewModel {
         bool IsUpdateAvailable { get; }
         bool HasDetails { get; }
         bool IsSelected { get; set; }
+        bool IsChanging { get; set; }
+
         void AddDetails(RPackage package, bool isInstalled);
         void UpdateAvailablePackageDetails(RPackage package);
         void Install();

--- a/src/R/Components/Impl/Resources.Designer.cs
+++ b/src/R/Components/Impl/Resources.Designer.cs
@@ -367,6 +367,15 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Load {0}..
+        /// </summary>
+        public static string PackageManager_LoadButtonToolTip {
+            get {
+                return ResourceManager.GetString("PackageManager_LoadButtonToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loaded.
         /// </summary>
         public static string PackageManager_Loaded {
@@ -471,6 +480,15 @@ namespace Microsoft.R.Components {
         public static string PackageManager_UninstallButtonToolTip {
             get {
                 return ResourceManager.GetString("PackageManager_UninstallButtonToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unload {0}..
+        /// </summary>
+        public static string PackageManager_UnloadButtonToolTip {
+            get {
+                return ResourceManager.GetString("PackageManager_UnloadButtonToolTip", resourceCulture);
             }
         }
         

--- a/src/R/Components/Impl/Resources.resx
+++ b/src/R/Components/Impl/Resources.resx
@@ -249,6 +249,12 @@
   <data name="PackageManager_UpdateAvailableToolTip" xml:space="preserve">
     <value>Update available</value>
   </data>
+  <data name="PackageManager_LoadButtonToolTip" xml:space="preserve">
+    <value>Load {0}.</value>
+  </data>
+  <data name="PackageManager_UnloadButtonToolTip" xml:space="preserve">
+    <value>Unload {0}.</value>
+  </data>
   <data name="PackageManager_InstallButtonToolTip" xml:space="preserve">
     <value>Install {0} version {1}.</value>
   </data>

--- a/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
+++ b/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
@@ -212,7 +212,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
                 await SetLocalRepoAsync(eval, _repo1Path);
             }
 
-            await _workflow.Packages.InstallPackage(TestPackages.RtvsLib1Description.Package, _libPath);
+            await _workflow.Packages.InstallPackageAsync(TestPackages.RtvsLib1Description.Package, _libPath);
 
             using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
                 await SetLocalLibsAsync(eval, _libPath);
@@ -221,7 +221,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
             var installed = await _workflow.Packages.GetInstalledPackagesAsync();
             ValidateRtvslib1Installed(installed, _libPath);
 
-            await _workflow.Packages.UninstallPackage(TestPackages.RtvsLib1Description.Package, _libPath);
+            await _workflow.Packages.UninstallPackageAsync(TestPackages.RtvsLib1Description.Package, _libPath);
 
             installed = await _workflow.Packages.GetInstalledPackagesAsync();
             installed.Should().NotContain(pkg => pkg.Package == TestPackages.RtvsLib1Description.Package && pkg.LibPath == _libPath.ToRPath());
@@ -235,7 +235,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
                 await SetLocalLibsAsync(eval, _libPath);
             }
 
-            await _workflow.Packages.InstallPackage(TestPackages.RtvsLib1Description.Package, null);
+            await _workflow.Packages.InstallPackageAsync(TestPackages.RtvsLib1Description.Package, null);
 
             var installed = await _workflow.Packages.GetInstalledPackagesAsync();
             ValidateRtvslib1Installed(installed, _libPath);
@@ -252,14 +252,14 @@ namespace Microsoft.R.Components.Test.PackageManager {
 
             await EvaluateCode("func1();", expectedError: "Error: could not find function \"func1\"");
 
-            await _workflow.Packages.LoadPackage(TestPackages.RtvsLib1Description.Package, null);
+            await _workflow.Packages.LoadPackageAsync(TestPackages.RtvsLib1Description.Package, null);
 
             await EvaluateCode("func1();", expectedResult: "func1");
 
             var loaded = await _workflow.Packages.GetLoadedPackagesAsync();
             loaded.Should().Contain("rtvslib1");
 
-            await _workflow.Packages.UnloadPackage(TestPackages.RtvsLib1Description.Package);
+            await _workflow.Packages.UnloadPackageAsync(TestPackages.RtvsLib1Description.Package);
 
             await EvaluateCode("func1();", expectedError: "Error: could not find function \"func1\"");
 

--- a/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
+++ b/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
@@ -16,7 +16,6 @@ using Microsoft.R.Components.Test.Fakes.InteractiveWindow;
 using Microsoft.R.Host.Client;
 using Microsoft.R.Host.Client.Test.Script;
 using Microsoft.R.Support.Settings;
-using Microsoft.UnitTests.Core.Threading;
 using Microsoft.UnitTests.Core.XUnit;
 using Xunit;
 
@@ -25,7 +24,6 @@ namespace Microsoft.R.Components.Test.PackageManager {
         private readonly ExportProvider _exportProvider;
         private readonly TestRInteractiveWorkflowProvider _workflowProvider;
         private readonly MethodInfo _testMethod;
-        private readonly TestFilesFixture _testFiles;
         private readonly string _repo1Path;
         private readonly string _libPath;
         private readonly string _lib2Path;
@@ -35,11 +33,10 @@ namespace Microsoft.R.Components.Test.PackageManager {
             _exportProvider = catalog.CreateExportProvider();
             _workflowProvider = _exportProvider.GetExportedValue<TestRInteractiveWorkflowProvider>();
             _testMethod = testMethod.MethodInfo;
-            _testFiles = testFiles;
             _workflowProvider.HostClientApp = new RHostClientTestApp();
-            _repo1Path = _testFiles.GetDestinationPath(Path.Combine("Repos", TestRepositories.Repo1));
-            _libPath = Path.Combine(_testFiles.GetDestinationPath("library"), _testMethod.Name);
-            _lib2Path = Path.Combine(_testFiles.GetDestinationPath("library2"), _testMethod.Name);
+            _repo1Path = testFiles.GetDestinationPath(Path.Combine("Repos", TestRepositories.Repo1));
+            _libPath = Path.Combine(testFiles.GetDestinationPath("library"), _testMethod.Name);
+            _lib2Path = Path.Combine(testFiles.GetDestinationPath("library2"), _testMethod.Name);
             Directory.CreateDirectory(_libPath);
             Directory.CreateDirectory(_lib2Path);
         }
@@ -135,8 +132,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
             result.Should().NotBeEmpty();
 
             // Since we don't control this package, only spot check a few fields unlikely to change
-            var graphics = result.SingleOrDefault(pkg => pkg.Package == "graphics");
-            graphics.Should().NotBeNull();
+            var graphics = result.Should().ContainSingle(pkg => pkg.Package == "graphics").Which;
             graphics.LibPath.Should().NotBeNullOrWhiteSpace();
             graphics.Priority.Should().Be("base");
             graphics.Depends.Should().BeNull();
@@ -212,113 +208,82 @@ namespace Microsoft.R.Components.Test.PackageManager {
         [Test]
         [Category.PackageManager]
         public async Task InstallAndUninstallPackageSpecifiedLib() {
-            var interactiveWindowComponentContainerFactory = _exportProvider.GetExportedValue<IInteractiveWindowComponentContainerFactory>();
-            using (await UIThreadHelper.Instance.Invoke(() => _workflow.GetOrCreateVisualComponent(interactiveWindowComponentContainerFactory))) {
-                _workflow.ActiveWindow.Should().NotBeNull();
-                _workflow.RSession.IsHostRunning.Should().BeTrue();
-
-                using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
-                    await SetLocalRepoAsync(eval, _repo1Path);
-                }
-
-                _workflow.Packages.InstallPackage(TestPackages.RtvsLib1Description.Package, _libPath);
-                WaitForReplDoneExecuting();
-                WaitForPackageInstalled(_libPath, TestPackages.RtvsLib1Description.Package);
-
-                using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
-                    await SetLocalLibsAsync(eval, _libPath);
-                }
-
-                var installed = await _workflow.Packages.GetInstalledPackagesAsync();
-                ValidateRtvslib1Installed(installed, _libPath);
-
-                _workflow.Packages.UninstallPackage(TestPackages.RtvsLib1Description.Package, _libPath);
-                WaitForReplDoneExecuting();
-
-                installed = await _workflow.Packages.GetInstalledPackagesAsync();
-                installed.Should().NotContain(pkg => pkg.Package == TestPackages.RtvsLib1Description.Package && pkg.LibPath == _libPath.ToRPath());
+            using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
+                await SetLocalRepoAsync(eval, _repo1Path);
             }
+
+            await _workflow.Packages.InstallPackage(TestPackages.RtvsLib1Description.Package, _libPath);
+
+            using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
+                await SetLocalLibsAsync(eval, _libPath);
+            }
+
+            var installed = await _workflow.Packages.GetInstalledPackagesAsync();
+            ValidateRtvslib1Installed(installed, _libPath);
+
+            await _workflow.Packages.UninstallPackage(TestPackages.RtvsLib1Description.Package, _libPath);
+
+            installed = await _workflow.Packages.GetInstalledPackagesAsync();
+            installed.Should().NotContain(pkg => pkg.Package == TestPackages.RtvsLib1Description.Package && pkg.LibPath == _libPath.ToRPath());
         }
 
         [Test]
         [Category.PackageManager]
         public async Task InstallPackageDefaultLib() {
-            var interactiveWindowComponentContainerFactory = _exportProvider.GetExportedValue<IInteractiveWindowComponentContainerFactory>();
-            using (await UIThreadHelper.Instance.Invoke(() => _workflow.GetOrCreateVisualComponent(interactiveWindowComponentContainerFactory))) {
-                _workflow.ActiveWindow.Should().NotBeNull();
-                _workflow.RSession.IsHostRunning.Should().BeTrue();
-
-                using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
-                    await SetLocalRepoAsync(eval, _repo1Path);
-                    await SetLocalLibsAsync(eval, _libPath);
-                }
-
-                _workflow.Packages.InstallPackage(TestPackages.RtvsLib1Description.Package, null);
-                WaitForReplDoneExecuting();
-                WaitForPackageInstalled(_libPath, TestPackages.RtvsLib1Description.Package);
-
-                var installed = await _workflow.Packages.GetInstalledPackagesAsync();
-                ValidateRtvslib1Installed(installed, _libPath);
+            using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
+                await SetLocalRepoAsync(eval, _repo1Path);
+                await SetLocalLibsAsync(eval, _libPath);
             }
+
+            await _workflow.Packages.InstallPackage(TestPackages.RtvsLib1Description.Package, null);
+
+            var installed = await _workflow.Packages.GetInstalledPackagesAsync();
+            ValidateRtvslib1Installed(installed, _libPath);
         }
 
         [Test]
         [Category.PackageManager]
         public async Task LoadAndUnloadPackage() {
-            var interactiveWindowComponentContainerFactory = _exportProvider.GetExportedValue<IInteractiveWindowComponentContainerFactory>();
-            using (await UIThreadHelper.Instance.Invoke(() => _workflow.GetOrCreateVisualComponent(interactiveWindowComponentContainerFactory))) {
-                _workflow.ActiveWindow.Should().NotBeNull();
-                _workflow.RSession.IsHostRunning.Should().BeTrue();
-
-                using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
-                    await SetLocalRepoAsync(eval, _repo1Path);
-                    await SetLocalLibsAsync(eval, _libPath);
-                    await InstallPackageAsync(eval, TestPackages.RtvsLib1Description.Package, _libPath);
-                }
-
-                await EvaluateCode("func1()", expectedError: "Error: could not find function \"func1\"");
-
-                _workflow.Packages.LoadPackage(TestPackages.RtvsLib1Description.Package, null);
-                WaitForReplDoneExecuting();
-
-                await EvaluateCode("func1()", expectedResult: "func1");
-
-                var loaded = await _workflow.Packages.GetLoadedPackagesAsync();
-                loaded.Should().Contain("rtvslib1");
-
-                _workflow.Packages.UnloadPackage(TestPackages.RtvsLib1Description.Package);
-                WaitForReplDoneExecuting();
-
-                await EvaluateCode("func1()", expectedError: "Error: could not find function \"func1\"");
-
-                loaded = await _workflow.Packages.GetLoadedPackagesAsync();
-                loaded.Should().NotContain("rtvslib1");
+            using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
+                await SetLocalRepoAsync(eval, _repo1Path);
+                await SetLocalLibsAsync(eval, _libPath);
+                await InstallPackageAsync(eval, TestPackages.RtvsLib1Description.Package, _libPath);
             }
+
+            await EvaluateCode("func1();", expectedError: "Error: could not find function \"func1\"");
+
+            await _workflow.Packages.LoadPackage(TestPackages.RtvsLib1Description.Package, null);
+
+            await EvaluateCode("func1();", expectedResult: "func1");
+
+            var loaded = await _workflow.Packages.GetLoadedPackagesAsync();
+            loaded.Should().Contain("rtvslib1");
+
+            await _workflow.Packages.UnloadPackage(TestPackages.RtvsLib1Description.Package);
+
+            await EvaluateCode("func1();", expectedError: "Error: could not find function \"func1\"");
+
+            loaded = await _workflow.Packages.GetLoadedPackagesAsync();
+            loaded.Should().NotContain("rtvslib1");
         }
 
         [Test]
         [Category.PackageManager]
         public async Task GetLoadedPackages() {
-            var interactiveWindowComponentContainerFactory = _exportProvider.GetExportedValue<IInteractiveWindowComponentContainerFactory>();
-            using (await UIThreadHelper.Instance.Invoke(() => _workflow.GetOrCreateVisualComponent(interactiveWindowComponentContainerFactory))) {
-                _workflow.ActiveWindow.Should().NotBeNull();
-                _workflow.RSession.IsHostRunning.Should().BeTrue();
-
-                using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
-                    await SetLocalRepoAsync(eval, _repo1Path);
-                    await SetLocalLibsAsync(eval, _libPath);
-                    await InstallPackageAsync(eval, TestPackages.RtvsLib1Description.Package, _libPath);
-                }
-
-                string[] results = await _workflow.Packages.GetLoadedPackagesAsync();
-                results.Should().NotContain(new string[] {
-                    "rtvslib1", ".GlobalEnv", "Autoloads",
-                });
-                results.Should().Contain(new string[] {
-                    "stats", "graphics", "grDevices", "grDevices",
-                    "utils", "datasets", "methods", "base",
-                });
+            using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
+                await SetLocalRepoAsync(eval, _repo1Path);
+                await SetLocalLibsAsync(eval, _libPath);
+                await InstallPackageAsync(eval, TestPackages.RtvsLib1Description.Package, _libPath);
             }
+
+            var results = await _workflow.Packages.GetLoadedPackagesAsync();
+            results.Should().NotContain(new[] {
+                "rtvslib1", ".GlobalEnv", "Autoloads",
+            });
+            results.Should().Contain(new[] {
+                "stats", "graphics", "grDevices", "grDevices",
+                "utils", "datasets", "methods", "base",
+            });
         }
 
         [Test]
@@ -335,7 +300,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
 
         private async Task EvaluateCode(string code, string expectedResult = null, string expectedError = null) {
             using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
-                var evalResult = await eval.EvaluateAsync("func1();", REvaluationKind.Normal);
+                var evalResult = await eval.EvaluateAsync(code, REvaluationKind.Normal);
                 if (expectedResult != null) {
                     evalResult.StringResult.Trim().Should().Be(expectedResult.Trim());
                 }
@@ -346,18 +311,18 @@ namespace Microsoft.R.Components.Test.PackageManager {
         }
 
         private async Task SetLocalRepoAsync(IRSessionEvaluation eval, string localRepoPath) {
-            var code = string.Format("options(repos=list(LOCAL=\"file:///{0}\"))", localRepoPath.ToRPath());
+            var code = $"options(repos=list(LOCAL=\"file:///{localRepoPath.ToRPath()}\"))";
             var evalResult = await eval.EvaluateAsync(code, REvaluationKind.Mutating);
         }
 
         private async Task SetLocalLibsAsync(IRSessionEvaluation eval, params string[] libPaths) {
             var paths = string.Join(",", libPaths.Select(p => p.ToRPath().ToRStringLiteral()));
-            var code = string.Format(".libPaths(c({0}))", paths);
+            var code = $".libPaths(c({paths}))";
             var evalResult = await eval.EvaluateAsync(code, REvaluationKind.Normal);
         }
 
         private async Task InstallPackageAsync(IRSessionEvaluation eval, string packageName, string libPath) {
-            var code = string.Format("install.packages(\"{0}\", verbose=FALSE, quiet=TRUE)", packageName);
+            var code = $"install.packages(\"{packageName}\", verbose=FALSE, quiet=TRUE)";
             var evalResult = await eval.EvaluateAsync(code, REvaluationKind.Normal);
             WaitForPackageInstalled(libPath, packageName);
         }
@@ -372,18 +337,9 @@ namespace Microsoft.R.Components.Test.PackageManager {
             }, 50000);
             return workflow;
         }
-
-        private void WaitForReplDoneExecuting(int timeoutInSecs = 30) {
-            var startTime = DateTime.Now;
-            var timeout = TimeSpan.FromSeconds(timeoutInSecs);
-            while (_workflow.ActiveWindow.IsRunning && DateTime.Now < (startTime + timeout)) {
-                Thread.Sleep(100);
-            }
-            _workflow.ActiveWindow.IsRunning.Should().BeFalse();
-        }
-
+        
         private static void WaitForPackageInstalled(string libPath, string packageName) {
-            WaitForAllFilesExist(new string[] {
+            WaitForAllFilesExist(new[] {
                 Path.Combine(libPath, packageName, "DESCRIPTION"),
                 Path.Combine(libPath, packageName, "NAMESPACE"),
             });
@@ -400,12 +356,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
         }
 
         private static bool AllFilesExist(string[] filePaths) {
-            foreach (var filePath in filePaths) {
-                if (!File.Exists(filePath)) {
-                    return false;
-                }
-            }
-            return true;
+            return filePaths.All(File.Exists);
         }
 
         public void Dispose() {

--- a/src/R/Wpf/Impl/Converters.cs
+++ b/src/R/Wpf/Impl/Converters.cs
@@ -18,6 +18,7 @@ namespace Microsoft.R.Wpf {
         public static IValueConverter NullIsFalse { get; } = LambdaConverter.Create<object>(x => x != null);
         public static IValueConverter TrueIsCollapsed { get; } = LambdaConverter.Create<bool>(x => x ? Visibility.Collapsed : Visibility.Visible);
         public static IValueConverter FalseIsCollapsed { get; } = LambdaConverter.Create<bool>(x => !x ? Visibility.Collapsed : Visibility.Visible);
+        public static IValueConverter Not { get; } = LambdaConverter.Create<bool>(x => !x);
         public static IValueConverter NullIsCollapsed { get; } = LambdaConverter.Create<object>(x => x == null ? Visibility.Collapsed : Visibility.Visible);
         public static IValueConverter NullIsVisible { get; } = LambdaConverter.Create<object>(x => x != null ? Visibility.Collapsed : Visibility.Visible);
         public static IValueConverter NullOrEmptyIsCollapsed { get; } = LambdaConverter.Create<IEnumerable>(x => x == null || !x.GetEnumerator().MoveNext() ? Visibility.Collapsed : Visibility.Visible);


### PR DESCRIPTION
- Add Load/Unload/Update methods to RPackageManagerViewModel
- Make IPackageManager.InstallPackage / IPackageManager.UninstallPackage / IPackageManager.LoadPackage / IPackageManager.UnloadPackage async. Missing input in REPL will be fixed later: #1469
- Make InstallAsync/UninstallAsync refresh installed packages cause existing logic skips dependent packages
- Fix #1450: Update package crashes
- Fix #1454: Uninstall package crashes
- Fix #1456: Package manager loaded view doesn't refresh when session is mutated or reset
- Fix #1459: 'Sources' button on package manager does nothing
- Fix #1460: pk mgr: search currently search at beginning of name
- Fix #1463: Package manager detail view should have margin at bottom