### PR TITLE
Fix ##1069: Placement of R project templates in New Project dialog is weird

### DIFF
--- a/src/Package/Impl/Packages/R/RPackage.cs
+++ b/src/Package/Impl/Packages/R/RPackage.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.R.Packages.R {
     [ProvideLanguageEditorOptionPage(typeof(REditorOptionsDialog), RContentTypeDefinition.LanguageName, "", "Advanced", "#20136")]
     [ProvideKeyBindingTable(RGuidList.REditorFactoryGuidString, 200)]
     [ProvideProjectFileGenerator(typeof(RProjectFileGenerator), RGuidList.CpsProjectFactoryGuidString, FileExtensions = RContentTypeDefinition.RStudioProjectExtensionNoDot, DisplayGeneratorFilter = 300)]
-    [DeveloperActivity(RContentTypeDefinition.LanguageName, RGuidList.RPackageGuidString, sortPriority: 9)]
+    [DeveloperActivity(RContentTypeDefinition.LanguageName, RGuidList.RPackageGuidString, sortPriority: 40)]
     [ProvideCpsProjectFactory(RGuidList.CpsProjectFactoryGuidString, RContentTypeDefinition.LanguageName)]
     [ProvideOptionPage(typeof(RToolsOptionsPage), "R Tools", "Advanced", 20116, 20136, true)]
     //[ProvideOptionPage(typeof(PackageSourceOptionsPage), "R Tools", "Package Sources", 20116, 20135, true)]


### PR DESCRIPTION
Adjust priority to place it right after SQL, and next to Python.

![image](https://cloud.githubusercontent.com/assets/1175142/15980076/2c2830a6-2f1d-11e6-94ba-68d0a6d419c6.png)
