### PR TITLE
Remove names from the package lists returned to VS.

### DIFF
--- a/src/Debugger/Impl/rtvs/R/packages.R
+++ b/src/Debugger/Impl/rtvs/R/packages.R
@@ -4,7 +4,8 @@
 packages.installed <- function() {
   pkgs <- installed.packages(fields = c('Title', 'Author', 'Description'))
   pkgs <- pkgs[!duplicated(pkgs[, 'Package']),]
-  apply(pkgs, 1, as.list)
+  pkgs <- apply(pkgs, 1, as.list)
+  unname(pkgs)
 }
 
 packages.loaded <- function() {
@@ -67,7 +68,7 @@ packages.available <- function() {
   # the urls of the repos we'll need to get additional details from
   repo.urls <- unique(all.available[, 'Repository'])
 
-  # we return a named list (where the names are the package names)
+  # we return an unnamed list
   # each element in that list is a named list
   # ie. Package='abc', Version='1.0', Title='', etc.
   res <- list()
@@ -82,5 +83,5 @@ packages.available <- function() {
     res <- append(res, apply(repo.available.with.details, 1, function(x) as.list(x)))
   }
 
-  return(res)
+  return(unname(res))
 }

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -160,14 +160,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
                     var result = await queryFunc(sessionToken.Session);
                     CheckEvaluationResult(result);
 
-                    // An empty list is serialized as json array because it does not have names
-                    // This happens when there are no results
-                    if (result.JsonResult is JArray) {
-                        return new List<RPackage>().AsReadOnly();
-                    }
-
-                    return ((JObject)result.JsonResult).Properties()
-                        .Select(p => p.Value.ToObject<RPackage>())
+                    return ((JArray)result.JsonResult)
+                        .Select(p => p.ToObject<RPackage>())
                         .ToList().AsReadOnly();
                 }
             } catch (MessageTransportException ex) {


### PR DESCRIPTION
The only optimization that I've been aware of that hadn't been done.  I'll close https://github.com/Microsoft/RTVS/issues/1328 after this.

This reduces the length of the JSON by 100kb, saving on serialization/transport/deserialization, and removes the special case of empty lists on deserialization.

We'll also now be able to have the same package be listed twice for "installed packages", which was not possible before with named lists.  I'm still preventing duplicates from happening right now, as I'm not sure the UI would expect it, but we can stop removing duplicates later.
