### PR TITLE
SourceRScriptCommandTest fixes

### DIFF
--- a/src/Package/Impl/Commands/CommandAsyncToOleMenuCommandShim.cs
+++ b/src/Package/Impl/Commands/CommandAsyncToOleMenuCommandShim.cs
@@ -7,9 +7,9 @@ using Microsoft.R.Components.Controller;
 
 namespace Microsoft.VisualStudio.R.Package.Commands {
     internal class CommandAsyncToOleMenuCommandShim : PackageCommand {
-        private readonly ICommandAsync _command;
+        private readonly IAsyncCommand _command;
 
-        public CommandAsyncToOleMenuCommandShim(Guid group, int id, ICommandAsync command)
+        public CommandAsyncToOleMenuCommandShim(Guid group, int id, IAsyncCommand command)
             : base(group, id) {
             if (command == null) {
                 throw new ArgumentNullException(nameof(command));

--- a/src/Package/Impl/Packages/R/PackageCommands.cs
+++ b/src/Package/Impl/Packages/R/PackageCommands.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Design;
 using Microsoft.R.Components.InteractiveWorkflow;
+using Microsoft.R.Components.InteractiveWorkflow.Commands;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.R.Package.Commands;
 using Microsoft.VisualStudio.R.Package.DataInspect.Commands;

--- a/src/R/Components/Impl/Controller/IAsyncCommand.cs
+++ b/src/R/Components/Impl/Controller/IAsyncCommand.cs
@@ -7,7 +7,7 @@ namespace Microsoft.R.Components.Controller {
     /// <summary>
     /// An object that implements a single command. 
     /// </summary>
-    public interface ICommandAsync {
+    public interface IAsyncCommand {
         /// <summary>
         /// Determines current command status.
         /// </summary>

--- a/src/R/Components/Impl/InteractiveWorkflow/Commands/SourceRScriptCommand.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Commands/SourceRScriptCommand.cs
@@ -5,20 +5,15 @@ using System.Threading.Tasks;
 using Microsoft.R.Components.ContentTypes;
 using Microsoft.R.Components.Controller;
 using Microsoft.R.Components.Extensions;
-using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.VisualStudio.Text.Editor;
 
-namespace Microsoft.VisualStudio.R.Package.Repl.Commands {
-    public sealed class SourceRScriptCommand : ICommandAsync {
+namespace Microsoft.R.Components.InteractiveWorkflow.Commands {
+    public sealed class SourceRScriptCommand : IAsyncCommand {
         private readonly IRInteractiveWorkflow _interactiveWorkflow;
         private readonly IActiveWpfTextViewTracker _activeTextViewTracker;
         private readonly bool _echo;
 
-        public SourceRScriptCommand(
-            IRInteractiveWorkflow interactiveWorkflow,
-            IActiveWpfTextViewTracker activeTextViewTracker,
-            bool echo
-        ) {
+        public SourceRScriptCommand(IRInteractiveWorkflow interactiveWorkflow, IActiveWpfTextViewTracker activeTextViewTracker, bool echo) {
             _interactiveWorkflow = interactiveWorkflow;
             _activeTextViewTracker = activeTextViewTracker;
             _echo = echo;

--- a/src/R/Components/Impl/Microsoft.R.Components.csproj
+++ b/src/R/Components/Impl/Microsoft.R.Components.csproj
@@ -58,7 +58,7 @@
     <Compile Include="ContentTypes\RContentTypeDefinition.cs" />
     <Compile Include="Controller\CommandResult.cs" />
     <Compile Include="Controller\CommandStatus.cs" />
-    <Compile Include="Controller\ICommandAsync.cs" />
+    <Compile Include="Controller\IAsyncCommand.cs" />
     <Compile Include="Controller\ICommandTarget.cs" />
     <Compile Include="Extensions\CoreShellExtensions.cs" />
     <Compile Include="Extensions\TextBufferExtensions.cs" />
@@ -152,7 +152,7 @@
       <DesignTime>True</DesignTime>
     </Compile>
     <Compile Include="Resources\Images.cs" />
-    <Compile Include="Repl\Commands\SourceRScriptCommand.cs" />
+    <Compile Include="InteractiveWorkflow\Commands\SourceRScriptCommand.cs" />
     <Compile Include="Search\ISearchControl.cs" />
     <Compile Include="Search\ISearchControlProvider.cs" />
     <Compile Include="Search\ISearchHandler.cs" />

--- a/src/R/Components/Test/AssertionExtensions.cs
+++ b/src/R/Components/Test/AssertionExtensions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.R.Components.Controller;
+using Microsoft.R.Components.Test.Assertions;
+
+namespace Microsoft.R.Components.Test {
+    [ExcludeFromCodeCoverage]
+    public static class AssertionExtensions {
+        public static AsyncCommandAssertions Should(this IAsyncCommand command) {
+            return new AsyncCommandAssertions(command);
+        }
+    }
+}

--- a/src/R/Components/Test/Assertions/AsyncCommandAssertions.cs
+++ b/src/R/Components/Test/Assertions/AsyncCommandAssertions.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+ 
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using Microsoft.R.Components.Controller;
+
+namespace Microsoft.R.Components.Test.Assertions {
+    [ExcludeFromCodeCoverage]
+    public class AsyncCommandAssertions : ReferenceTypeAssertions<IAsyncCommand, AsyncCommandAssertions> {
+        protected override string Context { get; } = "Microsoft.R.Components.Controller.IAsyncCommand";
+
+        public AsyncCommandAssertions(IAsyncCommand command) {
+            Subject = command;
+        }
+
+        public AndConstraint<AsyncCommandAssertions> BeVisibleAndEnabled(string because = "", params object[] reasonArgs) {
+            return BeVisible(because, reasonArgs).And.BeEnabled(because, reasonArgs);
+        }
+
+        public AndConstraint<AsyncCommandAssertions> BeVisibleAndDisabled(string because = "", params object[] reasonArgs) {
+            return BeVisible(because, reasonArgs).And.BeDisabled(because, reasonArgs);
+        }
+
+        public AndConstraint<AsyncCommandAssertions> BeInvisibleAndDisabled(string because = "", params object[] reasonArgs) {
+            return BeInvisible(because, reasonArgs).And.BeDisabled(because, reasonArgs);
+        }
+
+        public AndConstraint<AsyncCommandAssertions> BeEnabled(string because = "", params object[] reasonArgs) {
+            return AssertStatus(CommandStatus.Enabled, true, because, reasonArgs, "Expected command of type {0} should be enabled {reason}, but it is disabled.");
+        }
+
+        public AndConstraint<AsyncCommandAssertions> BeDisabled(string because = "", params object[] reasonArgs) {
+            return AssertStatus(CommandStatus.Enabled, false, because, reasonArgs, "Expected command of type {0} should be disabled {reason}, but it is enabled.");
+        }
+
+        public AndConstraint<AsyncCommandAssertions> BeVisible(string because = "", params object[] reasonArgs) {
+            return AssertStatus(CommandStatus.Invisible, false, because, reasonArgs, "Expected command of type {0} should be visible {reason}, but it is invisible.");
+        }
+
+        public AndConstraint<AsyncCommandAssertions> BeInvisible(string because = "", params object[] reasonArgs) {
+            return AssertStatus(CommandStatus.Invisible, true, because, reasonArgs, "Expected command of type {0} should be invisible {reason}, but it is visible.");
+        }
+
+        public AndConstraint<AsyncCommandAssertions> BeChecked(string because = "", params object[] reasonArgs) {
+            return AssertStatus(CommandStatus.Latched, true, because, reasonArgs, "Expected command of type {0} should be checked {reason}, but it is unchecked.");
+        }
+
+        public AndConstraint<AsyncCommandAssertions> BeUnchecked(string because = "", params object[] reasonArgs) {
+            return AssertStatus(CommandStatus.Latched, false, because, reasonArgs, "Expected command of type {0} should be unchecked {reason}, but it is checked.");
+        }
+
+        public AndConstraint<AsyncCommandAssertions> BeSupported(string because = "", params object[] reasonArgs) {
+            return AssertStatus(CommandStatus.Supported, true, because, reasonArgs, "Expected command of type {0} should be supported {reason}, but it is unsupported.");
+        }
+
+        public AndConstraint<AsyncCommandAssertions> BeUnsupported(string because = "", params object[] reasonArgs) {
+            return AssertStatus(CommandStatus.Supported, false, because, reasonArgs, "Expected command of type {0} should be unsupported {reason}, but it is supported.");
+        }
+
+        private AndConstraint<AsyncCommandAssertions> AssertStatus(CommandStatus status, bool hasStatus, string because, object[] reasonArgs, string message) {
+            Subject.Should().NotBeNull();
+
+            Execute.Assertion.ForCondition(((Subject.Status & status) == status) == hasStatus)
+                .BecauseOf(because, reasonArgs)
+                .FailWith(message, Subject.GetType().Name);
+
+            return new AndConstraint<AsyncCommandAssertions>(this);
+        }
+    }
+}

--- a/src/R/Components/Test/Microsoft.R.Components.Test.csproj
+++ b/src/R/Components/Test/Microsoft.R.Components.Test.csproj
@@ -123,6 +123,24 @@
     <None Include="Files\Repos\Repo1\src\contrib\rtvslib1_0.1.0.tar.gz" />
     <None Include="project.json" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)'=='14.0'">
+      <ItemGroup>
+        <ProjectReference Include="..\..\..\UnitTests\References.14.0\Microsoft.UnitTests.References.14.0.csproj">
+          <Project>{78203460-9937-45E5-81CC-3045DDC10527}</Project>
+          <Name>Microsoft.UnitTests.References.14.0</Name>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(VisualStudioVersion)'=='15.0'">
+      <ItemGroup>
+        <ProjectReference Include="..\..\..\UnitTests\References.15.0\Microsoft.UnitTests.References.14.0.csproj">
+          <Project>{78203460-9937-45E5-81CC-3045DDC10527}</Project>
+          <Name>Microsoft.UnitTests.References.15.0</Name>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\Core\Impl\Microsoft.Common.Core.csproj">
       <Project>{8D408909-459F-4853-A36C-745118F99869}</Project>
@@ -147,14 +165,6 @@
     <ProjectReference Include="..\..\..\UnitTests\Core\Impl\Microsoft.UnitTests.Core.csproj">
       <Project>{5ef2ad64-d6fe-446b-b350-8c7f0df0834d}</Project>
       <Name>Microsoft.UnitTests.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\UnitTests\References.14.0\Microsoft.UnitTests.References.14.0.csproj" Condition="'$(VisualStudioVersion)'=='14.0'">
-      <Project>{78203460-9937-45E5-81CC-3045DDC10527}</Project>
-      <Name>Microsoft.UnitTests.References.14.0</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\UnitTests\References.15.0\Microsoft.UnitTests.References.15.0.csproj" Condition="'$(VisualStudioVersion)'=='15.0'">
-      <Project>{4297FA87-629A-4000-8169-D97E8E64890E}</Project>
-      <Name>Microsoft.UnitTests.References.15.0</Name>
     </ProjectReference>
     <ProjectReference Include="..\Impl\Microsoft.R.Components.csproj">
       <Project>{506141be-1418-4d75-8e24-54a9280b0a66}</Project>

--- a/src/R/Components/Test/Microsoft.R.Components.Test.csproj
+++ b/src/R/Components/Test/Microsoft.R.Components.Test.csproj
@@ -45,6 +45,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssertionExtensions.cs" />
+    <Compile Include="Assertions\AsyncCommandAssertions.cs" />
     <Compile Include="EventTaskSources.cs" />
     <Compile Include="Fakes\InteractiveWindow\TestInteractiveWindowEditorsFactoryService.cs" />
     <Compile Include="Fakes\InteractiveWindow\TestRInteractiveWorkflowProvider.cs" />
@@ -80,7 +82,7 @@
     <Compile Include="PackageManager\TestRepositories.cs" />
     <Compile Include="RComponentsMefCatalogFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Repl\ReplCommandTest.cs" />
+    <Compile Include="InteractiveWorkflow\RInteractiveWorkflowCommandTest.cs" />
     <Compile Include="StubFactories\InteractiveWorkflowStubFactory.cs" />
     <Compile Include="StubFactories\RHistoryStubFactory.cs" />
     <Compile Include="StubFactories\RHistoryProviderStubFactory.cs" />


### PR DESCRIPTION
- Build fix (replaced RToolsSettings singleton with test-related ISettings instance)
- Move SourceRScriptCommand to the correct namespace
- Add AsyncCommandAssertions to simplify status checks