### PR TITLE
Add proper package version comparison.

### DIFF
--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageViewModel.cs
@@ -177,8 +177,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             License = package.License;
             RepositoryUri = repositoryUri;
             RepositoryText = repositoryUri != null ? null : package.Repository;
-            // TODO: Need proper version comparison
-            IsUpdateAvailable = InstalledVersion != LatestVersion;
+            IsUpdateAvailable = new RPackageVersion(LatestVersion).CompareTo(new RPackageVersion(InstalledVersion)) > 0;
         }
 
         public void Install() {
@@ -202,8 +201,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             if (isInstalled) {
                 InstalledVersion = package.Version;
                 IsInstalled = true;
-                // TODO: Need proper version comparison
-                IsUpdateAvailable = InstalledVersion != LatestVersion;
+                IsUpdateAvailable = new RPackageVersion(LatestVersion).CompareTo(new RPackageVersion(InstalledVersion)) > 0;
             }
 
             HasDetails = true;

--- a/src/R/Components/Impl/PackageManager/Model/RPackageVersion.cs
+++ b/src/R/Components/Impl/PackageManager/Model/RPackageVersion.cs
@@ -12,8 +12,48 @@ namespace Microsoft.R.Components.PackageManager.Model {
         }
 
         public int CompareTo(RPackageVersion other) {
-            // TODO: Add real implementation
+            if (_version == other._version) {
+                return 0;
+            }
+
+            if (_version == null) {
+                return -1;
+            }
+
+            if (other._version == null) {
+                return 1;
+            }
+
+            // R version numbers can be separated with dots and hyphens (ex: 0.3-10)
+            char[] splitChars = new char[] { '.', '-' };
+
+            // Compare each version part, a missing part is considered the same as 0
+            // Bad values that can't be parsed are also considered as 0
+            string[] thisParts = _version.Split(splitChars);
+            string[] otherParts = other._version.Split(splitChars);
+            int count = Math.Max(thisParts.Length, otherParts.Length);
+            for (int i = 0; i < count; i++) {
+                int res = ComparePart(
+                    thisParts.Length > i ? thisParts[i] : null,
+                    otherParts.Length > i ? otherParts[i] : null
+                );
+                if (res != 0) {
+                    return res;
+                }
+            }
             return 0;
+        }
+
+        private static int ComparePart(string thisPart, string otherPart) {
+            return ParsePart(thisPart).CompareTo(ParsePart(otherPart));
+        }
+
+        private static int ParsePart(string part) {
+            int val = 0;
+            if (part != null) {
+                int.TryParse(part, out val);
+            }
+            return val;
         }
 
         public override string ToString() {

--- a/src/R/Components/Test/Microsoft.R.Components.Test.csproj
+++ b/src/R/Components/Test/Microsoft.R.Components.Test.csproj
@@ -115,6 +115,7 @@
     <Compile Include="History\RHistoryTests.cs" />
     <Compile Include="InteractiveWorkflow\RInteractiveWorkflowOperationsTest.cs" />
     <Compile Include="MefCompositionTests.cs" />
+    <Compile Include="PackageManager\PackageVersionTest.cs" />
     <Compile Include="PackageManager\PackageManagerIntegrationTest.cs" />
     <Compile Include="PackageManager\TestPackages.cs" />
     <Compile Include="PackageManager\TestRepositories.cs" />

--- a/src/R/Components/Test/PackageManager/PackageVersionTest.cs
+++ b/src/R/Components/Test/PackageManager/PackageVersionTest.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using FluentAssertions;
+using Microsoft.R.Components.PackageManager.Model;
+using Microsoft.UnitTests.Core.XUnit;
+using Xunit;
+
+namespace Microsoft.R.Components.Test.PackageManager {
+    public class PackageVersionTest {
+        [CompositeTest]
+        [Category.PackageManager]
+        [InlineData("1.0", "1.1", -1)]
+        [InlineData("1.1", "1.0", 1)]
+        [InlineData("1.1", "1.1", 0)]
+        [InlineData("2", "2.0", 0)]
+        [InlineData("2", "2.0.0", 0)]
+        [InlineData("2", "2.0-0", 0)]
+        [InlineData("2.1", "2-1", 0)]
+        [InlineData("2.1.0", "2-1", 0)]
+        [InlineData("2.1.10", "2-1-1", 1)]
+        [InlineData("2.1", "2-1.1", -1)]
+        [InlineData("2.2", "2.10", -1)]
+        [InlineData(null, null, 0)]
+        [InlineData(null, "2.10", -1)]
+        [InlineData("2.10", null, 1)]
+        [InlineData("", "", 0)]
+        [InlineData("foo", "bar", 0)]
+        public void CompareVersion(string a, string b, int expected) {
+            new RPackageVersion(a).CompareTo(new RPackageVersion(b)).Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Microsoft/RTVS/issues/1413

I left the data type on the view model as a string, it could be changed to RPackageVersion if we like that better.  I remember it used to be a RPackageVersion instance and got changed to a string at some point, but I'm not sure why.