### PR TITLE
Fix #1725: Support non-system encoding for Source R Script command

### DIFF
--- a/src/Host/Client/Impl/rtvs/R/breakpoints.R
+++ b/src/Host/Client/Impl/rtvs/R/breakpoints.R
@@ -237,7 +237,8 @@ enable_breakpoints <- function(enable) {
 # an expression object containing separate calls. Consequently, when the returned object is eval'd,
 # it is possible to use debug stepping commands to execute expressions sequentially.
 debug_parse <- function(filename, encoding = getOption('encoding')) {
-  exprs <- parse(filename, encoding = encoding);
+  src <- file(filename, "r", encoding = encoding);
+  exprs <- tryCatch(parse(src), finally = close(src));
 
   # Create a `{` call wrapping all expressions in the file.
   result <- quote({});

--- a/src/Package/Impl/Repl/Commands/SourceRScriptCommand.cs
+++ b/src/Package/Impl/Repl/Commands/SourceRScriptCommand.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
+using Microsoft.Languages.Editor.EditorHelpers;
 using Microsoft.R.Components.ContentTypes;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.VisualStudio.R.Package.Commands;
@@ -32,8 +32,8 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Commands {
         }
 
         protected override void SetStatus() {
-            Visible = _interactiveWorkflow.ActiveWindow != null && _interactiveWorkflow.ActiveWindow.Container.IsOnScreen;
-            Enabled = GetFilePath() != null;
+            Visible = _interactiveWorkflow.ActiveWindow != null;
+            Enabled = Visible && !string.IsNullOrEmpty(GetFilePath());
         }
 
         protected override void Handle() {
@@ -42,8 +42,14 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Commands {
                 // Save file before sourcing
                 ITextView textView = GetActiveTextView();
                 if (textView != null) {
-                    textView.SaveFile();
-                    _interactiveWorkflow.Operations.SourceFile(filePath, _echo);
+                    if (RPackage.Current != null) {
+                        textView.SaveFile();
+                    }
+
+                    var encoding = textView.TextBuffer.GetTextDocument()?.Encoding;
+
+                    _interactiveWorkflow.ActiveWindow?.Container.Show(false);
+                    _interactiveWorkflow.Operations.SourceFile(filePath, _echo, encoding);
                 }
             }
         }

--- a/src/Package/Test/Repl/ReplCommandTest.cs
+++ b/src/Package/Test/Repl/ReplCommandTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.R.Components.ContentTypes;
@@ -22,12 +23,14 @@ using Microsoft.VisualStudio.R.Package.Test.Mocks;
 using Microsoft.VisualStudio.R.Package.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using NSubstitute;
 using Xunit;
 
 namespace Microsoft.VisualStudio.R.Package.Test.Commands {
     [ExcludeFromCodeCoverage]
     [Collection(CollectionNames.NonParallel)]
-    public class ReplCommandTest: IDisposable {
+    public class ReplCommandTest : IDisposable {
         private readonly VsDebuggerModeTracker _debuggerModeTracker;
         private readonly IRInteractiveWorkflow _workflow;
         private readonly IRInteractiveWorkflowProvider _workflowProvider;
@@ -80,7 +83,7 @@ namespace Microsoft.VisualStudio.R.Package.Test.Commands {
 
             var commandFactory = new VsRCommandFactory(_workflowProvider, _componentContainerFactory);
             var commands = UIThreadHelper.Instance.Invoke(() => commandFactory.GetCommands(tv, editorBuffer));
-            
+
             await _workflow.RSession.HostStarted;
             _workflow.ActiveWindow.Should().NotBeNull();
 
@@ -113,6 +116,40 @@ namespace Microsoft.VisualStudio.R.Package.Test.Commands {
             line.GetText().Trim().Should().Be("x");
 
             _workflow.ActiveWindow.Dispose();
+        }
+
+
+        [CompositeTest]
+        [Category.Repl]
+        [InlineData(false, "utf-8")]
+        [InlineData(true, "Windows-1252")]
+        public void SourceRScriptTest(bool echo, string encoding) {
+            var textBuffer = new TextBufferMock("", RContentTypeDefinition.ContentType);
+            var textView = new WpfTextViewMock(textBuffer);
+            var tracker = Substitute.For<IActiveWpfTextViewTracker>();
+            tracker.GetLastActiveTextView(RContentTypeDefinition.ContentType).Returns((IWpfTextView)null);
+
+            var operations = Substitute.For<IRInteractiveWorkflowOperations>();
+            var workflow = Substitute.For<IRInteractiveWorkflow>();
+            workflow.Operations.Returns(operations);
+            workflow.ActiveWindow.Returns((IInteractiveWindowVisualComponent)null);
+
+            var command = new SourceRScriptCommand(workflow, tracker, echo);
+            command.Should().BeInvisibleAndDisabled();
+
+            workflow.ActiveWindow.Returns(Substitute.For<IInteractiveWindowVisualComponent>());
+            command.Should().BeVisibleAndDisabled();
+
+            tracker.GetLastActiveTextView(RContentTypeDefinition.ContentType).Returns(textView);
+            command.Should().BeVisibleAndDisabled();
+
+            var document = new TextDocumentMock(textBuffer, "~/foo.R");
+            document.Encoding = Encoding.GetEncoding(encoding);
+            textBuffer.Properties[typeof(ITextDocument)] = document;
+            command.Should().BeVisibleAndEnabled();
+
+            command.Invoke();
+            operations.Received().SourceFile(document.FilePath, echo, document.Encoding);
         }
     }
 }

--- a/src/R/Components/Impl/InteractiveWorkflow/IRInteractiveWorkflowOperations.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/IRInteractiveWorkflowOperations.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.Text;
@@ -34,7 +35,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow {
 
         void SourceFiles(IEnumerable<string> files, bool echo);
 
-        void SourceFile(string file, bool echo);
+        void SourceFile(string file, bool echo, Encoding encoding = null);
 
         /// <summary>
         /// Attempts to launch Shiby app. Invokes 'library(shiny)'

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflowOperations.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflowOperations.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core;
@@ -172,17 +173,20 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
             });
         }
 
-        public void SourceFile(string file, bool echo) {
+        public void SourceFile(string file, bool echo, Encoding encoding = null) {
             Task.Run(async () => {
                 file = await _workflow.RSession.MakeRelativeToRUserDirectoryAsync(file);
                 _coreShell.DispatchOnUIThread(() => {
-                    ExecuteExpression(GetSourceExpression(file, echo));
+                    ExecuteExpression(GetSourceExpression(file, echo, encoding));
                 });
             });
         }
 
-        private string GetSourceExpression(string file, bool echo) {
-            return $"{(_debuggerModeTracker.IsDebugging && !echo ? "rtvs::debug_source" : "source")}({file.ToRStringLiteral()}{(echo ? ", echo=TRUE" : "")})";
+        private string GetSourceExpression(string file, bool echo, Encoding encoding = null) {
+            string func = _debuggerModeTracker.IsDebugging && !echo ? "rtvs::debug_source" : "source";
+            string echoArg = echo ? ", echo = TRUE" : "";
+            string encodingArg = encoding != null ? ", encoding = " + encoding.WebName.ToRStringLiteral() : "";
+            return $"{func}({file.ToRStringLiteral()}{echoArg}{encodingArg})";
         }
 
         public void TryRunShinyApp () {


### PR DESCRIPTION
Add support for encoding to SourceFile helper methods, and fix encoding handling in rtvs:::debug_source.

Use ITextDocument encoding when available in SourceRScript.

Enable SourceRScript command whenever there's an active REPL window, regardless of whether it is visible or not; and make it visible when command is invoked.

Add tests for SourceRScript.