### PR TITLE
Fix XAML bindings

### DIFF
--- a/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml
+++ b/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml
@@ -42,7 +42,7 @@
             <TextBox Grid.Column="0" x:Name="FilePathBox" MinHeight="20" VerticalContentAlignment="Center" />
             <Button Grid.Column="2" x:Name="FileOpenButton" Padding="0" Content="..." Click="FileOpenButton_Click" VerticalAlignment="Center"
                     Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" MinHeight="22" MinWidth="22" 
-                    FontSize="{Binding ElementName=_self, Path=FontSize, Converter={x:Static wpf:Converters.FontScale155}}" />
+                    FontSize="{Binding ElementName=Self, Path=FontSize, Converter={x:Static wpf:Converters.FontScale155}}" />
             <RadioButton Grid.Column="4" x:Name="TabFile" GroupName="Tabs" Template="{StaticResource TabHeaderToggleButton}" Content="Input File" />
             <RadioButton Grid.Column="6" x:Name="TabFrame" GroupName="Tabs" Template="{StaticResource TabHeaderToggleButton}" Content="Data Frame" IsChecked="True" />
         </Grid>

--- a/src/Package/Impl/PackageManager/VsRPackageManagerVisualComponent.cs
+++ b/src/Package/Impl/PackageManager/VsRPackageManagerVisualComponent.cs
@@ -2,18 +2,14 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.ComponentModel.Composition;
-using Microsoft.Common.Core;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Components.PackageManager;
 using Microsoft.R.Components.Search;
 using Microsoft.R.Components.View;
 using Microsoft.R.Host.Client;
 using Microsoft.R.Support.Settings;
-using Microsoft.VisualStudio.R.Package.Commands;
 using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.R.Package.Windows;
-using Microsoft.VisualStudio.R.Packages.R;
-using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.R.Package.PackageManager {
     [Export(typeof(IRPackageManagerVisualComponentContainerFactory))]
@@ -30,9 +26,10 @@ namespace Microsoft.VisualStudio.R.Package.PackageManager {
         }
 
         public IVisualComponentContainer<IRPackageManagerVisualComponent> GetOrCreate(IRPackageManager packageManager, IRSession session, int instanceId = 0) {
-            var o = new object();
-            var shell = VsAppShell.Current.GetGlobalService<IVsUIShell>(typeof(SVsUIShell));
-            shell.PostExecCommand(RGuidList.RCmdSetGuid, RPackageCommandId.icmdShowReplWindow, 0, ref o);
+            var workflow = _workflowProvider.GetOrCreate();
+            if (workflow.ActiveWindow == null) {
+                VsAppShell.Current.DispatchOnMainThreadAsync(() => workflow.GetOrCreateVisualComponent(_componentContainerFactory));
+            }
             return GetOrCreate(instanceId, i => new PackageManagerWindowPane(packageManager, session, _searchControlProvider, RToolsSettings.Current, VsAppShell.Current));
         }
     }

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
@@ -94,7 +94,7 @@
                                 </ToolTip>
                             </StackPanel.ToolTip>
                             <TextBlock FontWeight="Bold" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" VerticalAlignment="Center" Text="{Binding Path=Name, Mode=OneWay}"
-                                       FontSize="{Binding ElementName=_self, Path=FontSize, Converter={x:Static wpf:Converters.FontScale122}}" Margin="4,0,0,0" />
+                                       FontSize="{Binding ElementName=Self, Path=FontSize, Converter={x:Static wpf:Converters.FontScale122}}" Margin="4,0,0,0" />
                             <TextBlock Text="{Binding Path=Title, Mode=OneWay}" Margin="4,0,0,0" />
                         </StackPanel>
 

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
@@ -8,7 +8,7 @@
              xmlns:view="clr-namespace:Microsoft.R.Components.PackageManager.Implementation.View"
              xmlns:designTime="clr-namespace:Microsoft.R.Components.PackageManager.Implementation.View.DesignTime"
              xmlns:viewModel="clr-namespace:Microsoft.R.Components.PackageManager.ViewModel"
-             mc:Ignorable="d" 
+             mc:Ignorable="d" x:Name="Self"
              d:DataContext="{d:DesignInstance Type=designTime:DesignTimeRPackageManagerViewModel, IsDesignTimeCreatable=True}"
              d:DesignHeight="250" d:DesignWidth="800">
     <UserControl.Resources>

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageManagerControl.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageManagerControl.xaml
@@ -7,7 +7,7 @@
              xmlns:components="clr-namespace:Microsoft.R.Components"
              xmlns:view="clr-namespace:Microsoft.R.Components.PackageManager.Implementation.View"
              xmlns:designTime="clr-namespace:Microsoft.R.Components.PackageManager.Implementation.View.DesignTime"
-             mc:Ignorable="d" 
+             mc:Ignorable="d" x:Name="Self"
              d:DataContext="{d:DesignInstance Type=designTime:DesignTimeRPackageManagerViewModel, IsDesignTimeCreatable=True}"
              d:DesignHeight="600" d:DesignWidth="600">
     <UserControl.Resources>
@@ -55,8 +55,8 @@
 
                     <!-- Settings button -->
                     <Button Grid.Column="8" x:Name="ButtonSettings" VerticalAlignment="Center" Padding="0" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" Visibility="Hidden" Click="ButtonSettings_Click">
-                        <Rectangle Width="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={x:Static rwpf:Converters.FontScale122}}"
-                                   Height="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={x:Static rwpf:Converters.FontScale122}}"
+                        <Rectangle Width="{Binding Path=FontSize, ElementName=Self, Converter={x:Static rwpf:Converters.FontScale122}}"
+                                   Height="{Binding Path=FontSize, ElementName=Self, Converter={x:Static rwpf:Converters.FontScale122}}"
                                    Fill="{StaticResource IconSettings}" />
                     </Button>
                 </Grid>

--- a/src/R/Components/Impl/PackageManager/Implementation/View/Spinner.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/Spinner.xaml
@@ -48,7 +48,7 @@
         <ItemsControl ItemsSource="{Binding Source={StaticResource EllipseData}}">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <Canvas Style="{StaticResource AnimatedCanvasStyle}" Visibility="{Binding Visibility,RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"/>
+                    <Canvas Style="{StaticResource AnimatedCanvasStyle}" Visibility="{Binding Visibility, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"/>
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
             <ItemsControl.ItemContainerStyle>


### PR DESCRIPTION
+ Adjust fix for #1507: VS crash: ObjectDisposedException for MarshalingWindowFrame (we don't actually need to show REPL when PM is loaded - we just need to start it).