### PR TITLE
Debugger refactoring and cleanup

### DIFF
--- a/src/Debugger/Engine/Impl/AD7BoundBreakpoint.cs
+++ b/src/Debugger/Engine/Impl/AD7BoundBreakpoint.cs
@@ -13,12 +13,12 @@ namespace Microsoft.R.Debugger.Engine {
     internal sealed class AD7BoundBreakpoint : IDebugBoundBreakpoint2 {
         private enum_BP_STATE _state;
         public AD7PendingBreakpoint PendingBreakpoint { get; }
-        public DebugBreakpointLocation Location { get; }
+        public DebugSourceLocation Location { get; }
         public DebugBreakpoint DebugBreakpoint { get; private set; }
 
         public AD7Engine Engine => PendingBreakpoint.Engine;
 
-        public AD7BoundBreakpoint(AD7PendingBreakpoint pendingBreakpoint, DebugBreakpointLocation location, enum_PENDING_BP_STATE state) {
+        public AD7BoundBreakpoint(AD7PendingBreakpoint pendingBreakpoint, DebugSourceLocation location, enum_PENDING_BP_STATE state) {
             PendingBreakpoint = pendingBreakpoint;
             Location = location;
             SetState((enum_BP_STATE)state);

--- a/src/Debugger/Engine/Impl/AD7Engine.cs
+++ b/src/Debugger/Engine/Impl/AD7Engine.cs
@@ -112,7 +112,7 @@ namespace Microsoft.R.Debugger.Engine {
                     currentBrowseDebugEventArgs = _currentBrowseEventArgs;
                 }
 
-                if (currentBrowseDebugEventArgs != null && currentBrowseDebugEventArgs.Contexts == inter.Contexts) {
+                if (currentBrowseDebugEventArgs != null && currentBrowseDebugEventArgs.Context.Contexts == inter.Contexts) {
                     await inter.RespondAsync("Q\n");
                 }
             }
@@ -587,7 +587,7 @@ namespace Microsoft.R.Debugger.Engine {
             bool? sentContinue;
             lock (_browseLock) {
                 var browseEventArgs = _currentBrowseEventArgs;
-                if (browseEventArgs == null || browseEventArgs.Contexts != e.Contexts) {
+                if (browseEventArgs == null || browseEventArgs.Context.Contexts != e.Contexts) {
                     // This AfterRequest does not correspond to a Browse prompt, or at least not one
                     // that we have seen before (and paused on), so there's nothing to do.
                     return;

--- a/src/Debugger/Engine/Impl/AD7PendingBreakpoint.cs
+++ b/src/Debugger/Engine/Impl/AD7PendingBreakpoint.cs
@@ -57,7 +57,7 @@ namespace Microsoft.R.Debugger.Engine {
             TEXT_POSITION start, end;
             GetLocation(out fileName, out lineNumber, out start, out end);
 
-            _boundBreakpoint = new AD7BoundBreakpoint(this, new DebugBreakpointLocation(fileName, lineNumber), _state);
+            _boundBreakpoint = new AD7BoundBreakpoint(this, new DebugSourceLocation(fileName, lineNumber), _state);
             return VSConstants.S_OK;
         }
 

--- a/src/Debugger/Engine/Impl/AD7Property.cs
+++ b/src/Debugger/Engine/Impl/AD7Property.cs
@@ -262,9 +262,10 @@ namespace Microsoft.R.Debugger.Engine {
             errorString = null;
 
             // TODO: dwRadix
-            var setResult = TaskExtensions.RunSynchronouslyOnUIThread(ct => EvaluationResult.SetValueAsync(pszValue, ct)) as DebugErrorEvaluationResult;
-            if (setResult != null) {
-                errorString = setResult.ErrorText;
+            try {
+                TaskExtensions.RunSynchronouslyOnUIThread(ct => EvaluationResult.SetValueAsync(pszValue, ct));
+            } catch (RException ex) { 
+                errorString = ex.Message;
                 return VSConstants.E_FAIL;
             }
 

--- a/src/Debugger/Impl/DebugActiveBindingEvaluationResult.cs
+++ b/src/Debugger/Impl/DebugActiveBindingEvaluationResult.cs
@@ -1,22 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Common.Core;
-using Microsoft.R.Host.Client;
-using Newtonsoft.Json.Linq;
-using static System.FormattableString;
-
 namespace Microsoft.R.Debugger {
     public class DebugActiveBindingEvaluationResult : DebugEvaluationResult {
-        public DebugActiveBindingEvaluationResult(DebugStackFrame stackFrame, string expression, string name)
-            : base(stackFrame, expression, name) {
+        internal DebugActiveBindingEvaluationResult(DebugSession session, string environmentExpression, string expression, string name)
+            : base(session, environmentExpression, expression, name) {
         }
     }
 }

--- a/src/Debugger/Impl/DebugBreakpoint.cs
+++ b/src/Debugger/Impl/DebugBreakpoint.cs
@@ -60,22 +60,19 @@ namespace Microsoft.R.Debugger {
             return Invariant($"rtvs:::add_breakpoint({fileName.ToRStringLiteral()}, {Location.LineNumber}, {(reapply ? "TRUE" : "FALSE")})");
         }
 
-        internal async Task ReapplyBreakpointAsync(IRExpressionEvaluator evaluator, CancellationToken cancellationToken = default(CancellationToken)) {
+        internal async Task ReapplyBreakpointAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             TaskUtilities.AssertIsOnBackgroundThread();
-            await evaluator.ExecuteAsync(GetAddBreakpointExpression(false), REvaluationKind.Mutating, cancellationToken);
+            await Session.RSession.ExecuteAsync(GetAddBreakpointExpression(false), REvaluationKind.Mutating, cancellationToken);
             // TODO: mark breakpoint as invalid if this fails.
         }
 
-        internal async Task SetBreakpointAsync(IRExpressionEvaluator evaluator, CancellationToken cancellationToken = default(CancellationToken)) {
+        internal async Task SetBreakpointAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             TaskUtilities.AssertIsOnBackgroundThread();
-            await evaluator.ExecuteAsync(GetAddBreakpointExpression(true), REvaluationKind.Mutating, cancellationToken);
+            await Session.RSession.ExecuteAsync(GetAddBreakpointExpression(true), REvaluationKind.Mutating, cancellationToken);
             ++UseCount;
         }
 
-        public Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken)) =>
-            DeleteAsync(Session.RSession, cancellationToken);
-
-        public async Task DeleteAsync(IRExpressionEvaluator evaluator, CancellationToken cancellationToken = default(CancellationToken)) {
+        public async Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             Trace.Assert(UseCount > 0);
             await TaskUtilities.SwitchToBackgroundThread();
             await Session.InitializeAsync(cancellationToken);
@@ -92,7 +89,7 @@ namespace Microsoft.R.Debugger {
 
                 var code = $"rtvs:::remove_breakpoint({fileName.ToRStringLiteral()}, {Location.LineNumber})";
                 try {
-                    await evaluator.ExecuteAsync(code, REvaluationKind.Mutating, cancellationToken);
+                    await Session.RSession.ExecuteAsync(code, REvaluationKind.Mutating, cancellationToken);
                 } catch (RException ex) {
                     throw new InvalidOperationException(ex.Message, ex);
                 }

--- a/src/Debugger/Impl/DebugBreakpoint.cs
+++ b/src/Debugger/Impl/DebugBreakpoint.cs
@@ -60,19 +60,22 @@ namespace Microsoft.R.Debugger {
             return Invariant($"rtvs:::add_breakpoint({fileName.ToRStringLiteral()}, {Location.LineNumber}, {(reapply ? "TRUE" : "FALSE")})");
         }
 
-        internal async Task ReapplyBreakpointAsync(CancellationToken cancellationToken = default(CancellationToken)) {
+        internal async Task ReapplyBreakpointAsync(IRExpressionEvaluator evaluator, CancellationToken cancellationToken = default(CancellationToken)) {
             TaskUtilities.AssertIsOnBackgroundThread();
-            await Session.RSession.ExecuteAsync(GetAddBreakpointExpression(false), REvaluationKind.Mutating, cancellationToken);
+            await evaluator.ExecuteAsync(GetAddBreakpointExpression(false), REvaluationKind.Mutating, cancellationToken);
             // TODO: mark breakpoint as invalid if this fails.
         }
 
-        internal async Task SetBreakpointAsync(CancellationToken cancellationToken = default(CancellationToken)) {
+        internal async Task SetBreakpointAsync(IRExpressionEvaluator evaluator, CancellationToken cancellationToken = default(CancellationToken)) {
             TaskUtilities.AssertIsOnBackgroundThread();
-            await Session.RSession.ExecuteAsync(GetAddBreakpointExpression(true), REvaluationKind.Mutating, cancellationToken);
+            await evaluator.ExecuteAsync(GetAddBreakpointExpression(true), REvaluationKind.Mutating, cancellationToken);
             ++UseCount;
         }
 
-        public async Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken)) {
+        public Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken)) =>
+            DeleteAsync(Session.RSession, cancellationToken);
+
+        public async Task DeleteAsync(IRExpressionEvaluator evaluator, CancellationToken cancellationToken = default(CancellationToken)) {
             Trace.Assert(UseCount > 0);
             await TaskUtilities.SwitchToBackgroundThread();
             await Session.InitializeAsync(cancellationToken);
@@ -89,7 +92,7 @@ namespace Microsoft.R.Debugger {
 
                 var code = $"rtvs:::remove_breakpoint({fileName.ToRStringLiteral()}, {Location.LineNumber})";
                 try {
-                    await Session.RSession.ExecuteAsync(code, REvaluationKind.Mutating, cancellationToken);
+                    await evaluator.ExecuteAsync(code, REvaluationKind.Mutating, cancellationToken);
                 } catch (RException ex) {
                     throw new InvalidOperationException(ex.Message, ex);
                 }

--- a/src/Debugger/Impl/DebugBreakpoint.cs
+++ b/src/Debugger/Impl/DebugBreakpoint.cs
@@ -11,40 +11,17 @@ using Microsoft.R.Host.Client;
 using static System.FormattableString;
 
 namespace Microsoft.R.Debugger {
-    public struct DebugBreakpointLocation : IEquatable<DebugBreakpointLocation> {
-        public string FileName { get; }
-        public int LineNumber { get; }
-
-        public DebugBreakpointLocation(string fileName, int lineNumber) {
-            FileName = fileName;
-            LineNumber = lineNumber;
-        }
-
-        public override int GetHashCode() {
-            return new { FileName, LineNumber }.GetHashCode();
-        }
-
-        public override bool Equals(object obj) {
-            return (obj as DebugBreakpointLocation?)?.Equals(this) ?? false;
-        }
-
-        public bool Equals(DebugBreakpointLocation other) {
-            return FileName == other.FileName && LineNumber == other.LineNumber;
-        }
-
-        public override string ToString() {
-            return Invariant($"{FileName}:{LineNumber}");
-        }
-    }
-
+    /// <summary>
+    /// A breakpoint in R code.
+    /// </summary>
     public sealed class DebugBreakpoint {
         public DebugSession Session { get; }
-        public DebugBreakpointLocation Location { get; }
+        public DebugSourceLocation Location { get; }
         internal int UseCount { get; private set; }
 
         public event EventHandler BreakpointHit;
 
-        internal DebugBreakpoint(DebugSession session, DebugBreakpointLocation location) {
+        internal DebugBreakpoint(DebugSession session, DebugSourceLocation location) {
             Session = session;
             Location = location;
         }

--- a/src/Debugger/Impl/DebugBrowseEventArgs.cs
+++ b/src/Debugger/Impl/DebugBrowseEventArgs.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.R.Host.Client;
+
+namespace Microsoft.R.Debugger {
+    /// <seealso cref="DebugSession.Browse"/>
+    public class DebugBrowseEventArgs : EventArgs {
+        /// <summary>
+        /// R context for the Browse> prompt.
+        /// </summary>
+        public IRSessionContext Context { get; }
+        /// <summary>
+        /// Whether this Browse> prompt signifies the completion of a stepping operation.
+        /// </summary>
+        public bool IsStepCompleted { get; }
+        /// <summary>
+        /// Breakpoints that were hit at this Browse> prompt.
+        /// </summary>
+        public IReadOnlyCollection<DebugBreakpoint> BreakpointsHit { get; }
+
+        public DebugBrowseEventArgs(IRSessionContext context, bool isStepCompleted, IReadOnlyCollection<DebugBreakpoint> breakpointsHit) {
+            Context = context;
+            IsStepCompleted = isStepCompleted;
+            BreakpointsHit = breakpointsHit ?? new DebugBreakpoint[0];
+        }
+    }
+}

--- a/src/Debugger/Impl/DebugChildAccessorKind.cs
+++ b/src/Debugger/Impl/DebugChildAccessorKind.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.R.Debugger {
+    /// <seealso cref="DebugValueEvaluationResult.AccessorKind"/>
+    public enum DebugChildAccessorKind {
+        /// <summary>
+        /// Unknown or inapplicable - for example, when the evaluation result is not a child of any parent.
+        /// </summary>
+        None,
+        /// <summary>
+        /// Operator <c>[[ ]]</c>.
+        /// </summary>
+        Brackets,
+        /// <summary>
+        /// Operator <c>$</c>.
+        /// </summary>
+        Dollar,
+        /// <summary>
+        /// Operator <c>@</c>.
+        /// </summary>
+        At,
+    }
+}

--- a/src/Debugger/Impl/DebugErrorEvaluationResult.cs
+++ b/src/Debugger/Impl/DebugErrorEvaluationResult.cs
@@ -7,8 +7,8 @@ namespace Microsoft.R.Debugger {
     public class DebugErrorEvaluationResult : DebugEvaluationResult {
         public string ErrorText { get; }
 
-        public DebugErrorEvaluationResult(DebugStackFrame stackFrame, string expression, string name, string errorText)
-            : base(stackFrame, expression, name) {
+        internal DebugErrorEvaluationResult(DebugSession session, string environmentExpression, string expression, string name, string errorText)
+            : base(session, environmentExpression, expression, name) {
             ErrorText = errorText;
         }
 

--- a/src/Debugger/Impl/DebugEvaluationResult.cs
+++ b/src/Debugger/Impl/DebugEvaluationResult.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.R.Host.Client;
@@ -11,56 +9,42 @@ using Newtonsoft.Json.Linq;
 using static System.FormattableString;
 
 namespace Microsoft.R.Debugger {
-    [Flags]
-    public enum DebugEvaluationResultFields : ulong {
-        None,
-        Expression = 1 << 1,
-        Kind = 1 << 2,
-        Repr = 1 << 3,
-        ReprDeparse = Repr | (1 << 4),
-        ReprToString = Repr | (1 << 5),
-        ReprStr = Repr | (1 << 6),
-        TypeName = 1 << 7,
-        Classes = 1 << 8,
-        Length = 1 << 9,
-        SlotCount = 1 << 10,
-        AttrCount = 1 << 11,
-        NameCount = 1 << 12,
-        Dim = 1 << 13,
-        EnvName = 1 << 14,
-        Flags = 1 << 15,
-        Children = Expression | Length | AttrCount | SlotCount | NameCount | Flags,
-    }
-
-    internal static class DebugEvaluationResultFieldsExtensions {
-        private static readonly Dictionary<DebugEvaluationResultFields, string> _mapping = new Dictionary<DebugEvaluationResultFields, string> {
-            [DebugEvaluationResultFields.Expression] = "expression",
-            [DebugEvaluationResultFields.Kind] = "kind",
-            [DebugEvaluationResultFields.Repr] = "repr",
-            [DebugEvaluationResultFields.ReprDeparse] = "repr.deparse",
-            [DebugEvaluationResultFields.ReprToString] = "repr.toString",
-            [DebugEvaluationResultFields.ReprStr] = "repr.str",
-            [DebugEvaluationResultFields.TypeName] = "type",
-            [DebugEvaluationResultFields.Classes] = "classes",
-            [DebugEvaluationResultFields.Length] = "length",
-            [DebugEvaluationResultFields.SlotCount] = "slot_count",
-            [DebugEvaluationResultFields.AttrCount] = "attr_count",
-            [DebugEvaluationResultFields.NameCount] = "name_count",
-            [DebugEvaluationResultFields.Dim] = "dim",
-            [DebugEvaluationResultFields.EnvName] = "env_name",
-            [DebugEvaluationResultFields.Flags] = "flags",
-        };
-
-        public static string ToRVector(this DebugEvaluationResultFields fields) {
-            var fieldNames = _mapping.Where(kv => fields.HasFlag(kv.Key)).Select(kv => "'" + kv.Value + "'");
-            return Invariant($"base::c({string.Join(", ", fieldNames)})");
-        }
-    }
-
+    /// <summary>
+    /// Describes the result of evaluating an R expression, with additional metadata such as type information.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// All properties of this class, and its derived classes such as <see cref="DebugValueEvaluationResult"/>, implement snapshot
+    /// semantics - that is, they have values that describe the result of evaluation at the point where it took place, and do not
+    /// reflect any changes to R state that have occurred since then. For methods, however, this can vary; if the method does not
+    /// implement snapshot semantics, then its documentation will reflect that.
+    /// </para>
+    /// <para>
+    /// Those methods that do not have snapshot semantics will return fresh results obtained by evaluating the expression that produced
+    /// this result in its original context. If the context is no longer available (for example, it was a stack frame that is no
+    /// longer there), the results are undefined. 
+    /// </remarks>
     public abstract class DebugEvaluationResult {
         public DebugSession Session { get; }
+
+        /// <summary>
+        /// R expression designating the environment in which the evaluation that produced this result took place.
+        /// </summary>
         public string EnvironmentExpression { get; }
+
+        /// <summary>
+        /// R expression that was evaluated to produce this result.
+        /// </summary>
         public string Expression { get; }
+
+        /// <summary>
+        /// Name of the result. This corresponds to the <c>name</c> parameter of <see cref="DebugSession.EvaluateAsync"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This property is filled automatically when the result is produced by <see cref="DebugValueEvaluationResult.GetChildrenAsync"/>, 
+        /// and is primarily useful in that scenario. See the documentation of that method for more information.
+        /// </para>
         public string Name { get; }
 
         internal DebugEvaluationResult(DebugSession session, string environmentExpression, string expression, string name) {
@@ -91,14 +75,29 @@ namespace Microsoft.R.Debugger {
             return new DebugValueEvaluationResult(session, environmentExpression, expression, name, json);
         }
 
+        /// <summary>
+        /// If this evaluation result corresponds to an expression that is a valid assignment target (i.e. valid on the
+        /// left side of R operator <c>&lt;-</c>, such as a variable), assigns the specified value to that target.
+        /// </summary>
+        /// <param name="value">Value to assign. Must be a valid R expression.</param>
+        /// <returns>
+        /// A task that is completed once the assignment completes. Failure to assign is reported as exception on the task.
+        /// </returns>
         public Task SetValueAsync(string value, CancellationToken cancellationToken = default(CancellationToken)) {
             if (string.IsNullOrEmpty(Expression)) {
                 throw new InvalidOperationException(Invariant($"{nameof(SetValueAsync)} is not supported for this {nameof(DebugEvaluationResult)} because it doesn't have an associated {nameof(Expression)}."));
             }
-
             return Session.RSession.ExecuteAsync($"{Expression} <- {value}", REvaluationKind.Mutating, cancellationToken);
         }
 
+        /// <summary>
+        /// Re-evaluates the expression that produced this result in its original context, and produces a new result.
+        /// <see cref="DebugSession.EvaluateAsync"/> for description of parameters.
+        /// </summary>
+        /// <remarks>
+        /// This is used primarily to evaluate the result with a different set of <see cref="DebugEvaluationResultFields"/>,
+        /// or different <c>reprMaxLength</c>, to load additional data on demand.
+        /// </remarks>
         public Task<DebugEvaluationResult> EvaluateAsync(
             DebugEvaluationResultFields fields,
             int? reprMaxLength = null,
@@ -110,7 +109,6 @@ namespace Microsoft.R.Debugger {
             if (Expression == null) {
                 throw new InvalidOperationException("Cannot re-evaluate an evaluation result that does not have an associated expression.");
             }
-
             return Session.EvaluateAsync(EnvironmentExpression, Expression, Name, fields, reprMaxLength, cancellationToken);
         }
 

--- a/src/Debugger/Impl/DebugEvaluationResultFields.cs
+++ b/src/Debugger/Impl/DebugEvaluationResultFields.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.R.Host.Client;
+using Newtonsoft.Json.Linq;
+using static System.FormattableString;
+
+namespace Microsoft.R.Debugger {
+    /// <summary>
+    /// Used to specify properties of <see cref="DebugValueEvaluationResult"/> to fill when evaluating expressions using
+    /// <see cref="DebugSession.EvaluateAsync"/>, <see cref="DebugStackFrame.EvaluateAsync"/>, or
+    /// <see cref="DebugValueEvaluationResult.GetChildrenAsync"/>.
+    /// </summary>
+    [Flags]
+    public enum DebugEvaluationResultFields : ulong {
+        None,
+        Expression = 1 << 1,
+        Kind = 1 << 2,
+        Repr = 1 << 3,
+        ReprDeparse = Repr | (1 << 4),
+        ReprToString = Repr | (1 << 5),
+        ReprStr = Repr | (1 << 6),
+        TypeName = 1 << 7,
+        Classes = 1 << 8,
+        Length = 1 << 9,
+        SlotCount = 1 << 10,
+        AttrCount = 1 << 11,
+        NameCount = 1 << 12,
+        Dim = 1 << 13,
+        EnvName = 1 << 14,
+        Flags = 1 << 15,
+        Children = Expression | Length | AttrCount | SlotCount | NameCount | Flags,
+    }
+
+    internal static class DebugEvaluationResultFieldsExtensions {
+        private static readonly Dictionary<DebugEvaluationResultFields, string> _mapping = new Dictionary<DebugEvaluationResultFields, string> {
+            [DebugEvaluationResultFields.Expression] = "expression",
+            [DebugEvaluationResultFields.Kind] = "kind",
+            [DebugEvaluationResultFields.Repr] = "repr",
+            [DebugEvaluationResultFields.ReprDeparse] = "repr.deparse",
+            [DebugEvaluationResultFields.ReprToString] = "repr.toString",
+            [DebugEvaluationResultFields.ReprStr] = "repr.str",
+            [DebugEvaluationResultFields.TypeName] = "type",
+            [DebugEvaluationResultFields.Classes] = "classes",
+            [DebugEvaluationResultFields.Length] = "length",
+            [DebugEvaluationResultFields.SlotCount] = "slot_count",
+            [DebugEvaluationResultFields.AttrCount] = "attr_count",
+            [DebugEvaluationResultFields.NameCount] = "name_count",
+            [DebugEvaluationResultFields.Dim] = "dim",
+            [DebugEvaluationResultFields.EnvName] = "env_name",
+            [DebugEvaluationResultFields.Flags] = "flags",
+        };
+
+        public static string ToRVector(this DebugEvaluationResultFields fields) {
+            var fieldNames = _mapping.Where(kv => fields.HasFlag(kv.Key)).Select(kv => "'" + kv.Value + "'");
+            return Invariant($"base::c({string.Join(", ", fieldNames)})");
+        }
+    }
+}

--- a/src/Debugger/Impl/DebugPromiseEvaluationResult.cs
+++ b/src/Debugger/Impl/DebugPromiseEvaluationResult.cs
@@ -7,8 +7,8 @@ namespace Microsoft.R.Debugger {
     public class DebugPromiseEvaluationResult : DebugEvaluationResult {
         public string Code { get; }
 
-        public DebugPromiseEvaluationResult(DebugStackFrame stackFrame, string expression, string name, string code)
-            : base(stackFrame, expression, name) {
+        internal DebugPromiseEvaluationResult(DebugSession session, string environmentExpression, string expression, string name, string code)
+            : base(session, environmentExpression, expression, name) {
             Code = code;
         }
 

--- a/src/Debugger/Impl/DebugSession.cs
+++ b/src/Debugger/Impl/DebugSession.cs
@@ -14,6 +14,16 @@ using Newtonsoft.Json.Linq;
 using static System.FormattableString;
 
 namespace Microsoft.R.Debugger {
+    /// <summary>
+    /// An R debug session for a specific <see cref="IRSession"/>. Provides functionality to:
+    /// <list type="bullet">
+    /// <item>
+    /// Evaluate R expressions and reflect over the resulting values, providing type information, children retrieval for containers etc.
+    /// </item>
+    /// <item>Step through R code.</item>
+    /// <item>Create breakpoints in R code, and be notified when they are hit.</item>
+    /// </list>
+    /// </summary>
     public sealed class DebugSession : IDisposable {
         private Task _initializeTask;
         private readonly object _initializeLock = new object();
@@ -31,8 +41,19 @@ namespace Microsoft.R.Debugger {
 
         public IRSession RSession { get; private set; }
 
-        public bool IsBrowsing => _currentBrowseEventArgs != null;
-
+        /// <summary>
+        /// Raised when the associated R session is stopped at the Browse> prompt.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If a handler is subscribed when the session is already at a Browse> prompt, that handler will be
+        /// invoked immediately.
+        /// </para>
+        /// <para>
+        /// If a stepping operation is in progress that requires issuing several consecutive commands, the event is not
+        /// raised for any intermediate Browse> prompts, but only for the final prompt at which the step is complete.
+        /// </para>
+        /// </remarks>
         public event EventHandler<DebugBrowseEventArgs> Browse {
             add {
                 var eventArgs = _currentBrowseEventArgs;
@@ -52,6 +73,10 @@ namespace Microsoft.R.Debugger {
         }
 
         public DebugSession(IRSession session) {
+            if (session == null) {
+                throw new ArgumentNullException(nameof(session));
+            }
+
             RSession = session;
             RSession.Connected += RSession_Connected;
             RSession.BeforeRequest += RSession_BeforeRequest;
@@ -71,12 +96,19 @@ namespace Microsoft.R.Debugger {
             }
         }
 
+        /// <summary>
+        /// Initializes the debug session, enabling all other operations on it.
+        /// </summary>
+        /// <remarks>
+        /// All operations that require initialization will automatically perform it if it hasn't been performed
+        /// already, so calling this method is never a requirement. However, since initialization can be potentially
+        /// costly, calling it in advance at a more opportune moment can be preferable to lazy initialization.
+        /// </remarks>
         public Task InitializeAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             lock (_initializeLock) {
                 if (_initializeTask == null) {
                     _initializeTask = InitializeWorkerAsync(cancellationToken);
                 }
-
                 return _initializeTask;
             }
         }
@@ -112,8 +144,23 @@ namespace Microsoft.R.Debugger {
             }
         }
 
+        /// <summary>
+        /// Waits for the next REPL prompt, and executes the given command at it if it is a Browse> prompt.
+        /// </summary>
+        /// <param name="command">Command to execute. The trailing newline is appended automatically.</param>
+        /// <param name="prepare">
+        /// If not <see langword="null"/>, the provided delegate is invoked after getting exclusive access
+        /// to the prompt, but before command is executed. Can be used to perform preparatory evaluations.</param>
+        /// <returns>
+        /// <see langword="true"/> if command was successfully submitted for execution.
+        /// <see langword="false"/> if the next prompt was not a Browse> prompt.
+        /// </returns>
         public async Task<bool> ExecuteBrowserCommandAsync(string command, Func<IRSessionInteraction, Task<bool>> prepare = null, CancellationToken cancellationToken = default(CancellationToken)) {
             ThrowIfDisposed();
+            if (command == null) {
+                throw new ArgumentNullException(nameof(command));
+            }
+
             await TaskUtilities.SwitchToBackgroundThread();
 
             using (var inter = await RSession.BeginInteractionAsync(isVisible: true, cancellationToken: cancellationToken)) {
@@ -132,6 +179,10 @@ namespace Microsoft.R.Debugger {
             return false;
         }
 
+        /// <summary>
+        /// Like <see cref="EvaluateAsync(string, DebugEvaluationResultFields, int?, CancellationToken)"/>, with no limit on
+        /// representation length.
+        /// </summary>
         public Task<DebugEvaluationResult> EvaluateAsync(
             string expression,
             DebugEvaluationResultFields fields,
@@ -139,6 +190,10 @@ namespace Microsoft.R.Debugger {
         ) =>
             EvaluateAsync(expression, fields, null, cancellationToken);
 
+        /// <summary>
+        /// Like <see cref="EvaluateAsync(string, string, string, DebugEvaluationResultFields, int?, CancellationToken)"/>,
+        /// but evaluates in the global environment (<c>.GlobalEnv</c>), and the result is not named.
+        /// </summary>
         public Task<DebugEvaluationResult> EvaluateAsync(
             string expression,
             DebugEvaluationResultFields fields,
@@ -147,6 +202,19 @@ namespace Microsoft.R.Debugger {
         ) =>
             EvaluateAsync("base::.GlobalEnv", expression, null, fields, reprMaxLength, cancellationToken);
 
+        /// <summary>
+        /// Evaluates the expresion in the specified environment, and returns an object describing the result.
+        /// </summary>
+        /// <param name="environmentExpression">
+        /// Expression designating the environment in which <paramref name="expression"/> will be evaluated.
+        /// </param>
+        /// <param name="expression">Expression to evaluate.</param>
+        /// <param name="name"><see cref="DebugEvaluationResult.Name"/> of the returned evaluation result.</param>
+        /// <param name="fields">Specifies which <see cref="DebugEvaluationResult"/> properties should be present in the result.</param>
+        /// <param name="reprMaxLength">
+        /// If not <see langword="null"/>, trims representation (as returned by <see cref="DebugValueEvaluationResult.GetRepresentation"/>)
+        /// of the resulting value to the specified length.
+        /// </param>
         public async Task<DebugEvaluationResult> EvaluateAsync(
             string environmentExpression,
             string expression,
@@ -156,6 +224,12 @@ namespace Microsoft.R.Debugger {
             CancellationToken cancellationToken = default(CancellationToken)
         ) {
             ThrowIfDisposed();
+            if (environmentExpression == null) {
+                throw new ArgumentNullException(nameof(environmentExpression));
+            }
+            if (expression == null) {
+                throw new ArgumentNullException(nameof(expression));
+            }
 
             await TaskUtilities.SwitchToBackgroundThread();
             await InitializeAsync(cancellationToken);
@@ -166,6 +240,10 @@ namespace Microsoft.R.Debugger {
             return DebugEvaluationResult.Parse(this, environmentExpression, name, result);
         }
 
+        /// <summary>
+        /// Force the R session to pause wherever it is currently executing, with a Browse> prompt.
+        /// </summary>
+        /// <returns>A task that completes when the prompt appears.</returns>
         public async Task BreakAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             await TaskUtilities.SwitchToBackgroundThread();
 
@@ -178,6 +256,9 @@ namespace Microsoft.R.Debugger {
             using (var inter = await RSession.BeginInteractionAsync(true, cancellationToken)) { }
         }
 
+        /// <summary>
+        /// When paused at a Browse> prompt, continue execution.
+        /// </summary>
         public async Task ContinueAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             await TaskUtilities.SwitchToBackgroundThread();
             ExecuteBrowserCommandAsync("c", null, cancellationToken)
@@ -185,14 +266,46 @@ namespace Microsoft.R.Debugger {
                 .DoNotWait();
         }
 
+        /// <summary>
+        /// When paused at a Browse> prompt, step into the next call.
+        /// </summary>
+        /// <returns>
+        /// A task that completes when the step is either completed or interrupted (e.g. by a breakpoint).
+        /// The result is <see langword="true"/> if step was completed, and <see langword="false"/> if it was abandoned.
+        /// </returns>
+        /// <remarks>
+        /// Detailed semantics of step in are described in R documentation for
+        /// <a href="https://stat.ethz.ch/R-manual/R-devel/library/base/html/browser.html"><c>browser()</c></a> "s" command.
+        /// </remarks>
         public Task<bool> StepIntoAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             return StepAsync(cancellationToken, "s");
         }
 
+        /// <summary>
+        /// When paused at a Browse> prompt, step over the next call.
+        /// </summary>
+        /// <returns>
+        /// A task that completes when the step is either completed or interrupted (e.g. by a breakpoint).
+        /// The result is <see langword="true"/> if step was completed, and <see langword="false"/> if it was abandoned.
+        /// </returns>
+        /// <remarks>
+        /// Detailed semantics of step over are described in R documentation for
+        /// <a href="https://stat.ethz.ch/R-manual/R-devel/library/base/html/browser.html"><c>browser()</c></a> "n" command.
+        /// </remarks>
         public Task<bool> StepOverAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             return StepAsync(cancellationToken, "n");
         }
 
+        /// <summary>
+        /// When paused at a Browse> prompt, step out from the current call.
+        /// </summary>
+        /// <returns>
+        /// A task that completes when the step is either completed or interrupted (e.g. by a breakpoint).
+        /// The result is <see langword="true"/> if step was completed, and <see langword="false"/> if it was abandoned.
+        /// </returns>
+        /// Detailed semantics of step out are described in R documentation for
+        /// <a href="https://stat.ethz.ch/R-manual/R-devel/library/base/html/browserText.html"><c>browserSetDebug()</c></a> function.
+        /// </remarks>
         public Task<bool> StepOutAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             return StepAsync(cancellationToken, "c", async inter => {
                 using (var eval = await RSession.BeginEvaluationAsync(cancellationToken)) {
@@ -225,6 +338,9 @@ namespace Microsoft.R.Debugger {
             return await _stepTcs.Task;
         }
 
+        /// <summary>
+        /// If a step operation is currently in progress, cancel it.
+        /// </summary>
         public bool CancelStep() {
             ThrowIfDisposed();
 
@@ -278,12 +394,18 @@ namespace Microsoft.R.Debugger {
             return stackFrames;
         }
 
+        /// <summary>
+        /// Enables or disables breakpoints. When enabled, <see cref="DebugBreakpoint.BreakpointHit"/> events are raised.
+        /// </summary>
         public async Task EnableBreakpointsAsync(bool enable, CancellationToken cancellationToken = default(CancellationToken)) {
             ThrowIfDisposed();
             await TaskUtilities.SwitchToBackgroundThread();
             await RSession.ExecuteAsync($"rtvs:::enable_breakpoints({(enable ? "TRUE" : "FALSE")})", REvaluationKind.Mutating);
         }
 
+        /// <summary>
+        /// Creates a new breakpoint at the specified location.
+        /// </summary>
         public async Task<DebugBreakpoint> CreateBreakpointAsync(DebugBreakpointLocation location, CancellationToken cancellationToken = default(CancellationToken)) {
             ThrowIfDisposed();
 
@@ -376,7 +498,7 @@ namespace Microsoft.R.Debugger {
                 browse = _browse;
             }
 
-            var eventArgs = new DebugBrowseEventArgs(inter.Contexts, isStepCompleted, breakpointsHit);
+            var eventArgs = new DebugBrowseEventArgs(inter, isStepCompleted, breakpointsHit);
             _currentBrowseEventArgs = eventArgs;
             browse?.Invoke(this, eventArgs);
         }
@@ -399,13 +521,23 @@ namespace Microsoft.R.Debugger {
         }
     }
 
+    /// <seealso cref="DebugSession.Browse"/>
     public class DebugBrowseEventArgs : EventArgs {
-        public IReadOnlyList<IRContext> Contexts { get; }
+        /// <summary>
+        /// R context for the Browse> prompt.
+        /// </summary>
+        public IRSessionContext Context { get; }
+        /// <summary>
+        /// Whether this Browse> prompt signifies the completion of a stepping operation.
+        /// </summary>
         public bool IsStepCompleted { get; }
+        /// <summary>
+        /// Breakpoints that were hit at this Browse> prompt.
+        /// </summary>
         public IReadOnlyCollection<DebugBreakpoint> BreakpointsHit { get; }
 
-        public DebugBrowseEventArgs(IReadOnlyList<IRContext> contexts, bool isStepCompleted, IReadOnlyCollection<DebugBreakpoint> breakpointsHit) {
-            Contexts = contexts;
+        public DebugBrowseEventArgs(IRSessionContext context, bool isStepCompleted, IReadOnlyCollection<DebugBreakpoint> breakpointsHit) {
+            Context = context;
             IsStepCompleted = isStepCompleted;
             BreakpointsHit = breakpointsHit ?? new DebugBreakpoint[0];
         }

--- a/src/Debugger/Impl/DebugSourceLocation.cs
+++ b/src/Debugger/Impl/DebugSourceLocation.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using static System.FormattableString;
+
+namespace Microsoft.R.Debugger {
+    /// <summary>
+    /// A location in the source code, identified by a file name and a line number.
+    /// </summary>
+    public struct DebugSourceLocation : IEquatable<DebugSourceLocation> {
+        public string FileName { get; }
+        public int LineNumber { get; }
+
+        public DebugSourceLocation(string fileName, int lineNumber) {
+            FileName = fileName;
+            LineNumber = lineNumber;
+        }
+
+        public override int GetHashCode() {
+            return new { FileName, LineNumber }.GetHashCode();
+        }
+
+        public override bool Equals(object obj) {
+            return (obj as DebugSourceLocation?)?.Equals(this) ?? false;
+        }
+
+        public bool Equals(DebugSourceLocation other) {
+            return FileName == other.FileName && LineNumber == other.LineNumber;
+        }
+
+        public override string ToString() {
+            return Invariant($"{FileName}:{LineNumber}");
+        }
+    }
+}

--- a/src/Debugger/Impl/DebugStackFrame.cs
+++ b/src/Debugger/Impl/DebugStackFrame.cs
@@ -15,6 +15,13 @@ namespace Microsoft.R.Debugger {
         DoTrace, // .doTrace(if (rtvs:::is_breakpoint(...)) browser())
     }
 
+    /// <summary>
+    /// Describes an R stack frame.
+    /// </summary>
+    /// <remarks>
+    /// Properties of this class represent the state of the frame as it was at the point <seealso cref="DebugSession.GetStackFramesAsync"/> was called,
+    /// and do not necessarily correspond to the current state if it has changed since then.
+    /// </remarks>
     public class DebugStackFrame {
         private static readonly Regex _doTraceRegex = new Regex(
             @"^\.doTrace\(.*rtvs:::is_breakpoint\((?<filename>.*),\s*(?<line_number>\d+)\).*\)$",
@@ -22,20 +29,58 @@ namespace Microsoft.R.Debugger {
 
         public DebugSession Session { get; }
 
+        /// <summary>
+        /// Index of this frame in the call stack. Frames are counted from the bottom of the stack upward,
+        /// starting from 0 (which is normally <c>.GlobalEnv</c>).
+        /// </summary>
+        /// <remarks>
+        /// Corresponds to the <c>which</c> parameter of <c>sys.frame()</c> R function.
+        /// </remarks>
         public int Index { get; }
 
+        /// <summary>
+        /// An R expression that, when evaluated, will produce 
+        /// </summary>
         public string EnvironmentExpression => Invariant($"base::sys.frame({Index})");
 
+        /// <summary>
+        /// Name of R environment corresponding to this stack frame, or <c>null</c> if it doesn't have a name.
+        /// </summary>
+        /// <remarks>
+        /// This is <em>not</em> the same as <c>environmentName()</c> function in R. Rather, it corresponds to <c>format()</c>.
+        /// For example, the name of the global environment is <c>"&lt;environment: R_GlobalEnv&gt;"</c>, and the name of the
+        /// base package environment is <c>"&lt;environment: package:utils&gt;"</c>.
+        /// </remarks>
         public string EnvironmentName { get; }
 
+        /// <summary>
+        /// The stack frame that contains the call that produced this frame (i.e. the frame right below this one on the stack).
+        /// </summary>
         public DebugStackFrame CallingFrame { get; }
 
+        /// <summary>
+        /// Name of the file in which the currently executing line of code in this frame is located, or <c>null</c> if this
+        /// information is not available.
+        /// </summary>
         public string FileName { get; }
 
+        /// <summary>
+        /// Line number (1-based) of currently executing line of code in this frame is located, or <c>null</c> if this
+        /// information is not available.
+        /// </summary>
         public int? LineNumber { get; }
 
+        /// <summary>
+        /// Currently executing call in this frame, in its string representation as produced by <c>deparse()</c>.
+        /// </summary>
+        /// <remarks>
+        /// Corresponds to <c>sys.call()</c> for the <see cref="Index"/> of the frame.
+        /// </remarks>
         public string Call { get; }
 
+        /// <summary>
+        /// Whether this frame's environment is <c>.GlobalEnv</c>.
+        /// </summary>
         public bool IsGlobal => EnvironmentName == "<environment: R_GlobalEnv>";
 
         internal DebugStackFrameKind FrameKind { get; }
@@ -68,6 +113,10 @@ namespace Microsoft.R.Debugger {
             }
         }
 
+        /// <summary>
+        /// Same as <see cref="DebugSession.EvaluateAsync(string, string, string, DebugEvaluationResultFields, int?, CancellationToken)"/>,
+        /// but passes <see cref="EnvironmentExpression"/> of this frame as <c>environmentExpression</c> argument,
+        /// </summary>
         public Task<DebugEvaluationResult> EvaluateAsync(
             string expression,
             string name,
@@ -77,6 +126,10 @@ namespace Microsoft.R.Debugger {
         ) =>
             Session.EvaluateAsync(EnvironmentExpression, expression, name, fields, reprMaxLength, cancellationToken);
 
+        /// <summary>
+        /// Same as <see cref="EvaluateAsync(string, DebugEvaluationResultFields, int?, CancellationToken) "/>,
+        /// but uses <see langword="null"/> for <c>name</c>.
+        /// </summary>
         public Task<DebugEvaluationResult> EvaluateAsync(
             string expression,
             DebugEvaluationResultFields fields,
@@ -85,6 +138,26 @@ namespace Microsoft.R.Debugger {
         ) =>
             EvaluateAsync(expression, null, fields, reprMaxLength, cancellationToken);
 
+        /// <summary>
+        /// Produces an evaluation result describing this frame's environment. Its <see cref="DebugValueEvaluationResult.GetChildrenAsync"/>
+        /// method can then be used to retrieve the variables in the frame.
+        /// </summary>
+        /// <param name="fields">
+        /// Which fields of the evaluation result should be provided. Note that it should include at least the flags specified in the default
+        /// argument value in order for <see cref="DebugValueEvaluationResult.GetChildrenAsync"/> to be working. 
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// There is no guarantee that the returned evaluation result is <see cref="DebugValueEvaluationResult"/>. Retrieving the frame
+        /// environment involves evaluating <see cref="EnvironmentExpression"/>, and like any evaluation, it can fail. Caller should check for
+        /// <see cref="DebugErrorEvaluationResult"/> and handle it accordingly. However, it is never <see cref="DebugPromiseEvaluationResult"/>
+        /// or <see cref="DebugActiveBindingEvaluationResult"/>.
+        /// </para>
+        /// <para>
+        /// If this method is called on a stale frame (i.e if call stack has changed since the <see cref="DebugSession.GetStackFramesAsync"/>
+        /// call that produced this frame), the result is undefined, and can be an error result, or contain unrelated data.
+        /// </para>
+        /// </remarks>
         public Task<DebugEvaluationResult> GetEnvironmentAsync(
             DebugEvaluationResultFields fields = DebugEvaluationResultFields.Expression | DebugEvaluationResultFields.Length | DebugEvaluationResultFields.AttrCount | DebugEvaluationResultFields.Flags,
             CancellationToken cancellationToken = default(CancellationToken)

--- a/src/Debugger/Impl/DebugStackFrame.cs
+++ b/src/Debugger/Impl/DebugStackFrame.cs
@@ -74,25 +74,22 @@ namespace Microsoft.R.Debugger {
             DebugEvaluationResultFields fields,
             int? reprMaxLength = null,
             CancellationToken cancellationToken = default(CancellationToken)
-        ) {
-            return Session.EvaluateAsync(this, expression, name, null, fields, reprMaxLength, cancellationToken);
-        }
+        ) =>
+            Session.EvaluateAsync(EnvironmentExpression, expression, name, fields, reprMaxLength, cancellationToken);
 
         public Task<DebugEvaluationResult> EvaluateAsync(
             string expression,
             DebugEvaluationResultFields fields,
             int? reprMaxLength = null,
             CancellationToken cancellationToken = default(CancellationToken)
-        ) {
-            return EvaluateAsync(expression, null, fields, reprMaxLength, cancellationToken);
-        }
+        ) =>
+            EvaluateAsync(expression, null, fields, reprMaxLength, cancellationToken);
 
         public Task<DebugEvaluationResult> GetEnvironmentAsync(
             DebugEvaluationResultFields fields = DebugEvaluationResultFields.Expression | DebugEvaluationResultFields.Length | DebugEvaluationResultFields.AttrCount | DebugEvaluationResultFields.Flags,
             CancellationToken cancellationToken = default(CancellationToken)
-        ) {
-            return EvaluateAsync("base::environment()", fields: fields, cancellationToken: cancellationToken);
-        }
+        ) =>
+            EvaluateAsync("base::environment()", fields: fields, cancellationToken: cancellationToken);
 
         public override string ToString() =>
             Invariant($"{EnvironmentName ?? Call ?? "<null>"} at {FileName ?? "<null>"}:{(LineNumber?.ToString(CultureInfo.InvariantCulture) ?? "<null>")}");

--- a/src/Debugger/Impl/DebugValueEvaluationResult.cs
+++ b/src/Debugger/Impl/DebugValueEvaluationResult.cs
@@ -14,34 +14,72 @@ using Newtonsoft.Json.Linq;
 using static System.FormattableString;
 
 namespace Microsoft.R.Debugger {
-    public enum DebugValueEvaluationResultKind {
-        UnnamedItem,
-        NamedItem,
-        Slot,
-    }
-
-    [Flags]
-    public enum DebugValueEvaluationResultFlags {
-        None,
-        Atomic = 1 << 1,
-        Recursive = 1 << 2,
-        HasParentEnvironment = 1 << 3,
-    }
-
+    /// <summary>
+    /// Describes the result of evaluating an expression that produced a value that is not a promise or an active binding. 
+    /// </summary>
+    /// <remarks>
+    /// Note that most properties of the object will only have a meaningful value if the corresponding <see cref="DebugEvaluationResultFields"/>
+    /// flag was specified when producing the result. All properties which were not so requested will be <see langword="null"/>.
+    /// </remarks>
     public class DebugValueEvaluationResult : DebugEvaluationResult {
-        public DebugValueEvaluationResultKind Kind { get; }
+        private JObject _reprObj;
+
+        /// <summary>
+        /// The kind of accessor that was used to obtain this <see cref="DebugValueEvaluationResult"/> from its parent.
+        /// </summary>
+        public DebugChildAccessorKind AccessorKind { get; }
+        /// <summary>
+        /// Type of the value, as computed by <c>typeof(...)</c>.
+        /// </summary>
         public string TypeName { get; }
+        /// <summary>
+        /// List of classes of the value, as computed by <c>classes(...)</c>.
+        /// </summary>
+        /// <remarks>
+        /// If <see cref="DebugEvaluationResultFields.Classes"/> was not specified, this property will be
+        /// <see langword="null"/>, rather than an empty collection.
+        /// </remarks>
         public IReadOnlyList<string> Classes { get; }
+        /// <summary>
+        /// Length of the value, as computed by <c>length(...)</c>.
+        /// </summary>
         public int? Length { get; }
+        /// <summary>
+        /// Number of attributes that this value has, as computed by <c>length(attributes(...))</c>.
+        /// </summary>
         public int? AttributeCount { get; }
+        /// <summary>
+        /// Number of slots that this value has, as computed by <c>length(slotNames(class(...)))</c>.
+        /// </summary>
         public int? SlotCount { get; }
+        /// <summary>
+        /// Number of names that the children of value have, as computed by <c>length(names(...))</c>.
+        /// </summary>
         public int? NameCount { get; }
+        /// <summary>
+        /// Dimensions that this value has, as computed by <c>dim(...)</c>.
+        /// </summary>
+        /// <remarks>
+        /// If <see cref="DebugEvaluationResultFields.Dim"/> was not specified, this property will be
+        /// <see langword="null"/>, rather than an empty collection.
+        /// </remarks>
         public IReadOnlyList<int> Dim { get; }
+        /// <summary>
+        /// Various miscellaneous flags describing this value.
+        /// </summary>
         public DebugValueEvaluationResultFlags Flags { get; }
 
+        /// <seealso cref="DebugValueEvaluationResultFlags.Atomic"/>
         public bool IsAtomic => Flags.HasFlag(DebugValueEvaluationResultFlags.Atomic);
+
+        /// <seealso cref="DebugValueEvaluationResultFlags.Recursive"/>
         public bool IsRecursive => Flags.HasFlag(DebugValueEvaluationResultFlags.Recursive);
+
+        /// <summary>
+        /// Whether this value has any attributes.
+        /// </summary>
         public bool HasAttributes => AttributeCount != null && AttributeCount != 0;
+
         public bool HasSlots => SlotCount != null && SlotCount != 0;
 
         /// <summary>
@@ -76,9 +114,6 @@ namespace Microsoft.R.Debugger {
             }
         }
 
-
-        private JObject _reprObj;
-
         internal DebugValueEvaluationResult(DebugSession session, string environmentExpression, string expression, string name, JObject json)
             : base(session, environmentExpression, expression, name) {
 
@@ -109,14 +144,16 @@ namespace Microsoft.R.Debugger {
             var kind = json.Value<string>("kind");
             switch (kind) {
                 case null:
+                    AccessorKind = DebugChildAccessorKind.None;
+                    break;
                 case "[[":
-                    Kind = DebugValueEvaluationResultKind.UnnamedItem;
+                    AccessorKind = DebugChildAccessorKind.Brackets;
                     break;
                 case "$":
-                    Kind = DebugValueEvaluationResultKind.NamedItem;
+                    AccessorKind = DebugChildAccessorKind.Dollar;
                     break;
                 case "@":
-                    Kind = DebugValueEvaluationResultKind.Slot;
+                    AccessorKind = DebugChildAccessorKind.At;
                     break;
                 default:
                     throw new InvalidDataException(Invariant($"Invalid kind '{kind}' in:\n\n{json}"));
@@ -142,17 +179,36 @@ namespace Microsoft.R.Debugger {
             }
         }
 
+        /// <summary>
+        /// Returns a structure containing various representations of this value, as requested via <see cref="DebugEvaluationResultFields"/>
+        /// when this result was produced.
+        /// </summary>
         public DebugValueRepresentation GetRepresentation() {
-            return GetRepresentation(DebugValueRepresentationKind.Normal);
-        }
-
-        public DebugValueRepresentation GetRepresentation(DebugValueRepresentationKind kind) {
             if (_reprObj == null) {
                 throw new InvalidOperationException("Evaluation result does not have an associated representation.");
             }
-            return new DebugValueRepresentation(_reprObj, kind);
+            return new DebugValueRepresentation(_reprObj);
         }
 
+        /// <summary>
+        /// Computes the children of this value, and returns a collection of evaluation results describing each child.
+        /// See <see cref="DebugSession.EvaluateAsync"/> for the meaning of parameters.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Where order matters (e.g. for children of atomic vectors and lists), children are returned in that order.
+        /// Otherwise, the order is undefined. If an object has both ordered and unordered children (e.g. it is a vector
+        /// with slots), then it is guaranteed that each group is reported as a contiguous sequence within the returned
+        /// collection, and order is honored within each group; but groups themselves are not ordered relative to each other.
+        /// </para>
+        /// <para>
+        /// This method does not respect snapshot semantics - that is, it will re-evaluate the expression that produced
+        /// its value, and will obtain the most current list of children, rather than the ones that were there when
+        /// the result was originally produced. If the context in which this result was produced is no longer available
+        /// (e.g. if it was a stack frame that has since went away), the results are undefined.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="RException">Raised if child retrieval fails.</exception>
         public async Task<IReadOnlyList<DebugEvaluationResult>> GetChildrenAsync(
             DebugEvaluationResultFields fields,
             int? maxLength = null,

--- a/src/Debugger/Impl/DebugValueEvaluationResult.cs
+++ b/src/Debugger/Impl/DebugValueEvaluationResult.cs
@@ -153,16 +153,7 @@ namespace Microsoft.R.Debugger {
             return new DebugValueRepresentation(_reprObj, kind);
         }
 
-        public Task<IReadOnlyList<DebugEvaluationResult>> GetChildrenAsync(
-            DebugEvaluationResultFields fields,
-            int? maxLength = null,
-            int? reprMaxLength = null,
-            CancellationToken cancellationToken = default(CancellationToken)
-        ) =>
-            GetChildrenAsync(Session.RSession, fields, maxLength, reprMaxLength, cancellationToken);
-
         public async Task<IReadOnlyList<DebugEvaluationResult>> GetChildrenAsync(
-            IRExpressionEvaluator evaluator,
             DebugEvaluationResultFields fields,
             int? maxLength = null,
             int? reprMaxLength = null,
@@ -182,7 +173,7 @@ namespace Microsoft.R.Debugger {
             }
 
             var call = Invariant($"rtvs:::describe_children({Expression.ToRStringLiteral()}, {EnvironmentExpression}, {fields.ToRVector()}, {maxLength}, {reprMaxLength})");
-            var jChildren = await evaluator.EvaluateAsync<JArray>(call, REvaluationKind.Normal, cancellationToken);
+            var jChildren = await Session.RSession.EvaluateAsync<JArray>(call, REvaluationKind.Normal, cancellationToken);
             Trace.Assert(
                 jChildren.Children().All(t => t is JObject),
                 Invariant($"rtvs:::describe_children(): object of objects expected.\n\n{jChildren}"));

--- a/src/Debugger/Impl/DebugValueEvaluationResultFlags.cs
+++ b/src/Debugger/Impl/DebugValueEvaluationResultFlags.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.R.Debugger {
+    /// <seealso cref="DebugValueEvaluationResult.Flags"/>.
+    [Flags]
+    public enum DebugValueEvaluationResultFlags {
+        None,
+        /// <summary>
+        /// Whether <c>is.atomic()</c> is true for this value.
+        /// </summary>
+        Atomic = 1 << 1,
+        /// <summary>
+        /// Whether <c>is.recursive()</c> is true for this value.
+        /// </summary>
+        Recursive = 1 << 2,
+        /// <summary>
+        /// Whether <c>has.parent()</c> is true for this value.
+        /// </summary>
+        HasParentEnvironment = 1 << 3,
+    }
+}

--- a/src/Debugger/Impl/DebugValueRepresentation.cs
+++ b/src/Debugger/Impl/DebugValueRepresentation.cs
@@ -5,12 +5,34 @@ using System;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.R.Debugger {
+    /// <summary>
+    /// Holds various representations of an R value.
+    /// </summary>
+    /// <remarks>
+    /// For the fields of this structure to be filled, the corresponding <see cref="DebugEvaluationResultFields"/>
+    /// flags need to be specified when producing the <see cref="DebugValueEvaluationResult"/>.
+    /// </remarks>
+    /// <seealso cref="DebugValueEvaluationResult.GetRepresentation"/>
     public struct DebugValueRepresentation {
+        /// <summary>
+        /// Representation of the value obtained by calling <c>deparse()</c>.
+        /// </summary>
+        /// <seealso cref="DebugEvaluationResultFields.ReprDeparse"/>
         public readonly string Deparse;
+
+        /// <summary>
+        /// Representation of the value obtained by calling <c>toString()</c>.
+        /// </summary>
+        /// <seealso cref="DebugEvaluationResultFields.ReprToString"/>
         public readonly new string ToString;
+
+        /// <summary>
+        /// Representation of the value obtained by calling <c>str()</c>.
+        /// </summary>
+        /// <seealso cref="DebugEvaluationResultFields.ReprStr"/>
         public readonly string Str;
 
-        public DebugValueRepresentation(JObject repr, DebugValueRepresentationKind kind) {
+        internal DebugValueRepresentation(JObject repr) {
             Deparse = repr.Value<string>("deparse");
             ToString = repr.Value<string>("toString");
             Str = repr.Value<string>("str");

--- a/src/Debugger/Impl/DebugValueRepresentationKind.cs
+++ b/src/Debugger/Impl/DebugValueRepresentationKind.cs
@@ -1,8 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-namespace Microsoft.R.Debugger {
-    public enum DebugValueRepresentationKind {
-        Normal = 0,
-    }
-}

--- a/src/Debugger/Impl/IDebugSessionProvider.cs
+++ b/src/Debugger/Impl/IDebugSessionProvider.cs
@@ -6,7 +6,13 @@ using System.Threading.Tasks;
 using Microsoft.R.Host.Client;
 
 namespace Microsoft.R.Debugger {
+    /// <summary>
+    /// A service that manages debug session instances for R sessions.
+    /// </summary>
     public interface IDebugSessionProvider {
+        /// <summary>
+        /// Returns the debug session associated with the given R session. Creates the session if it doesn't exist.
+        /// </summary>
         Task<DebugSession> GetDebugSessionAsync(IRSession session, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Debugger/Impl/Microsoft.R.Debugger.csproj
+++ b/src/Debugger/Impl/Microsoft.R.Debugger.csproj
@@ -39,15 +39,19 @@
     <Compile Include="..\..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="DebugEvaluationResultFields.cs" />
+    <Compile Include="DebugSourceLocation.cs" />
     <Compile Include="DebugBreakpoint.cs" />
     <Compile Include="DebugErrorEvaluationResult.cs" />
     <Compile Include="DebugActiveBindingEvaluationResult.cs" />
     <Compile Include="DebugPromiseEvaluationResult.cs" />
+    <Compile Include="DebugBrowseEventArgs.cs" />
+    <Compile Include="DebugChildAccessorKind.cs" />
+    <Compile Include="DebugValueEvaluationResultFlags.cs" />
     <Compile Include="DebugValueRepresentation.cs" />
     <Compile Include="DebugValueEvaluationResult.cs" />
     <Compile Include="DebugSession.cs" />
     <Compile Include="DebugEvaluationResult.cs" />
-    <Compile Include="DebugValueRepresentationKind.cs" />
     <Compile Include="IDebugSessionProvider.cs" />
     <Compile Include="DebugStackFrame.cs" />
     <Compile Include="RDebugSessionProvider.cs" />

--- a/src/Debugger/Test/BreakpointsTest.cs
+++ b/src/Debugger/Test/BreakpointsTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.R.Debugger.Test {
 
             using (var debugSession = new DebugSession(_session))
             using (var sf = new SourceFile(code)) {
-                var bp1Loc = new DebugBreakpointLocation(sf.FilePath, 1);
+                var bp1Loc = new DebugSourceLocation(sf.FilePath, 1);
                 var bp1 = await debugSession.CreateBreakpointAsync(bp1Loc);
 
                 bp1.Location.Should().Be(bp1Loc);
@@ -59,7 +59,7 @@ namespace Microsoft.R.Debugger.Test {
 
                 debugSession.Breakpoints.Count.Should().Be(1);
 
-                var bp2Loc = new DebugBreakpointLocation(sf.FilePath, 3);
+                var bp2Loc = new DebugSourceLocation(sf.FilePath, 3);
                 var bp2 = await debugSession.CreateBreakpointAsync(bp2Loc);
 
                 bp2.Location.Should().Be(bp2Loc);
@@ -86,7 +86,7 @@ namespace Microsoft.R.Debugger.Test {
             using (var sf = new SourceFile(code)) {
                 await debugSession.EnableBreakpointsAsync(true);
 
-                var bp = await debugSession.CreateBreakpointAsync(new DebugBreakpointLocation(sf.FilePath, 2));
+                var bp = await debugSession.CreateBreakpointAsync(new DebugSourceLocation(sf.FilePath, 2));
                 var bpHit = new BreakpointHitDetector(bp);
 
                 await sf.Source(_session);
@@ -107,7 +107,7 @@ namespace Microsoft.R.Debugger.Test {
             using (var sf = new SourceFile(code)) {
                 await debugSession.EnableBreakpointsAsync(true);
 
-                var bp = await debugSession.CreateBreakpointAsync(new DebugBreakpointLocation(sf.FilePath, 2));
+                var bp = await debugSession.CreateBreakpointAsync(new DebugSourceLocation(sf.FilePath, 2));
                 var bpHit = new BreakpointHitDetector(bp);
 
                 await sf.Source(_session);
@@ -128,7 +128,7 @@ namespace Microsoft.R.Debugger.Test {
                 await debugSession.EnableBreakpointsAsync(true);
                 await sf.Source(_session);
 
-                var bp = await debugSession.CreateBreakpointAsync(new DebugBreakpointLocation(sf.FilePath, 2));
+                var bp = await debugSession.CreateBreakpointAsync(new DebugSourceLocation(sf.FilePath, 2));
                 var bpHit = new BreakpointHitDetector(bp);
 
                 using (var inter = await _session.BeginInteractionAsync()) {
@@ -152,7 +152,7 @@ namespace Microsoft.R.Debugger.Test {
                 await debugSession.EnableBreakpointsAsync(true);
                 await sf.Source(_session);
 
-                var bp = await debugSession.CreateBreakpointAsync(new DebugBreakpointLocation(sf.FilePath, 2));
+                var bp = await debugSession.CreateBreakpointAsync(new DebugSourceLocation(sf.FilePath, 2));
                 var bpHit = new BreakpointHitDetector(bp);
 
                 using (var inter = await _session.BeginInteractionAsync()) {
@@ -184,7 +184,7 @@ namespace Microsoft.R.Debugger.Test {
 
             using (var debugSession = new DebugSession(_session))
             using (var sf = new SourceFile(code)) {
-                var bp = await debugSession.CreateBreakpointAsync(new DebugBreakpointLocation(sf.FilePath, 2));
+                var bp = await debugSession.CreateBreakpointAsync(new DebugSourceLocation(sf.FilePath, 2));
                 debugSession.Breakpoints.Count.Should().Be(1);
 
                 await sf.Source(_session);
@@ -259,11 +259,11 @@ namespace Microsoft.R.Debugger.Test {
             using (var sf2 = new SourceFile($"eval(parse({sf1.FilePath.ToRStringLiteral()}))")) {
                 await debugSession.EnableBreakpointsAsync(true);
 
-                var bp1Loc = new DebugBreakpointLocation(sf1.FilePath, 1);
+                var bp1Loc = new DebugSourceLocation(sf1.FilePath, 1);
                 var bp1 = await debugSession.CreateBreakpointAsync(bp1Loc);
                 bp1.Location.Should().Be(bp1Loc);
 
-                var bp2Loc = new DebugBreakpointLocation(sf2.FilePath, 1);
+                var bp2Loc = new DebugSourceLocation(sf2.FilePath, 1);
                 var bp2 = await debugSession.CreateBreakpointAsync(bp2Loc);
                 bp2.Location.Should().Be(bp2Loc);
 

--- a/src/Debugger/Test/DebugSessionExtensions.cs
+++ b/src/Debugger/Test/DebugSessionExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.R.Debugger.Test {
         }
 
         public static Task<DebugBreakpoint> CreateBreakpointAsync(this DebugSession session, SourceFile sf, int lineNumber) {
-            return session.CreateBreakpointAsync(new DebugBreakpointLocation(sf.FilePath, lineNumber));
+            return session.CreateBreakpointAsync(new DebugSourceLocation(sf.FilePath, lineNumber));
         }
     }
 }

--- a/src/Debugger/Test/Match/MatchDebugStackFrames.cs
+++ b/src/Debugger/Test/Match/MatchDebugStackFrames.cs
@@ -50,15 +50,15 @@ namespace Microsoft.R.Debugger.Test.Match {
             Add(sourceFile.FilePath, lineNumber);
         }
 
-        public void Add(DebugBreakpointLocation location, int offset, IEquatable<string> call) {
+        public void Add(DebugSourceLocation location, int offset, IEquatable<string> call) {
             Add(location.FileName, location.LineNumber + offset, call);
         }
 
-        public void Add(DebugBreakpointLocation location, int offset = 0) {
+        public void Add(DebugSourceLocation location, int offset = 0) {
             Add(location.FileName, location.LineNumber + offset, MatchAny<string>.Instance);
         }
 
-        public void Add(DebugBreakpointLocation location, IEquatable<string> call) {
+        public void Add(DebugSourceLocation location, IEquatable<string> call) {
             Add(location.FileName, location.LineNumber, call);
         }
     }

--- a/src/Package/Impl/DataInspect/EvaluationWrapper.cs
+++ b/src/Package/Impl/DataInspect/EvaluationWrapper.cs
@@ -61,17 +61,6 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         #endregion
 
-        public int FrameIndex {
-            get {
-                if (base.DebugEvaluation != null && base.DebugEvaluation.StackFrame != null) {
-                    return base.DebugEvaluation.StackFrame.Index;
-                }
-
-                Debug.Fail("DebugEvaluationResult doesn't set StackFrame");
-                return 0;   // global frame index, by default
-            }
-        }
-
         protected override async Task<IReadOnlyList<IRSessionDataObject>> GetChildrenAsyncInternal() {
             List<IRSessionDataObject> result = null;
 

--- a/src/R.sln
+++ b/src/R.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.R.Package", "Package\Impl\Microsoft.VisualStudio.R.Package.csproj", "{26035FE3-25AB-45EC-BB45-7FD0B6C1D545}"
 EndProject


### PR DESCRIPTION
Clean up the use of evaluation - ditch unnecessary helpers, don't use `BeginEvaluationAsync` where it's not necessary, do not tie `DebugEvaluationResult` to a stack frame.

Rename things so that they're more descriptive and/or not misleading.

Split types into separate source files for better readability.

Remove unused stuff.

Comments, comments everywhere!