### PR TITLE
Fix #1538: Package manager could warn user when uninstall didn't remove all files

### DIFF
--- a/src/R/Components/Impl/Resources.Designer.cs
+++ b/src/R/Components/Impl/Resources.Designer.cs
@@ -430,6 +430,24 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package {0} can&apos;t be uninstalled because one of its files is locked by other process..
+        /// </summary>
+        public static string PackageManager_PackageLocked {
+            get {
+                return ResourceManager.GetString("PackageManager_PackageLocked", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package {0} can&apos;t be uninstalled because it has been loaded into R. You need to reset R before package can be uninstalled..
+        /// </summary>
+        public static string PackageManager_PackageLockedByRSession {
+            get {
+                return ResourceManager.GetString("PackageManager_PackageLockedByRSession", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package sources:.
         /// </summary>
         public static string PackageManager_PackageSources {

--- a/src/R/Components/Impl/Resources.resx
+++ b/src/R/Components/Impl/Resources.resx
@@ -153,6 +153,12 @@
   <data name="PackageManager_LegalDisclaimer" xml:space="preserve">
     <value>Each package is licensed to you by its owner. Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.</value>
   </data>
+  <data name="PackageManager_PackageLockedByRSession" xml:space="preserve">
+    <value>Package {0} can't be uninstalled because it has been loaded into R. You need to reset R before package can be uninstalled.</value>
+  </data>
+  <data name="PackageManager_PackageLocked" xml:space="preserve">
+    <value>Package {0} can't be uninstalled because one of its files is locked by other process.</value>
+  </data>
   <data name="PackageManager_PackageSources" xml:space="preserve">
     <value>Package sources:</value>
   </data>


### PR DESCRIPTION
User will be notified prior to uninstalling/updating package that it is locked and can't be uninstalled.