### PR TITLE
Fix #1136: Create debugger data inspection tests 

### DIFF
--- a/src/Common/Core/Test/Match/MatchAny.cs
+++ b/src/Common/Core/Test/Match/MatchAny.cs
@@ -2,25 +2,58 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using FluentAssertions.Formatting;
 
 namespace Microsoft.Common.Core.Test.Match {
     public class MatchAny<T> : IEquatable<T> {
         public static readonly MatchAny<T> Instance = new MatchAny<T>();
 
-        public bool Equals(T other) {
-            return true;
+        private readonly Func<T, bool> _condition;
+        private readonly Func<string> _toString;
+        private readonly object _wrapped;
+
+        static MatchAny() {
+            FluentAssertions.Formatting.Formatter.AddFormatter(new Formatter());
         }
 
-        public override bool Equals(object obj) {
-            return true;
+        private MatchAny(Func<T, bool> condition, object wrapped) {
+            _condition = condition;
+            _toString = wrapped.ToString;
+            _wrapped = wrapped;
         }
 
-        public override int GetHashCode() {
-            return 0;
+        public MatchAny() {
+            _condition = _ => true;
+            _toString = () => "<any>";
         }
 
-        public override string ToString() {
-            return "<any>";
+        public MatchAny(Expression<Func<T, bool>> condition) {
+            _condition = condition.Compile();
+            _toString = () => $"<satisfies {condition.ToString()}>";
+        }
+
+        public static MatchAny<T> ThatMatches<TOther>(IEquatable<TOther> match) {
+            return new MatchAny<T>(x => x is TOther && match.Equals((TOther)(object)x), match);
+        }
+
+        public bool Equals(T other) =>
+            _condition(other);
+
+        public override bool Equals(object obj) =>
+            (obj == null || obj is T) && Equals((T)obj);
+
+        public override int GetHashCode() => 0;
+
+        public override string ToString() => _toString();
+
+        private class Formatter : IValueFormatter {
+            public bool CanHandle(object value) =>
+                (value as MatchAny<T>)?._wrapped != null;
+
+            public string ToString(object value, bool useLineBreaks, IList<object> processedObjects = null, int nestedPropertyLevel = 0) =>
+                FluentAssertions.Formatting.Formatter.ToString(((MatchAny<T>)value)._wrapped, useLineBreaks, processedObjects, nestedPropertyLevel);
         }
     }
 }

--- a/src/Common/Core/Test/Match/MatchAny.cs
+++ b/src/Common/Core/Test/Match/MatchAny.cs
@@ -34,8 +34,9 @@ namespace Microsoft.Common.Core.Test.Match {
             _toString = () => $"<satisfies {condition.ToString()}>";
         }
 
-        public static MatchAny<T> ThatMatches<TOther>(IEquatable<TOther> match) {
-            return new MatchAny<T>(x => x is TOther && match.Equals((TOther)(object)x), match);
+        public static MatchAny<T> ThatMatches<TOther>(IEquatable<TOther> match)
+            where TOther : T  {
+            return new MatchAny<T>(x => x is TOther && match.Equals((TOther)x), match);
         }
 
         public bool Equals(T other) =>

--- a/src/Common/Core/Test/Match/MatchElements.cs
+++ b/src/Common/Core/Test/Match/MatchElements.cs
@@ -53,12 +53,6 @@ namespace Microsoft.Common.Core.Test.Match {
         public override bool Equals(object obj) =>
             Equals(obj as IEnumerable<T>);
 
-        public override int GetHashCode() {
-            return 0;
-        }
-
-        public override string ToString() {
-            return "<any>";
-        }
+        public override int GetHashCode() => 0;
     }
 }

--- a/src/Common/Core/Test/Match/MatchElements.cs
+++ b/src/Common/Core/Test/Match/MatchElements.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Common.Core.Test.Match {
+    public class MatchElements<T> : IEquatable<IEnumerable<T>> {
+        private readonly bool _exactOrder;
+        private readonly List<IEquatable<T>> _expected = new List<IEquatable<T>>();
+
+        public MatchElements(bool exactOrder) {
+            _exactOrder = exactOrder;
+        }
+
+        public MatchElements(bool exactOrder, IEnumerable<IEquatable<T>> elements)
+            : this(exactOrder) {
+            _expected.AddRange(elements);
+        }
+
+        public void Add(IEquatable<T> element) {
+            _expected.Add(element);
+        }
+
+        private bool Matches(IEquatable<T> expected, T actual) =>
+            expected == null ? actual == null : expected.Equals(actual);
+
+        public bool Equals(IEnumerable<T> other) {
+            if (other == null) {
+                return false;
+            }
+
+            var actual = other.ToList();
+            if (actual.Count != _expected.Count) {
+                return false;
+            }
+
+            if (_exactOrder) {
+                return _expected.Zip(actual, Matches).All(b => b);
+            } else {
+                foreach (var e in _expected) {
+                    int i = actual.FindIndex(a => Matches(e, a));
+                    if (i < 0) {
+                        return false;
+                    }
+                    actual.RemoveAt(i);
+                }
+                return actual.Count == 0;
+            }
+        }
+
+        public override bool Equals(object obj) =>
+            Equals(obj as IEnumerable<T>);
+
+        public override int GetHashCode() {
+            return 0;
+        }
+
+        public override string ToString() {
+            return "<any>";
+        }
+    }
+}

--- a/src/Common/Core/Test/Match/MatchMembers.cs
+++ b/src/Common/Core/Test/Match/MatchMembers.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Common.Core.Test.Match {
                 _memberName = memberSelector.ToString();
             }
 
-            _memberName = (memberSelector.Body as MemberExpression)?.Member.Name ?? memberSelector.ToString();
             _next = next;
             _expected = expected;
             _equals = equals;

--- a/src/Common/Core/Test/Match/MatchMembers.cs
+++ b/src/Common/Core/Test/Match/MatchMembers.cs
@@ -23,12 +23,20 @@ namespace Microsoft.Common.Core.Test.Match {
         }
 
         private MatchMembers(MatchMembers<T> next, LambdaExpression memberSelector, object expected, Func<T, bool> equals) {
-            var member = memberSelector?.Body as MemberExpression;
-            if (member == null) {
-                throw new ArgumentException("Member selector must be of the form `x => x.Member`.", "memberSelector");
+            if (memberSelector == null) {
+                throw new ArgumentNullException("memberSelector");
             }
 
-            _memberName = member.Member.Name;
+            // If selector is of the form x => x.Member, which is the most common kind, then shorten it to Member.
+            // Otherwise, just use the whole body of the lambda.
+            var member = memberSelector.Body as MemberExpression;
+            if (member != null && member.Expression is ParameterExpression) {
+                _memberName = member.Member.Name;
+            } else {
+                _memberName = memberSelector.ToString();
+            }
+
+            _memberName = (memberSelector.Body as MemberExpression)?.Member.Name ?? memberSelector.ToString();
             _next = next;
             _expected = expected;
             _equals = equals;

--- a/src/Common/Core/Test/Microsoft.Common.Core.Test.csproj
+++ b/src/Common/Core/Test/Microsoft.Common.Core.Test.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Disposables\DisposableTest.cs" />
     <Compile Include="EnumerableExtensionsTest.cs" />
     <Compile Include="Fakes\TestCoreShell.cs" />
+    <Compile Include="Match\MatchElements.cs" />
     <Compile Include="Match\MatchNull.cs" />
     <Compile Include="Match\MatchRange.cs" />
     <Compile Include="Match\MatchAny.cs" />

--- a/src/Debugger/Engine/Impl/AD7Property.cs
+++ b/src/Debugger/Engine/Impl/AD7Property.cs
@@ -58,17 +58,18 @@ namespace Microsoft.R.Debugger.Engine {
         private IReadOnlyList<DebugEvaluationResult> CreateChildren() =>
             TaskExtensions.RunSynchronouslyOnUIThread(async ct => {
                 var valueResult = EvaluationResult as DebugValueEvaluationResult;
-                if (valueResult != null) {
-                    var children = await valueResult.GetChildrenAsync(PrefetchedFields, ChildrenMaxLength, ReprMaxLength, ct);
-
-                    // Children of environments do not have any meaningful order, so sort them by name.
-                    if (valueResult.TypeName == "environment") {
-                        children = children.OrderBy(er => er.Name).ToArray();
-                    }
-
-                    return children;
+                if (valueResult == null) {
+                    return new DebugEvaluationResult[0];
                 }
-                return new DebugEvaluationResult[0];
+
+                var children = await valueResult.GetChildrenAsync(PrefetchedFields, ChildrenMaxLength, ReprMaxLength, ct);
+
+                // Children of environments do not have any meaningful order, so sort them by name.
+                if (valueResult.TypeName == "environment") {
+                    children = children.OrderBy(er => er.Name).ToArray();
+                }
+
+                return children;
             });
 
         private string CreateReprToString() {

--- a/src/Debugger/Engine/Impl/AD7StackFrame.cs
+++ b/src/Debugger/Engine/Impl/AD7StackFrame.cs
@@ -19,7 +19,7 @@ namespace Microsoft.R.Debugger.Engine {
             Engine = engine;
             StackFrame = stackFrame;
 
-            _property = Lazy.Create(() => new AD7Property(this, TaskExtensions.RunSynchronouslyOnUIThread(ct => StackFrame.GetEnvironmentAsync(cancellationToken:ct)), isFrameEnvironment: true));
+            _property = Lazy.Create(() => new AD7Property(this, TaskExtensions.RunSynchronouslyOnUIThread(ct => StackFrame.GetEnvironmentAsync(cancellationToken: ct)), isFrameEnvironment: true));
         }
 
         int IDebugStackFrame2.EnumProperties(enum_DEBUGPROP_INFO_FLAGS dwFields, uint nRadix, ref Guid guidFilter, uint dwTimeout, out uint pcelt, out IEnumDebugPropertyInfo2 ppEnum) {

--- a/src/Debugger/Impl/DebugEvaluationResult.cs
+++ b/src/Debugger/Impl/DebugEvaluationResult.cs
@@ -28,6 +28,7 @@ namespace Microsoft.R.Debugger {
         Dim = 1 << 13,
         EnvName = 1 << 14,
         Flags = 1 << 15,
+        Children = Expression | Length | AttrCount | SlotCount | NameCount | Flags,
     }
 
     internal static class DebugEvaluationResultFieldsExtensions {

--- a/src/Debugger/Impl/DebugStackFrame.cs
+++ b/src/Debugger/Impl/DebugStackFrame.cs
@@ -87,7 +87,7 @@ namespace Microsoft.R.Debugger {
         }
 
         public Task<DebugEvaluationResult> GetEnvironmentAsync(
-            DebugEvaluationResultFields fields = DebugEvaluationResultFields.Expression | DebugEvaluationResultFields.Length | DebugEvaluationResultFields.AttrCount,
+            DebugEvaluationResultFields fields = DebugEvaluationResultFields.Expression | DebugEvaluationResultFields.Length | DebugEvaluationResultFields.AttrCount | DebugEvaluationResultFields.Flags,
             CancellationToken cancellationToken = default(CancellationToken)
         ) {
             return EvaluateAsync("base::environment()", fields: fields, cancellationToken: cancellationToken);

--- a/src/Debugger/Impl/rtvs/R/breakpoints.R
+++ b/src/Debugger/Impl/rtvs/R/breakpoints.R
@@ -12,6 +12,8 @@ is_breakpoint <- function(filename, line_number) {
   if (locals$breakpoints_enabled) {
     line_numbers <- breakpoints[[filename]];
     return(line_number %in% line_numbers);
+  } else {
+  	return(FALSE);
   }
 }
 

--- a/src/Debugger/Impl/rtvs/R/eval.R
+++ b/src/Debugger/Impl/rtvs/R/eval.R
@@ -84,7 +84,7 @@ describe_object <- function(obj, res, fields, repr_max_length = NA) {
     
   has_parent_env <- FALSE;
   if (is.environment(obj)) {
-    has_parent_env <- !identical(obj, emptyenv());
+    has_parent_env <- !identical(parent.env(obj), emptyenv());
     if (field('env_name')) {
       res$env_name <- NA_if_error(environmentName(obj));
     }
@@ -251,7 +251,7 @@ describe_children <- function(obj, env, fields, count = NULL, repr_max_length = 
       # use slot(). Still, always use '@' as accessor name to show to the user.
       accessor <- paste0('@', name_sym, collapse = '');
       if (is_S4) {
-        slot_expr <- paste0('(', expr, ')', accessor, collapse = '')
+        slot_expr <- paste0(expr, accessor, collapse = '')
       } else {
         slot_expr <- paste0('methods::slot((', expr, '), ', deparse_str(name), ')', collapse = '')
       }

--- a/src/Debugger/Test/BreakpointsTest.cs
+++ b/src/Debugger/Test/BreakpointsTest.cs
@@ -190,9 +190,9 @@ namespace Microsoft.R.Debugger.Test {
 
                 await sf.Source(_session);
 
-                var res = (await debugSession.EvaluateAsync("is.function(f)", DebugEvaluationResultFields.ReprDeparse)).As<DebugValueEvaluationResult>();
-                res.GetRepresentation().Deparse
-                    .Should().Be("TRUE");
+                var res = (await debugSession.EvaluateAsync("is.function(f)", DebugEvaluationResultFields.ReprDeparse))
+                    .Should().BeOfType<DebugValueEvaluationResult>()
+                    .Which.GetRepresentation().Deparse.Should().Be("TRUE");
             }
         }
 

--- a/src/Debugger/Test/JsonTest.cs
+++ b/src/Debugger/Test/JsonTest.cs
@@ -68,7 +68,6 @@ namespace Microsoft.R.Debugger.Test {
         [InlineData("structure(list(), names = ''[FALSE])", "{}")]
         [InlineData("list(n = 0, s = 's', u = NULL)", @"{""n"":0,""s"":""s"",""u"":null}")]
         [InlineData("list(n = 0, na = NA)", @"{""n"":0}")]
-        [InlineData("list(n = 0, na = NA)", @"{""n"":0}")]
         [InlineData("as.environment(list())", "{}")]
         [InlineData("as.environment(list(n = 0, s = 's', u = NULL))", @"{""n"":0,""s"":""s"",""u"":null}")]
         [InlineData("as.environment(list(n = 0, na = NA))", @"{""n"":0}")]

--- a/src/Debugger/Test/Match/MatchDebugEvaluationResults.cs
+++ b/src/Debugger/Test/Match/MatchDebugEvaluationResults.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Common.Core.Test.Match;
+
+namespace Microsoft.R.Debugger.Test.Match {
+    internal class MatchDebugEvaluationResults : IEnumerable<IEquatable<DebugEvaluationResult>> {
+        private readonly List<IEquatable<DebugEvaluationResult>> _results = new List<IEquatable<DebugEvaluationResult>>();
+
+        public IEnumerator<IEquatable<DebugEvaluationResult>> GetEnumerator() {
+            return _results.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        public void Add(IEquatable<DebugEvaluationResult> match) {
+            _results.Add(match);
+        }
+
+        public void Add(IEquatable<string> name, IEquatable<string> expr, IEquatable<string> deparse, IEquatable<string> type, IEquatable<string>[] classes) {
+            _results.Add(
+                MatchAny<DebugEvaluationResult>.ThatMatches(
+                    new MatchMembers<DebugValueEvaluationResult>()
+                        .Matching(r => r.Name, name)
+                        .Matching(r => r.Expression, expr)
+                        .Matching(r => r.Classes, new MatchElements<string>(false, classes))
+                        .Matching(r => r.GetRepresentation().Deparse, deparse)));
+        }
+    }
+}

--- a/src/Debugger/Test/Microsoft.R.Debugger.Test.csproj
+++ b/src/Debugger/Test/Microsoft.R.Debugger.Test.csproj
@@ -70,6 +70,7 @@
     <Compile Include="CallStackTest.cs" />
     <Compile Include="DebugSessionExtensions.cs" />
     <Compile Include="EventTaskSources.cs" />
+    <Compile Include="Match\MatchDebugEvaluationResults.cs" />
     <Compile Include="Match\MatchDebugStackFrames.cs" />
     <Compile Include="SourceFile.cs" />
     <Compile Include="DebugReplTest.cs" />

--- a/src/Debugger/Test/SteppingTest.cs
+++ b/src/Debugger/Test/SteppingTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.R.Debugger.Test {
             _sessionProvider.Dispose();
         }
 
-        [Test]
+        [Test(Skip = "https://github.com/Microsoft/RTVS/issues/1382")]
         [Category.R.Debugger]
         public async Task BreakContinue() {
             const string code =

--- a/src/Debugger/Test/ValuesTest.cs
+++ b/src/Debugger/Test/ValuesTest.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Common.Core;
 using Microsoft.Common.Core.Test.Match;
 using Microsoft.Common.Core.Test.Utility;
 using Microsoft.R.Host.Client;
@@ -14,10 +17,13 @@ using Microsoft.R.Host.Client.Session;
 using Microsoft.R.Host.Client.Test.Script;
 using Microsoft.UnitTests.Core.XUnit;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.R.Debugger.Test {
     [ExcludeFromCodeCoverage]
     public class ValuesTest : IAsyncLifetime {
+        private const DebugEvaluationResultFields AllFields = unchecked((DebugEvaluationResultFields)~0);
+
         private readonly MethodInfo _testMethod;
         private readonly IRSessionProvider _sessionProvider;
         private readonly IRSession _session;
@@ -49,7 +55,7 @@ namespace Microsoft.R.Debugger.Test {
                 stackFrames.Should().NotBeEmpty();
 
                 var frame = (await stackFrames.Last().GetEnvironmentAsync()).Should().BeOfType<DebugValueEvaluationResult>().Which;
-                var children = await frame.GetChildrenAsync(DebugEvaluationResultFields.Expression | DebugEvaluationResultFields.ReprDeparse);
+                var children = await frame.GetChildrenAsync(DebugEvaluationResultFields.Expression | DebugEvaluationResultFields.ReprDeparse | DebugEvaluationResultFields.Length);
                 var parent = children.Should().Contain(er => er.Name == "`123`")
                     .Which.Should().BeOfType<DebugValueEvaluationResult>().Which;
                 parent.Expression.Should().Be("`123`");
@@ -63,35 +69,97 @@ namespace Microsoft.R.Debugger.Test {
 
         [Test]
         [Category.R.Debugger]
-        public async Task MultilinePromise() {
-            const string code = @"
-f <- function(p, d) {
-    force(d)
+        public async Task Promise() {
+            const string code =
+@"f <- function(p) {
     browser()
-}
-x <- quote({{{}}})
-eval(substitute(f(P, x), list(P = x)))
+    force(p)
+    browser()
+  }
+  f(1 + 2)";
+
+            using (var debugSession = new DebugSession(_session))
+            using (var sf = new SourceFile(code)) {
+                await debugSession.EnableBreakpointsAsync(true);
+
+                await sf.Source(_session);
+                await debugSession.NextPromptShouldBeBrowseAsync();
+
+                var stackFrames = (await debugSession.GetStackFramesAsync()).ToArray();
+                stackFrames.Should().NotBeEmpty();
+
+                var frame = (await stackFrames.Last().GetEnvironmentAsync()).Should().BeOfType<DebugValueEvaluationResult>().Which;
+                var children = await frame.GetChildrenAsync(DebugEvaluationResultFields.ReprDeparse);
+                children.Should().ContainSingle(er => er.Name == "p")
+                    .Which.Should().BeOfType<DebugPromiseEvaluationResult>()
+                    .Which.Code.Should().Be("1 + 2");
+
+                await debugSession.ContinueAsync();
+                await debugSession.NextPromptShouldBeBrowseAsync();
+
+                children = await frame.GetChildrenAsync(DebugEvaluationResultFields.ReprDeparse);
+                children.Should().ContainSingle(er => er.Name == "p")
+                    .Which.Should().BeOfType<DebugValueEvaluationResult>()
+                    .Which.GetRepresentation().Deparse.Should().Be("3");
+            }
+        }
+
+
+        [Test]
+        [Category.R.Debugger]
+        public async Task ActiveBinding() {
+            const string code =
+@"makeActiveBinding('x', function() 42, environment());
+  browser();
 ";
 
             using (var debugSession = new DebugSession(_session))
             using (var sf = new SourceFile(code)) {
                 await debugSession.EnableBreakpointsAsync(true);
 
-                var browseTask = EventTaskSources.DebugSession.Browse.Create(debugSession);
-
                 await sf.Source(_session);
-                await browseTask;
+                await debugSession.NextPromptShouldBeBrowseAsync();
 
                 var stackFrames = (await debugSession.GetStackFramesAsync()).ToArray();
                 stackFrames.Should().NotBeEmpty();
 
-                var frame = (await stackFrames.Last().GetEnvironmentAsync()).As<DebugValueEvaluationResult>();
-                var children = (await frame.GetChildrenAsync(DebugEvaluationResultFields.ReprDeparse)).ToDictionary(er => er.Name);
+                var frame = (await stackFrames.Last().GetEnvironmentAsync()).Should().BeOfType<DebugValueEvaluationResult>().Which;
+                var children = await frame.GetChildrenAsync(DebugEvaluationResultFields.ReprDeparse);
+                children.Should().ContainSingle(er => er.Name == "x")
+                    .Which.Should().BeOfType<DebugActiveBindingEvaluationResult>();
+            }
+        }
 
-                var p = children.Should().ContainKey("p").WhichValue.As<DebugPromiseEvaluationResult>();
-                var d = children.Should().ContainKey("d").WhichValue.As<DebugValueEvaluationResult>();
+        [Test]
+        [Category.R.Debugger]
+        public async Task MultilinePromise() {
+            const string code =
+@"f <- function(p, d) {
+    force(d)
+    browser()
+  }
+  x <- quote({{{}}})
+  eval(substitute(f(P, x), list(P = x)))";
 
-                p.Code.Should().Be(d.GetRepresentation().Deparse);
+            using (var debugSession = new DebugSession(_session))
+            using (var sf = new SourceFile(code)) {
+                await debugSession.EnableBreakpointsAsync(true);
+
+                await sf.Source(_session);
+                await debugSession.NextPromptShouldBeBrowseAsync();
+
+                var stackFrames = (await debugSession.GetStackFramesAsync()).ToArray();
+                stackFrames.Should().NotBeEmpty();
+
+                var frame = (await stackFrames.Last().GetEnvironmentAsync()).Should().BeOfType<DebugValueEvaluationResult>().Which;
+                var children = (await frame.GetChildrenAsync(DebugEvaluationResultFields.ReprDeparse));
+                var d = children.Should().ContainSingle(er => er.Name == "d")
+                    .Which.Should().BeOfType<DebugValueEvaluationResult>()
+                    .Which;
+
+                var p = children.Should().ContainSingle(er => er.Name == "p")
+                    .Which.Should().BeOfType<DebugPromiseEvaluationResult>()
+                    .Which.Code.Should().Be(d.GetRepresentation().Deparse);
             }
         }
 
@@ -133,6 +201,7 @@ eval(substitute(f(P, x), list(P = x)))
         [InlineData(@"'\'\""\n\r\t\b\a\f\v\\\001'", @"""'\""\n\r\t\b\a\f\v\\\001""", @"""'\""\n\r\t\b\a\f\v\\\001""", "'\"\n\r\t\b\a\f\v\\\x01")]
         //[InlineData(@"'\u2260'", @"""≠""", @"""≠""", "≠")]
         [InlineData(@"sQuote(dQuote('x'))", @"""‘“x”’""", @"""‘“x”’""", "‘“x”’")]
+        [InlineData(@"quote(sym)", @"sym", @"sym", "sym")]
         public async Task Representation(string expr, string deparse, string str, string toString) {
             using (var debugSession = new DebugSession(_session)) {
                 var res = (await debugSession.EvaluateAsync(expr, DebugEvaluationResultFields.ReprDeparse | DebugEvaluationResultFields.ReprStr | DebugEvaluationResultFields.ReprToString))
@@ -144,5 +213,213 @@ eval(substitute(f(P, x), list(P = x)))
             }
         }
 
+        private const string Postfix = "<POSTFIX>";
+
+        public class ChildrenDataRow : IEnumerable, IXunitSerializable {
+            public string Expression { get; private set; }
+            public int Length { get; private set; }
+            public int NameCount { get; private set; }
+            public int AttrCount { get; private set; }
+            public int SlotCount { get; private set; }
+            public bool Sorted { get; private set; }
+            public object[][] Children { get; private set; } = new object[][] { };
+
+            public ChildrenDataRow() {
+            }
+
+            public ChildrenDataRow(string expression, int length, int nameCount = 0, int attrCount = 0, int slotCount = 0, bool sorted = false) {
+                Expression = expression;
+                Length = length;
+                NameCount = nameCount;
+                AttrCount = attrCount;
+                SlotCount = slotCount;
+                Sorted = sorted;
+            }
+
+            public void Add(string name, string expression, string deparse) {
+                Children = Children.Append(new object[] { name, expression, deparse }).ToArray();
+            }
+
+            public void Add(string name, string deparse) {
+                Add(name, "PARENT" + name, deparse);
+            }
+
+            public static implicit operator object[] (ChildrenDataRow row) =>
+                new object[] { row };
+
+            IEnumerator IEnumerable.GetEnumerator() =>
+                new[] { ToString() }.GetEnumerator();
+
+            public override string ToString() => Expression;
+
+            void IXunitSerializable.Serialize(IXunitSerializationInfo info) {
+                info.AddValue(nameof(Expression), Expression);
+                info.AddValue(nameof(Length), Length);
+                info.AddValue(nameof(NameCount), NameCount);
+                info.AddValue(nameof(AttrCount), AttrCount);
+                info.AddValue(nameof(SlotCount), SlotCount);
+                info.AddValue(nameof(Sorted), Sorted);
+                info.AddValue(nameof(Children), Children);
+            }
+
+            void IXunitSerializable.Deserialize(IXunitSerializationInfo info) {
+                Expression = info.GetValue<string>(nameof(Expression));
+                Length = info.GetValue<int>(nameof(Length));
+                NameCount = info.GetValue<int>(nameof(NameCount));
+                AttrCount = info.GetValue<int>(nameof(AttrCount));
+                SlotCount = info.GetValue<int>(nameof(SlotCount));
+                Sorted = info.GetValue<bool>(nameof(Sorted));
+                Children = info.GetValue<object[][]>(nameof(Children));
+            }
+        }
+
+        // Parent expression is assigned to variable "PARENT" after being evaluated, and children are retrieved
+        // from that variable, so the corresponding expressions should use "PARENT" for the parent expression.
+        // For example, if the parent expression is "c(1, 2)", and we're matching the first child, the expression
+        // for that child should be written as "PARENT[[1]]".
+        //
+        // Furthermore, if child expression is not specified at all, then it is assumed to be "PARENT" followed 
+        // by child name - e.g. if the name of the first child is "[[1]]", then, instead of using "PARENT[[1]]",
+        // for the child expression, one can just omit it for the same effect.
+        //
+        // Due to a bug in the test discoverer, rows containing single quotes are not handled right, so
+        // only double quotes should be used for string literals in expressions below.
+        public static readonly object[][] ChildrenData = {
+            new ChildrenDataRow("NULL", 0),
+            new ChildrenDataRow("NA", 1),
+            new ChildrenDataRow("NA_integer_", 1),
+            new ChildrenDataRow("NA_real_", 1),
+            new ChildrenDataRow("NA_complex_", 1),
+            new ChildrenDataRow("NA_character_", 1),
+            new ChildrenDataRow("+Inf", 1),
+            new ChildrenDataRow("-Inf", 1),
+            new ChildrenDataRow("NaN", 1),
+            new ChildrenDataRow("TRUE", 1),
+            new ChildrenDataRow("42L", 1),
+            new ChildrenDataRow("42", 1),
+            new ChildrenDataRow("42i", 1),
+            new ChildrenDataRow(@"""str""", 1),
+            new ChildrenDataRow("quote(sym)", 1),
+            new ChildrenDataRow("TRUE[FALSE]", 0),
+            new ChildrenDataRow("42[FALSE]", 0),
+            new ChildrenDataRow("42L[FALSE]", 0),
+            new ChildrenDataRow("42i[FALSE]", 0),
+            new ChildrenDataRow(@"""str""[FALSE]", 0),
+            new ChildrenDataRow("list()", 0),
+            new ChildrenDataRow("pairlist()", 0),
+            new ChildrenDataRow("as.environment(list())", 0),
+            new ChildrenDataRow("c(TRUE, FALSE, NA)", 3) {
+                { "[[1]]", "TRUE" },
+                { "[[2]]", "FALSE" },
+                { "[[3]]", "NA" },
+            },
+            new ChildrenDataRow("c(1L, 2L, NA_integer_)", 3) {
+                { "[[1]]", "1L" },
+                { "[[2]]", "2L" },
+                { "[[3]]", "NA_integer_" },
+            },
+            new ChildrenDataRow("c(1, 2, NA)", 3) {
+                { "[[1]]", "1" },
+                { "[[2]]", "2" },
+                { "[[3]]", "NA_real_" },
+            },
+            new ChildrenDataRow("c(1i, 2i, NA_complex_)", 3) {
+                { "[[1]]", "0+1i" },
+                { "[[2]]", "0+2i" },
+                { "[[3]]", "NA_complex_" },
+            },
+            new ChildrenDataRow(@"c(""1"", ""2"", NA_character_)", 3) {
+                { "[[1]]", @"""1""" },
+                { "[[2]]", @"""2""" },
+                { "[[3]]", "NA_character_" },
+            },
+            new ChildrenDataRow("c(1, x = 2, 3, `y \n z` = 4, x = 5)", 5, nameCount: 5, attrCount: 1) {
+                { "[[1]]", "1" },
+                { "[[\"x\"]]", "2" },
+                { "[[3]]", "3" },
+                { "[[\"y \\n z\"]]", "4" },
+                { "[[5]]", "5" },
+            },
+            new ChildrenDataRow("c(x = 1)", 1, nameCount: 1, attrCount: 1) {
+                { "[[\"x\"]]", "1" },
+            },
+            new ChildrenDataRow("list(1, TRUE, NA, NULL, list())", 5) {
+                { "[[1]]", "1" },
+                { "[[2]]", "TRUE" },
+                { "[[3]]", "NA" },
+                { "[[4]]", "NULL" },
+                { "[[5]]", "list()" },
+            },
+            new ChildrenDataRow("list(1, x = 2, 3, `y \n z` = 4, x = 5)", 5, nameCount: 5, attrCount: 1) {
+                { "[[1]]", "1" },
+                { "$x", "2" },
+                { "[[3]]", "3" },
+                { "$`y \\n z`", "4" },
+                { "[[5]]", "5" },
+            },
+            new ChildrenDataRow("pairlist(1, TRUE, NA, NULL, list())", 5) {
+                { "[[1]]", "1" },
+                { "[[2]]", "TRUE" },
+                { "[[3]]", "NA" },
+                { "[[4]]", "NULL" },
+                { "[[5]]", "list()" },
+            },
+            new ChildrenDataRow("pairlist(1, x = 2, 3, `y \n z` = 4, x = 5)", 5, nameCount: 5, attrCount: 1) {
+                { "[[1]]", "1" },
+                { "$x", "2" },
+                { "[[3]]", "3" },
+                { "$`y \\n z`", "4" },
+                { "[[5]]", "5" },
+            },
+            new ChildrenDataRow("as.environment(list(x = 1, `y \n z` = NA, n = NULL, e = .GlobalEnv))", 4, nameCount: 4, sorted: true) {
+                { "`y \\n z`", "PARENT$`y \\n z`", "NA" },
+                { "e", "PARENT$e", "<environment>" },
+                { "n", "PARENT$n", "NULL" },
+                { "x", "PARENT$x", "1" },
+            },
+            new ChildrenDataRow("setClass(\"C\", slots = list(x = \"numeric\", `y \n z` = \"logical\"))(x = 1, `y \n z` = NA)", 1, slotCount: 2, attrCount: 3) {
+                { "@x", "1" },
+                { "@`y \\n z`", "NA" },
+            },
+            new ChildrenDataRow("setClass(\"C\", contains = \"list\", slots = list(y = \"numeric\"))(list(x = 1), y = 2)", 1, nameCount: 1, slotCount: 2, attrCount: 3) {
+                { "@.Data", "list(1)" },
+                { "@y", "2" },
+                { "$x", "1" },
+            },
+        };
+
+        [CompositeTest]
+        [Category.R.Debugger]
+        [MemberData("ChildrenData")]
+        public async Task Children(ChildrenDataRow row) {
+            var children = row.Children.Select(childRow =>
+                MatchAny<DebugEvaluationResult>.ThatMatches(
+                    new MatchMembers<DebugValueEvaluationResult>()
+                        .Matching(er => er.Name, (string)childRow[0])
+                        .Matching(er => er.Expression, (string)childRow[1])
+                        .Matching(er => er.GetRepresentation().Deparse, (string)childRow[2])));
+
+            using (var debugSession = new DebugSession(_session)) {
+                var frame = (await debugSession.GetStackFramesAsync()).Single();
+
+                (await frame.EvaluateAsync("PARENT <- {" + row.Expression + "}", DebugEvaluationResultFields.None))
+                    .Should().BeOfType<DebugValueEvaluationResult>();
+
+                var res = (await frame.EvaluateAsync("PARENT", AllFields))
+                    .Should().BeOfType<DebugValueEvaluationResult>().Which;
+                res.Length.Should().Be(row.Length);
+                res.NameCount.Should().Be(row.NameCount);
+                res.AttributeCount.Should().Be(row.AttrCount);
+                res.SlotCount.Should().Be(row.SlotCount);
+
+                var actualChildren = await res.GetChildrenAsync(AllFields);
+                res.HasChildren.Should().Be(children.Any());
+
+                if (row.Sorted) {
+                    actualChildren = actualChildren.OrderBy(er => er.Name).ToArray();
+                }
+                actualChildren.Should().Equal(children);
+            }
+        }
     }
 }

--- a/src/Debugger/Test/ValuesTest.cs
+++ b/src/Debugger/Test/ValuesTest.cs
@@ -247,6 +247,10 @@ namespace Microsoft.R.Debugger.Test {
             public static implicit operator object[] (ChildrenDataRow row) =>
                 new object[] { row };
 
+            // Class must implement IEnumerable in order to support collection initializers. However, for those classes
+            // that do that, when producing the signature of the test, xUnit will ignore ToString and just format them
+            // as a list, element by element. Since we want our ToString to show up, instead of the children, implement
+            // IEnumerable by returning our own ToString. 
             IEnumerator IEnumerable.GetEnumerator() =>
                 new[] { ToString() }.GetEnumerator();
 
@@ -390,7 +394,7 @@ namespace Microsoft.R.Debugger.Test {
 
         [CompositeTest]
         [Category.R.Debugger]
-        [MemberData("ChildrenData")]
+        [MemberData(nameof(ChildrenData))]
         public async Task Children(ChildrenDataRow row) {
             var children = row.Children.Select(childRow =>
                 MatchAny<DebugEvaluationResult>.ThatMatches(


### PR DESCRIPTION
(and fixes to various minor code issues exposed by the tests)

Add value tests for promises and active bindings.

Add value tests for children of evaluation results.

Remove duplicate JSON test data.

Use ShouldBeOfType instead of As where appropriate, because the latter doesn't assert the type.

Fix expression for slots to enable assignment.

Always sort children of environments - not just for frames.

Add synthetic parent environment nodes to environments.

Disable BreakContinue test.

Fix #737: Variable Explorer doesn't show name of element in 1-element vector