### PR TITLE
#1574 #1579

### DIFF
--- a/src/Languages/Core/Impl/Tokens/Tokenizer.cs
+++ b/src/Languages/Core/Impl/Tokens/Tokenizer.cs
@@ -31,21 +31,20 @@ namespace Microsoft.Languages.Core.Tokens {
 
             cs.MoveToNextChar();
 
-            if (cs.IsEndOfStream())
-                return;
+            if (!cs.IsEndOfStream()) {
+                while (true) {
+                    if (cs.CurrentChar == openQuote) {
+                        cs.MoveToNextChar();
+                        break;
+                    }
 
-            while (true) {
-                if (cs.CurrentChar == openQuote) {
-                    cs.MoveToNextChar();
-                    break;
+                    if (cs.CurrentChar == '\\') {
+                        cs.MoveToNextChar();
+                    }
+
+                    if (!cs.MoveToNextChar())
+                        break;
                 }
-
-                if (cs.CurrentChar == '\\') {
-                    cs.MoveToNextChar();
-                }
-
-                if (!cs.MoveToNextChar())
-                    break;
             }
 
             int length = cs.Position - start;

--- a/src/Package/Impl/Utilities/ProjectUtilities.cs
+++ b/src/Package/Impl/Utilities/ProjectUtilities.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using EnvDTE;
@@ -57,17 +58,13 @@ namespace Microsoft.VisualStudio.R.Package.Utilities {
             DTE dte = VsAppShell.Current.GetGlobalService<DTE>();
             if (dte.Solution.Projects.Count > 0) {
                 try {
-                    if (dte.Solution != null) {
-                        Array projects;
-                        var solutionFile = dte.Solution.FullName;
-                        if (!string.IsNullOrEmpty(solutionFile)) {
-                            projects = (Array)dte.ActiveSolutionProjects;
-                            return (EnvDTE.Project)projects.GetValue(0);
-                        } else {
-                            var e = dte.Solution.Projects.GetEnumerator();
-                            e.MoveNext();
-                            return (EnvDTE.Project)e.Current;
-                        }
+                    Array projects;
+                    var solutionFile = dte.Solution.FullName;
+                    if (!string.IsNullOrEmpty(solutionFile)) {
+                        projects = (Array)dte.ActiveSolutionProjects;
+                        return (EnvDTE.Project)projects.GetValue(0);
+                    } else {
+                        return dte.Solution.Projects.Cast<EnvDTE.Project>().First();
                     }
                 } catch (COMException) { }
             }

--- a/src/R/Components/Impl/Microsoft.R.Components.csproj
+++ b/src/R/Components/Impl/Microsoft.R.Components.csproj
@@ -192,7 +192,9 @@
     <Compile Include="View\IVisualComponentContainer.cs" />
     <Compile Include="View\IVisualComponentContainerFactory.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\Core\Impl\Microsoft.Common.Core.csproj">
       <Project>{8d408909-459f-4853-a36c-745118f99869}</Project>

--- a/src/R/Editor/Impl/Signatures/SignatureHelpSource.cs
+++ b/src/R/Editor/Impl/Signatures/SignatureHelpSource.cs
@@ -37,6 +37,7 @@ namespace Microsoft.R.Editor.Signatures {
             if (document != null && !document.EditorTree.IsReady) {
                 document.EditorTree.InvokeWhenReady((p) => {
                     var broker = EditorShell.Current.ExportProvider.GetExportedValue<ISignatureHelpBroker>();
+                    broker.DismissAllSessions((ITextView)p);
                     broker.TriggerSignatureHelp((ITextView)p);
                 }, session.TextView, this.GetType(), processNow: true);
             }

--- a/src/R/Editor/Test/Completions/RCompletionSourceTest.cs
+++ b/src/R/Editor/Test/Completions/RCompletionSourceTest.cs
@@ -81,6 +81,10 @@ namespace Microsoft.R.Editor.Test.Completions {
         [InlineData("iii ", 2)]
         [InlineData("`i `", 2)]
         [InlineData("2. ", 2)]
+        [InlineData("' ", 2)]
+        [InlineData("\"a", 2)]
+        [InlineData("\"a'", 2)]
+        [InlineData("\"", 1)]
         public void SuppressedCompletion(string content, int position) {
             List<CompletionSet> completionSets = new List<CompletionSet>();
             GetCompletions(content, position, completionSets);


### PR DESCRIPTION
#1579 Crash viewing in Excel in specific scenario
- check for misc files solution
- add catching com exceptions just in case

#1574 It is possible to get duplicate signature sessions
- minor issue when caret is at the end of an unterminated string
- fix tokenizer so it actually creates token when opening quote is at the very end of the file