### PR TITLE
Fix #1806, #1796, #1805

### DIFF
--- a/src/Debugger/Impl/AD7ErrorBreakpoint.cs
+++ b/src/Debugger/Impl/AD7ErrorBreakpoint.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Debugger.Interop;
+
+namespace Microsoft.R.Debugger {
+    internal sealed class AD7ErrorBreakpoint : IDebugErrorBreakpoint2 {
+        public AD7PendingBreakpoint PendingBreakpoint { get; }
+
+        public AD7ErrorBreakpointResolution ErrorResolution { get; }
+        
+        public AD7ErrorBreakpoint(AD7PendingBreakpoint pendingBreakpoint, AD7ErrorBreakpointResolution errorResolution) {
+            PendingBreakpoint = pendingBreakpoint;
+            ErrorResolution = errorResolution;
+        }
+
+        public int GetPendingBreakpoint(out IDebugPendingBreakpoint2 ppPendingBreakpoint) {
+            ppPendingBreakpoint = PendingBreakpoint;
+            return VSConstants.S_OK;
+        }
+
+        public int GetBreakpointResolution(out IDebugErrorBreakpointResolution2 ppErrorResolution) {
+            ppErrorResolution = ErrorResolution;
+            return VSConstants.S_OK;
+        }
+    }
+}

--- a/src/Debugger/Impl/AD7ErrorBreakpointResolution.cs
+++ b/src/Debugger/Impl/AD7ErrorBreakpointResolution.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Debugger.Interop;
+
+namespace Microsoft.R.Debugger {
+    internal sealed class AD7ErrorBreakpointResolution : IDebugErrorBreakpointResolution2 {
+        public string Message { get; }
+
+        public AD7ErrorBreakpointResolution(string message) {
+            Message = message;
+        }
+
+        public int GetBreakpointType(enum_BP_TYPE[] pBPType) {
+            pBPType[0] = enum_BP_TYPE.BPT_NONE;
+            return VSConstants.S_OK;
+        }
+
+        public int GetResolutionInfo(enum_BPERESI_FIELDS dwFields, BP_ERROR_RESOLUTION_INFO[] pErrorResolutionInfo) {
+            var result = new BP_ERROR_RESOLUTION_INFO();
+            result.dwFields = enum_BPERESI_FIELDS.BPERESI_MESSAGE | enum_BPERESI_FIELDS.BPERESI_TYPE;
+            result.dwType = enum_BP_ERROR_TYPE.BPET_GENERAL_ERROR;
+            result.bstrMessage = Message;
+
+            pErrorResolutionInfo[0] = result;
+            return VSConstants.S_OK;
+        }
+    }
+}

--- a/src/Debugger/Impl/Microsoft.R.Debugger.csproj
+++ b/src/Debugger/Impl/Microsoft.R.Debugger.csproj
@@ -31,6 +31,8 @@
     <Compile Include="..\..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AD7ErrorBreakpointResolution.cs" />
+    <Compile Include="AD7ErrorBreakpoint.cs" />
     <Compile Include="AD7BoundBreakpoint.cs" />
     <Compile Include="AD7BreakpointResolution.cs" />
     <Compile Include="AD7CustomViewer.cs" />

