### PR TITLE
Couple fixes for Package Manager

### DIFF
--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
@@ -86,11 +86,13 @@
                         <TextBlock Grid.Column="2" FontWeight="Bold" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" VerticalAlignment="Center" Text="{Binding Path=Name, Mode=OneWay}"
                                    FontSize="{Binding ElementName=_self, Path=FontSize, Converter={x:Static wpf:Converters.FontScale122}}" Margin="4,0,0,0">
                             <TextBlock.ToolTip>
-                                <TextBlock Style="{StaticResource TooltipStyle}" Visibility="{Binding Path=Title, Mode=OneWay, Converter={x:Static wpf:Converters.NullOrEmptyIsCollapsed}}">
-                                    <Run Text="{Binding Path=Name, Mode=OneWay}" FontWeight="Bold" />
-                                    <LineBreak />
-                                    <Run Text="{Binding Path=Title, Mode=OneWay}" />
-                                </TextBlock>
+                                <ToolTip Visibility="{Binding Path=Title, Mode=OneWay, Converter={x:Static wpf:Converters.NullOrEmptyIsCollapsed}}">
+                                    <TextBlock Style="{StaticResource TooltipStyle}">
+                                        <Run Text="{Binding Path=Name, Mode=OneWay}" FontWeight="Bold" />
+                                        <LineBreak />
+                                        <Run Text="{Binding Path=Title, Mode=OneWay}" />
+                                    </TextBlock>
+                                </ToolTip>
                             </TextBlock.ToolTip>
                         </TextBlock>
 

--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
@@ -189,7 +189,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
 
             if(package.IsLoaded) {
-                await UnloadAsync(package);
+                await _packageManager.UnloadPackageAsync(package.Name);
+                await ReloadLoadedPackagesAsync();
             }
 
             if (!package.IsLoaded) {
@@ -203,7 +204,9 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                 }
             }
 
-            IsLoading = false;
+            if (_selectedTab == SelectedTab.InstalledPackages || _selectedTab == SelectedTab.LoadedPackages) {
+                IsLoading = false;
+            }
         }
 
         public void Load(IRPackageViewModel package) {
@@ -252,8 +255,11 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
 
         private void AfterLoadUnload(IRPackageViewModel package) {
             package.IsChanging = false;
-            IsLoading = false;
-            if (_selectedTab == SelectedTab.InstalledPackages) {
+            if (_selectedTab == SelectedTab.LoadedPackages) {
+                IsLoading = false;
+                ReplaceItems(_loadedPackages);
+            } else if (_selectedTab == SelectedTab.InstalledPackages) {
+                IsLoading = false;
                 ReplaceItems(_installedPackages);
             }
         }
@@ -402,12 +408,6 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                 }
 
                 await UpdateLoadedPackages(currentInstalledPackages, loadedPackageNames);
-                _coreShell.DispatchOnUIThread(() => {
-                    if (_selectedTab == SelectedTab.LoadedPackages) {
-                        IsLoading = false;
-                        ReplaceItems(_loadedPackages);
-                    }
-                });
             } catch (RPackageManagerException ex) {
             }
         }
@@ -517,7 +517,16 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
         }
 
         private void RSessionMutated(object sender, EventArgs e) {
-            ReloadLoadedPackagesAsync().DoNotWait();
+            ReloadLoadedPackagesAsync()
+                .ContinueWith(t => _coreShell.DispatchOnUIThread(() => {
+                    if (_selectedTab != SelectedTab.LoadedPackages) {
+                        return;
+                    }
+
+                    IsLoading = false;
+                    ReplaceItems(_loadedPackages);
+                }))
+                .DoNotWait();
         }
 
         public void Dispose() {


### PR DESCRIPTION
- Fix #1476: Tooltip for packages we haven't fetched description yet is empty
- Remove double UI update when Loaded tab is updated