### PR TITLE
Change implementation of TaskExtensions.DoNotWait 

### DIFF
--- a/src/Common/Core/Test/Microsoft.Common.Core.Test.csproj
+++ b/src/Common/Core/Test/Microsoft.Common.Core.Test.csproj
@@ -108,6 +108,7 @@
     <Compile Include="StubFactories\FileSystemStubFactory.cs" />
     <Compile Include="Tasks\EventTaskSourceTest.cs" />
     <Compile Include="Tasks\FailOnTimeoutTest.cs" />
+    <Compile Include="Tasks\TaskExtensionsTest.cs" />
     <Compile Include="Threading\BinaryAsyncLockTest.cs" />
     <Compile Include="Utility\CommonTestData.cs" />
     <Compile Include="Utility\RUtilities.cs" />

--- a/src/Common/Core/Test/Tasks/TaskExtensionsTest.cs
+++ b/src/Common/Core/Test/Tasks/TaskExtensionsTest.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.UnitTests.Core.Threading;
+using Microsoft.UnitTests.Core.XUnit;
+using Xunit;
+
+namespace Microsoft.Common.Core.Test.Tasks {
+    [Collection(CollectionNames.NonParallel)]
+    public class TaskExtensionsTest {
+        [Test]
+        public async Task DoNotWait() {
+            var expected = new InvalidOperationException();
+
+            Func<Task> backgroundThreadAction = async () => {
+                await TaskUtilities.SwitchToBackgroundThread();
+                throw expected;
+            };
+
+            Func<Task> uiThreadAction = async () => {
+                try {
+                    Thread.CurrentThread.Should().Be(UIThreadHelper.Instance.Thread);
+                    await backgroundThreadAction();
+                } finally {
+                    Thread.CurrentThread.Should().Be(UIThreadHelper.Instance.Thread);
+                }
+            };
+
+            var exceptionTask = UIThreadHelper.Instance.WaitForNextExceptionAsync();
+
+            UIThreadHelper.Instance.Invoke(() => uiThreadAction().DoNotWait());
+            var actual = await exceptionTask;
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/src/UnitTests/Core/Impl/EventTaskSources.cs
+++ b/src/UnitTests/Core/Impl/EventTaskSources.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Windows.Threading;
+using Microsoft.Common.Core.Tasks;
+
+namespace Microsoft.UnitTests.Core {
+    public static class EventTaskSources {
+        public static class Dispatcher {
+            public static readonly EventTaskSource<System.Windows.Threading.Dispatcher, DispatcherUnhandledExceptionEventHandler, DispatcherUnhandledExceptionEventArgs> UnhandledException =
+                new EventTaskSource<System.Windows.Threading.Dispatcher, DispatcherUnhandledExceptionEventHandler, DispatcherUnhandledExceptionEventArgs>(
+                    (o, e) => o.UnhandledException += e,
+                    (o, e) => o.UnhandledException -= e,
+                    a => (o, e) => a(o, e));
+        }
+    }
+}

--- a/src/UnitTests/Core/Impl/Microsoft.UnitTests.Core.csproj
+++ b/src/UnitTests/Core/Impl/Microsoft.UnitTests.Core.csproj
@@ -100,6 +100,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EventTaskSources.cs" />
     <Compile Include="FluentAssertions\CollectionAssertionsExtensions.cs" />
     <Compile Include="FluentAssertions\FluentAssertionExtensions.cs" />
     <Compile Include="FluentAssertions\GivenSelectorExtensions.cs" />

--- a/src/UnitTests/Core/Impl/Threading/UIThreadHelper.cs
+++ b/src/UnitTests/Core/Impl/Threading/UIThreadHelper.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using System.Windows;
 using System.Windows.Threading;
+using Microsoft.Common.Core.Tasks;
 
 namespace Microsoft.UnitTests.Core.Threading {
     [ExcludeFromCodeCoverage]
@@ -108,6 +109,11 @@ namespace Microsoft.UnitTests.Core.Threading {
             result.Exception?.Throw();
 
             return result.Value;
+        }
+
+        public async Task<Exception> WaitForNextExceptionAsync(CancellationToken cancellationToken = default (CancellationToken)) {
+            var args = await EventTaskSources.Dispatcher.UnhandledException.Create(_application.Dispatcher, e => e.Handled = true, cancellationToken);
+            return args.Exception;
         }
 
         private void RunMainThread(object obj) {


### PR DESCRIPTION
To ensure that exception is returned back to the synchronization context, or shown with Debug.Fail if there is no synchronization context that can be used