--- a/src/Host/Client/Impl/rtvs/R/breakpoints.R
+++ b/src/Host/Client/Impl/rtvs/R/breakpoints.R
@@ -247,7 +247,7 @@ debug_parse <- function(filename, encoding = getOption('encoding')) {
 
   srcfile <- srcfilecopy(filename, text, file.mtime(filename), isFile = TRUE)
 
-  exprs <- parse(text = text, encoding = encoding, srcfile = srcfile);
+  exprs <- parse(text = text, srcfile = srcfile);
 
   # Create a `{` call wrapping all expressions in the file.
   result <- quote({});

--- a/src/Package/Impl/Packages/Attributes/ProvideDebugEngineAttribute.cs
+++ b/src/Package/Impl/Packages/Attributes/ProvideDebugEngineAttribute.cs
@@ -8,45 +8,67 @@ using Microsoft.VisualStudio.Shell;
 namespace Microsoft.VisualStudio.R.Packages {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     class ProvideDebugEngineAttribute : RegistrationAttribute {
-        private readonly string _id, _name;
-        private readonly bool _setNextStatement, _hitCountBp, _justMyCodeStepping;
-        private readonly Type _programProvider, _debugEngine;
+        public string Name { get; set; }
 
-        public ProvideDebugEngineAttribute(string name, Type programProvider, Type debugEngine, string id, bool setNextStatement = true, bool hitCountBp = false, bool justMyCodeStepping = true) {
-            _name = name;
-            _programProvider = programProvider;
-            _debugEngine = debugEngine;
-            _id = id;
-            _setNextStatement = setNextStatement;
-            _hitCountBp = hitCountBp;
-            _justMyCodeStepping = justMyCodeStepping;
+        public string EngineGuid { get; set; }
+
+        public Type EngineType { get; set; }
+
+        public Type ProgramProviderType { get; set; }
+
+        public bool SupportsAttach { get; set; }
+
+        public bool SupportsSetNextStatement { get; set; }
+
+        public bool SupportsAddressBreakpoints { get; set; }
+
+        public bool SupportsCallstackBreakpoints { get; set; }
+
+        public bool SupportsFunctionBreakpoints { get; set; }
+
+        public bool SupportsConditionalBreakpoints { get; set; }
+
+        public bool SupportsHitCountBreakpoints { get; set; }
+
+        public bool SupportsJustMyCodeStepping { get; set; }
+
+        public bool SupportsExceptions { get; set; }
+
+        public bool SupportsRemoteDebugging { get; set; }
+
+        public int AutoSelectPriority { get; set; } = 6;
+
+        public ProvideDebugEngineAttribute(string name, string engineGuid, Type engineType) {
+            Name = name;
+            EngineGuid = engineGuid;
+            EngineType = engineType;
         }
 
         public override void Register(RegistrationContext context) {
-            var engineKey = context.CreateKey("AD7Metrics\\Engine\\" + new Guid(_id).ToString("B"));
-            engineKey.SetValue("Name", _name);
+            var engineKey = context.CreateKey("AD7Metrics\\Engine\\" + new Guid(EngineGuid).ToString("B"));
+            engineKey.SetValue("Name", Name);
 
-            engineKey.SetValue("CLSID", _debugEngine.GUID.ToString("B"));
-            if (_programProvider != null) {
-                engineKey.SetValue("ProgramProvider", _programProvider.GUID.ToString("B"));
+            engineKey.SetValue("CLSID", EngineType.GUID.ToString("B"));
+            if (ProgramProviderType != null) {
+                engineKey.SetValue("ProgramProvider", ProgramProviderType.GUID.ToString("B"));
             }
             engineKey.SetValue("PortSupplier", "{708C1ECA-FF48-11D2-904F-00C04FA302A1}"); // {708C1ECA-FF48-11D2-904F-00C04FA302A1}
 
-            engineKey.SetValue("Attach", 1);
-            engineKey.SetValue("AddressBP", 0);
-            engineKey.SetValue("AutoSelectPriority", 6);
-            engineKey.SetValue("CallstackBP", 1);
-            engineKey.SetValue("ConditionalBP", 1);
-            engineKey.SetValue("Exceptions", 1);
-            engineKey.SetValue("SetNextStatement", _setNextStatement ? 1 : 0);
-            engineKey.SetValue("RemoteDebugging", 1);
-            engineKey.SetValue("HitCountBP", _hitCountBp ? 1 : 0);
-            engineKey.SetValue("JustMyCodeStepping", _justMyCodeStepping ? 1 : 0);
-            //engineKey.SetValue("FunctionBP", 1); // TODO: Implement PythonLanguageInfo.ResolveName
+            engineKey.SetValue("Attach", SupportsAttach ? 1 : 0);
+            engineKey.SetValue("AddressBP", SupportsAddressBreakpoints ? 1 : 0);
+            engineKey.SetValue("AutoSelectPriority", AutoSelectPriority);
+            engineKey.SetValue("CallstackBP", SupportsCallstackBreakpoints ? 1 : 0);
+            engineKey.SetValue("ConditionalBP", SupportsConditionalBreakpoints ? 1 : 0);
+            engineKey.SetValue("Exceptions", SupportsExceptions ? 1 : 0);
+            engineKey.SetValue("SetNextStatement", SupportsSetNextStatement ? 1 : 0);
+            engineKey.SetValue("RemoteDebugging", SupportsRemoteDebugging ? 1 : 0);
+            engineKey.SetValue("HitCountBP", SupportsHitCountBreakpoints ? 1 : 0);
+            engineKey.SetValue("JustMyCodeStepping", SupportsJustMyCodeStepping ? 1 : 0);
+            engineKey.SetValue("FunctionBP", SupportsFunctionBreakpoints ? 1 : 0);
 
             // provide class / assembly so we can be created remotely from the GAC w/o registering a CLSID 
-            engineKey.SetValue("EngineClass", _debugEngine.FullName);
-            engineKey.SetValue("EngineAssembly", _debugEngine.Assembly.FullName);
+            engineKey.SetValue("EngineClass", EngineType.FullName);
+            engineKey.SetValue("EngineAssembly", EngineType.Assembly.FullName);
 
             // load locally so we don't need to create MSVSMon which would need to know how to
             // get at our provider type.  See AD7ProgramProvider.GetProviderProcessData for more info
@@ -68,24 +90,24 @@ namespace Microsoft.VisualStudio.R.Packages {
             }
 
             var clsidKey = context.CreateKey("CLSID");
-            var clsidGuidKey = clsidKey.CreateSubkey(_debugEngine.GUID.ToString("B"));
-            clsidGuidKey.SetValue("Assembly", _debugEngine.Assembly.FullName);
-            clsidGuidKey.SetValue("Class", _debugEngine.FullName);
+            var clsidGuidKey = clsidKey.CreateSubkey(EngineType.GUID.ToString("B"));
+            clsidGuidKey.SetValue("Assembly", EngineType.Assembly.FullName);
+            clsidGuidKey.SetValue("Class", EngineType.FullName);
             clsidGuidKey.SetValue("InprocServer32", context.InprocServerPath);
-            clsidGuidKey.SetValue("CodeBase", Path.Combine(context.ComponentPath, _debugEngine.Module.Name));
+            clsidGuidKey.SetValue("CodeBase", Path.Combine(context.ComponentPath, EngineType.Module.Name));
             clsidGuidKey.SetValue("ThreadingModel", "Free");
 
-            if (_programProvider != null) {
-                clsidGuidKey = clsidKey.CreateSubkey(_programProvider.GUID.ToString("B"));
-                clsidGuidKey.SetValue("Assembly", _programProvider.Assembly.FullName);
-                clsidGuidKey.SetValue("Class", _programProvider.FullName);
+            if (ProgramProviderType != null) {
+                clsidGuidKey = clsidKey.CreateSubkey(ProgramProviderType.GUID.ToString("B"));
+                clsidGuidKey.SetValue("Assembly", ProgramProviderType.Assembly.FullName);
+                clsidGuidKey.SetValue("Class", ProgramProviderType.FullName);
                 clsidGuidKey.SetValue("InprocServer32", context.InprocServerPath);
-                clsidGuidKey.SetValue("CodeBase", Path.Combine(context.ComponentPath, _debugEngine.Module.Name));
+                clsidGuidKey.SetValue("CodeBase", Path.Combine(context.ComponentPath, EngineType.Module.Name));
                 clsidGuidKey.SetValue("ThreadingModel", "Free");
             }
 
-            using (var exceptionAssistantKey = context.CreateKey("ExceptionAssistant\\KnownEngines\\" + new Guid(_id).ToString("B"))) {
-                exceptionAssistantKey.SetValue("", _name);
+            using (var exceptionAssistantKey = context.CreateKey("ExceptionAssistant\\KnownEngines\\" + new Guid(EngineGuid).ToString("B"))) {
+                exceptionAssistantKey.SetValue("", Name);
             }
         }
 

--- a/src/Package/Impl/Packages/R/RPackage.cs
+++ b/src/Package/Impl/Packages/R/RPackage.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.R.Packages.R {
     [ProvideToolWindow(typeof(HelpWindowPane), Style = VsDockStyle.Linked, Window = ToolWindowGuids80.PropertiesWindow)]
     [ProvideToolWindow(typeof(HistoryWindowPane), Style = VsDockStyle.Linked, Window = ToolWindowGuids80.SolutionExplorer)]
     [ProvideToolWindow(typeof(PackageManagerWindowPane), Style = VsDockStyle.MDI)]
-    [ProvideDebugEngine(RContentTypeDefinition.LanguageName, null, typeof(AD7Engine), DebuggerGuids.DebugEngineString)]
+    [ProvideDebugEngine(RContentTypeDefinition.LanguageName, DebuggerGuids.DebugEngineString, typeof(AD7Engine), SupportsAttach = true)]
     [ProvideDebugLanguage(RContentTypeDefinition.LanguageName, DebuggerGuids.LanguageGuidString, "{D67D5DB8-3D44-4105-B4B8-47AB1BA66180}", DebuggerGuids.DebugEngineString, DebuggerGuids.CustomViewerString)]
     [ProvideDebugPortSupplier("R Interactive sessions", typeof(RDebugPortSupplier), DebuggerGuids.PortSupplierString, typeof(RDebugPortPicker))]
     [ProvideComClass(typeof(RDebugPortPicker))]


### PR DESCRIPTION
Fix #1806: No error message for conditional and hit count breakpoints

Implement IDebugErrorBreakpoint2 and IDebugErrorBreakpointResolution2, and return them when binding a breakpoint of an unsupported kind (conditional, hit count, function etc).

Fix #1796: Do not advertise false capabilities for the debug engine

Expose all registry entries on the registration attribute, and default them all to false. Only set the supported features to true on the package.

Fix #1805: debug_source produces warning message

Do not specify encoding in call to parse() - it's ignored when parsing text rather than file.