### PR TITLE
Package manager backend: detect package dll lock

### DIFF
--- a/src/Common/Core/Impl/Microsoft.Common.Core.csproj
+++ b/src/Common/Core/Impl/Microsoft.Common.Core.csproj
@@ -39,6 +39,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Collections\ListExtensions.cs" />
+    <Compile Include="Diagnostics\RestartManager.cs" />
     <Compile Include="Disposables\DisposeToken.cs" />
     <Compile Include="Extensions\CharExtensions.cs" />
     <Compile Include="Extensions\IOExtensions.cs" />

--- a/src/Host/Client/Impl/Definitions/IRSession.cs
+++ b/src/Host/Client/Impl/Definitions/IRSession.cs
@@ -17,7 +17,7 @@ namespace Microsoft.R.Host.Client {
         event EventHandler<EventArgs> DirectoryChanged;
 
         int Id { get; }
-        int ProcessId { get; }
+        int? ProcessId { get; }
         string Prompt { get; }
         bool IsHostRunning { get; }
         Task HostStarted { get; }

--- a/src/Host/Client/Impl/Definitions/IRSession.cs
+++ b/src/Host/Client/Impl/Definitions/IRSession.cs
@@ -17,6 +17,7 @@ namespace Microsoft.R.Host.Client {
         event EventHandler<EventArgs> DirectoryChanged;
 
         int Id { get; }
+        int ProcessId { get; }
         string Prompt { get; }
         bool IsHostRunning { get; }
         Task HostStarted { get; }

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -50,6 +50,8 @@ namespace Microsoft.R.Host.Client {
         private TaskCompletionSource<object> _cancelAllTcs;
         private CancellationTokenSource _cancelAllCts = new CancellationTokenSource();
 
+        public int ProcessId { get { return _process != null ? _process.Id : 0; } }
+
         public RHost(string name, IRCallbacks callbacks) {
             Check.ArgumentStringNullOrEmpty(nameof(name), name);
 

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -50,7 +50,7 @@ namespace Microsoft.R.Host.Client {
         private TaskCompletionSource<object> _cancelAllTcs;
         private CancellationTokenSource _cancelAllCts = new CancellationTokenSource();
 
-        public int ProcessId { get { return _process != null ? _process.Id : 0; } }
+        public int? ProcessId => _process?.Id;
 
         public RHost(string name, IRCallbacks callbacks) {
             Check.ArgumentStringNullOrEmpty(nameof(name), name);

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -57,6 +57,13 @@ namespace Microsoft.R.Host.Client.Session {
         public bool IsHostRunning => _isHostRunning;
         public Task HostStarted => _initializationTcs?.Task ?? Task.FromCanceled(new CancellationToken(true));
 
+        public int ProcessId {
+            get
+            {
+                return _host != null ? _host.ProcessId : 0;
+            }
+        }
+
         /// <summary>
         /// For testing purpose only
         /// Do not expose this property to the IRSession interface

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -57,12 +57,7 @@ namespace Microsoft.R.Host.Client.Session {
         public bool IsHostRunning => _isHostRunning;
         public Task HostStarted => _initializationTcs?.Task ?? Task.FromCanceled(new CancellationToken(true));
 
-        public int ProcessId {
-            get
-            {
-                return _host != null ? _host.ProcessId : 0;
-            }
-        }
+        public int? ProcessId => _host?.ProcessId;
 
         /// <summary>
         /// For testing purpose only

--- a/src/Host/Client/Test/Mocks/RSessionMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionMock.cs
@@ -12,7 +12,7 @@ namespace Microsoft.R.Host.Client.Test.Mocks {
         private IRSessionInteraction _inter;
 
         public int Id { get; set; }
-        public int ProcessId { get; set; }
+        public int? ProcessId { get; set; }
         public bool IsHostRunning { get; set; }
 
         public Task HostStarted => IsHostRunning ? Task.FromResult(0) : Task.FromCanceled(new CancellationToken(true));

--- a/src/Host/Client/Test/Mocks/RSessionMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionMock.cs
@@ -12,7 +12,7 @@ namespace Microsoft.R.Host.Client.Test.Mocks {
         private IRSessionInteraction _inter;
 
         public int Id { get; set; }
-
+        public int ProcessId { get; set; }
         public bool IsHostRunning { get; set; }
 
         public Task HostStarted => IsHostRunning ? Task.FromResult(0) : Task.FromCanceled(new CancellationToken(true));

--- a/src/R/Components/Impl/Microsoft.R.Components.csproj
+++ b/src/R/Components/Impl/Microsoft.R.Components.csproj
@@ -132,7 +132,6 @@
     <Compile Include="InteractiveWorkflow\IRInteractiveWorkflow.cs" />
     <Compile Include="InteractiveWorkflow\IRInteractiveWorkflowOperations.cs" />
     <Compile Include="InteractiveWorkflow\IRInteractiveWorkflowProvider.cs" />
-    <Compile Include="PackageManager\Implementation\RestartManager.cs" />
     <Compile Include="PackageManager\Implementation\SessionPool.cs" />
     <Compile Include="PackageManager\Implementation\ViewModel\RPackageSourceViewModel.cs" />
     <Compile Include="PackageManager\Implementation\ViewModel\RPackageViewModel.cs" />

--- a/src/R/Components/Impl/Microsoft.R.Components.csproj
+++ b/src/R/Components/Impl/Microsoft.R.Components.csproj
@@ -132,6 +132,7 @@
     <Compile Include="InteractiveWorkflow\IRInteractiveWorkflow.cs" />
     <Compile Include="InteractiveWorkflow\IRInteractiveWorkflowOperations.cs" />
     <Compile Include="InteractiveWorkflow\IRInteractiveWorkflowProvider.cs" />
+    <Compile Include="PackageManager\Implementation\RestartManager.cs" />
     <Compile Include="PackageManager\Implementation\SessionPool.cs" />
     <Compile Include="PackageManager\Implementation\ViewModel\RPackageSourceViewModel.cs" />
     <Compile Include="PackageManager\Implementation\ViewModel\RPackageViewModel.cs" />
@@ -142,6 +143,7 @@
     <Compile Include="PackageManager\Implementation\View\PackageSourcesOptionsControl.Designer.cs">
       <DependentUpon>PackageSourcesOptionsControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="PackageManager\Model\PackageLockState.cs" />
     <Compile Include="PackageManager\Model\RPackage.cs" />
     <Compile Include="PackageManager\RPackageManagerException.cs" />
     <Compile Include="PackageManager\ViewModel\IRPackageViewModel.cs" />

--- a/src/R/Components/Impl/PackageManager/IRPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/IRPackageManager.cs
@@ -97,5 +97,14 @@ namespace Microsoft.R.Components.PackageManager {
         /// <exception cref="OperationCanceledException">
         /// </exception>
         Task<string[]> GetLibraryPathsAsync();
+
+        /// <summary>
+        /// Check if the dll for the specified package is locked by the REPL
+        /// session or external process.
+        /// </summary>
+        /// <param name="name">Package name.</param>
+        /// <param name="libraryPath">Library path (in any format).</param>
+        /// <returns>Lock state.</returns>
+        PackageLockState GetPackageLockState(string name, string libraryPath);
     }
 }

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -153,12 +153,14 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             string dllPath = GetPackageDllPath(name, libraryPath);
             if (!string.IsNullOrEmpty(dllPath)) {
                 var processes = RestartManager.GetProcessesUsingFiles(new string[] { dllPath });
-                if (processes.Count == 1 && IsProcessRHost(processes[0])) {
-                    return PackageLockState.LockedByRSession;
-                }
+                if (processes != null) {
+                    if (processes.Count == 1 && IsProcessRHost(processes[0])) {
+                        return PackageLockState.LockedByRSession;
+                    }
 
-                if (processes.Count > 0) {
-                    return PackageLockState.LockedByOther;
+                    if (processes.Count > 0) {
+                        return PackageLockState.LockedByOther;
+                    }
                 }
             }
 

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Common.Core.Diagnostics;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Components.PackageManager.Model;
 using Microsoft.R.Components.PackageManager.ViewModel;
@@ -152,13 +152,13 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
         public PackageLockState GetPackageLockState(string name, string libraryPath) {
             string dllPath = GetPackageDllPath(name, libraryPath);
             if (!string.IsNullOrEmpty(dllPath)) {
-                var processes = RestartManager.GetProcessesUsingFiles(new string[] { dllPath });
+                var processes = RestartManager.GetProcessesUsingFiles(new string[] { dllPath }).ToArray();
                 if (processes != null) {
-                    if (processes.Count == 1 && processes[0].Id == _interactiveWorkflow.RSession.ProcessId) {
+                    if (processes.Length == 1 && processes[0].Id == _interactiveWorkflow.RSession.ProcessId) {
                         return PackageLockState.LockedByRSession;
                     }
 
-                    if (processes.Count > 0) {
+                    if (processes.Length > 0) {
                         return PackageLockState.LockedByOther;
                     }
                 }

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -154,7 +154,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             if (!string.IsNullOrEmpty(dllPath)) {
                 var processes = RestartManager.GetProcessesUsingFiles(new string[] { dllPath });
                 if (processes != null) {
-                    if (processes.Count == 1 && IsProcessRHost(processes[0])) {
+                    if (processes.Count == 1 && processes[0].Id == _interactiveWorkflow.RSession.ProcessId) {
                         return PackageLockState.LockedByRSession;
                     }
 
@@ -165,10 +165,6 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             }
 
             return PackageLockState.Unlocked;
-        }
-
-        private bool IsProcessRHost(Process proc) {
-            return _interactiveWorkflow.RSession.ProcessId == proc.Id;
         }
 
         private string GetPackageDllPath(string name, string libraryPath) {

--- a/src/R/Components/Impl/PackageManager/Implementation/RestartManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RestartManager.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Microsoft.R.Components.PackageManager.Implementation {
+    internal class RestartManager {
+        /// <summary>
+        /// Given a list of filenames with aboslute path, returns list of process currently locking those files.
+        /// </summary>
+        /// <param name="filePaths">Filenames with absolute path.</param>
+        /// <returns>List of processes locking the files. null if it encounters any error.</returns>
+        public static IList<Process> GetProcessesUsingFiles(string[] filePaths) {
+            uint sessionHandle;
+            List<Process> processes = new List<Process>();
+
+            int restartManager = NativeMethods.RmStartSession(out sessionHandle, 0, Guid.NewGuid().ToString("N"));
+            if (restartManager != 0) {
+                return null;
+            }
+
+            try {
+                restartManager = NativeMethods.RmRegisterResources(sessionHandle, (uint)filePaths.Length, filePaths, 0, null, 0, null);
+                if (restartManager != 0) {
+                    return null;
+                }
+
+                uint pnProcInfoNeeded = 0, pnProcInfo = 0, lpdwRebootReasons = RmRebootReasonNone;
+                restartManager = NativeMethods.RmGetList(sessionHandle, out pnProcInfoNeeded, ref pnProcInfo, null, ref lpdwRebootReasons);
+
+                if (restartManager == ERROR_MORE_DATA) {
+                    RM_PROCESS_INFO[] processInfo = new RM_PROCESS_INFO[pnProcInfoNeeded];
+                    pnProcInfo = (uint)processInfo.Length;
+
+                    restartManager = NativeMethods.RmGetList(sessionHandle, out pnProcInfoNeeded, ref pnProcInfo, processInfo, ref lpdwRebootReasons);
+                    if (restartManager == 0) {
+                        foreach (RM_PROCESS_INFO procInfo in processInfo) {
+                            try {
+                                processes.Add(Process.GetProcessById(procInfo.Process.dwProcessId));
+                            } catch (ArgumentException) {
+                                // Eat exceptions for processes which are no longer running.
+                            }
+                        }
+                    } else {
+                        return null;
+                    }
+                } else if (restartManager != 0) {
+                    return null;
+                }
+            } finally {
+                NativeMethods.RmEndSession(sessionHandle);
+            }
+
+            return processes;
+        }
+
+        private const int RmRebootReasonNone = 0;
+        private const int CCH_RM_MAX_APP_NAME = 255;
+        private const int CCH_RM_MAX_SVC_NAME = 63;
+        private const int ERROR_MORE_DATA = 234;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RM_UNIQUE_PROCESS {
+            public int dwProcessId;
+            public System.Runtime.InteropServices.ComTypes.FILETIME ProcessStartTime;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct RM_PROCESS_INFO {
+            public RM_UNIQUE_PROCESS Process;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_APP_NAME + 1)]
+            public string strAppName;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_SVC_NAME + 1)]
+            public string strServiceShortName;
+            public RM_APP_TYPE ApplicationType;
+            public uint AppStatus;
+            public uint TSSessionId;
+            [MarshalAs(UnmanagedType.Bool)]
+            public bool bRestartable;
+        }
+
+        private enum RM_APP_TYPE {
+            RmUnknownApp = 0,
+            RmMainWindow = 1,
+            RmOtherWindow = 2,
+            RmService = 3,
+            RmExplorer = 4,
+            RmConsole = 5,
+            RmCritical = 1000
+        }
+
+        [SuppressUnmanagedCodeSecurity]
+        private static class NativeMethods {
+            /// <summary>
+            /// Starts a new Restart Manager session.
+            /// </summary>
+            /// <param name="pSessionHandle">A pointer to the handle of a Restart Manager session. The session handle can be passed in subsequent calls to the Restart Manager API.</param>
+            /// <param name="dwSessionFlags">Reserved must be 0.</param>
+            /// <param name="strSessionKey">A null-terminated string that contains the session key to the new session. A GUID will work nicely.</param>
+            /// <returns>Error code. 0 is successful.</returns>
+            [DllImport("RSTRTMGR.DLL", CharSet = CharSet.Unicode)]
+            public static extern int RmStartSession(out uint pSessionHandle, int dwSessionFlags, string strSessionKey);
+
+            /// <summary>
+            /// Ends the Restart Manager session.
+            /// </summary>
+            /// <param name="pSessionHandle">A handle to an existing Restart Manager session.</param>
+            /// <returns>Error code. 0 is successful.</returns>
+            [DllImport("RSTRTMGR.DLL")]
+            public static extern int RmEndSession(uint pSessionHandle);
+
+            /// <summary>
+            /// Registers resources to a Restart Manager session. 
+            /// </summary>
+            /// <param name="pSessionHandle">A handle to an existing Restart Manager session.</param>
+            /// <param name="nFiles">The number of files being registered.</param>
+            /// <param name="rgsFilenames">An array of strings of full filename paths.</param>
+            /// <param name="nApplications">The number of processes being registered.</param>
+            /// <param name="rgApplications">An array of RM_UNIQUE_PROCESS structures. </param>
+            /// <param name="nServices">The number of services to be registered.</param>
+            /// <param name="rgsServiceNames">An array of null-terminated strings of service short names.</param>
+            /// <returns>Error code. 0 is successful.</returns>
+            [DllImport("RSTRTMGR.DLL", CharSet = CharSet.Unicode)]
+            public static extern int RmRegisterResources(uint pSessionHandle, uint nFiles, string[] rgsFilenames, uint nApplications, [In] RM_UNIQUE_PROCESS[] rgApplications, uint nServices, string[] rgsServiceNames);
+
+            /// <summary>
+            /// Gets a list of all applications and services that are currently using resources that have been registered with the Restart Manager session.
+            /// </summary>
+            /// <param name="dwSessionHandle">A handle to an existing Restart Manager session.</param>
+            /// <param name="pnProcInfoNeeded">A pointer to an array size necessary to receive RM_PROCESS_INFO structures</param>
+            /// <param name="pnProcInfo">A pointer to the total number of RM_PROCESS_INFO structures in an array and number of structures filled.</param>
+            /// <param name="rgAffectedApps">An array of RM_PROCESS_INFO structures that list the applications and services using resources that have been registered with the session.</param>
+            /// <param name="lpdwRebootReasons">Pointer to location that receives a value of the RM_REBOOT_REASON enumeration that describes the reason a system restart is needed.</param>
+            /// <returns>Error code. 0 is successful.</returns>
+            [DllImport("RSTRTMGR.DLL")]
+            public static extern int RmGetList(uint dwSessionHandle, out uint pnProcInfoNeeded, ref uint pnProcInfo, [In, Out] RM_PROCESS_INFO[] rgAffectedApps, ref uint lpdwRebootReasons);
+        }
+    }
+}

--- a/src/R/Components/Impl/PackageManager/Model/PackageLockState.cs
+++ b/src/R/Components/Impl/PackageManager/Model/PackageLockState.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.R.Components.PackageManager.Model {
+    public enum PackageLockState {
+        Unlocked,
+        LockedByRSession,
+        LockedByOther,
+    }
+}

--- a/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
+++ b/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
@@ -260,7 +260,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
 
         [Test]
         [Category.PackageManager]
-        public async Task GetPackageLockState() {
+        public async Task GetPackageLockStateLockByRSession() {
             using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
                 await SetLocalLibsAsync(eval, _libPath);
                 await InstallPackageAsync(eval, "abn", _libPath);
@@ -278,7 +278,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
 
         [Test]
         [Category.PackageManager]
-        public async Task ResetNotRecommendedPriorToInstall() {
+        public async Task GetPackageLockStateUnlocked() {
             using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
                 await SetLocalLibsAsync(eval, _libPath);
                 await InstallPackageAsync(eval, "abn", _libPath);

--- a/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
+++ b/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
@@ -7,9 +7,12 @@ using System.ComponentModel.Composition.Hosting;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Common.Core;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Components.PackageManager.Model;
 using Microsoft.R.Components.Test.Fakes.InteractiveWindow;
@@ -253,6 +256,38 @@ namespace Microsoft.R.Components.Test.PackageManager {
 
             var result = await _workflow.Packages.GetLibraryPathsAsync();
             result[0].Should().Be(_libPath.ToRPath());
+        }
+
+        [Test]
+        [Category.PackageManager]
+        public async Task GetPackageLockState() {
+            using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
+                await SetLocalLibsAsync(eval, _libPath);
+                await InstallPackageAsync(eval, "abn", _libPath);
+            }
+
+            await _workflow.Packages.LoadPackageAsync("abn", null);
+
+            var pkgs = await _workflow.Packages.GetInstalledPackagesAsync();
+            var abn = pkgs.Should().ContainSingle(pkg => pkg.Package == "abn").Which;
+            var cairo = pkgs.Should().ContainSingle(pkg => pkg.Package == "Cairo").Which;
+
+            _workflow.Packages.GetPackageLockState(abn.Package, abn.LibPath).Should().Be(PackageLockState.LockedByRSession);
+            _workflow.Packages.GetPackageLockState(cairo.Package, cairo.LibPath).Should().Be(PackageLockState.LockedByRSession);
+        }
+
+        [Test]
+        [Category.PackageManager]
+        public async Task ResetNotRecommendedPriorToInstall() {
+            using (var eval = await _workflow.RSession.BeginEvaluationAsync()) {
+                await SetLocalLibsAsync(eval, _libPath);
+                await InstallPackageAsync(eval, "abn", _libPath);
+            }
+
+            var pkgs = await _workflow.Packages.GetInstalledPackagesAsync();
+            var abn = pkgs.Should().ContainSingle(pkg => pkg.Package == "abn").Which;
+
+            _workflow.Packages.GetPackageLockState(abn.Package, abn.LibPath).Should().Be(PackageLockState.Unlocked);
         }
 
         private async Task EvaluateCode(string code, string expectedResult = null, string expectedError = null) {


### PR DESCRIPTION
I haven't gotten the UI part to work successfully in the case where the user wants us to reset the repl for them before install/uninstall (Task returned BeginInteractionAsync is awaited forever), so it's just the backend + tests in this PR.

FYI RestartManager impl comes from VS.