### PR TITLE
Add StartupFile property generation to RProjectFileGenerator.

### DIFF
--- a/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
+++ b/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
@@ -337,7 +337,7 @@
     <Compile Include="Packages\Markdown\MdPackage.cs" />
     <Compile Include="Packages\Markdown\MdGuidList.cs" />
     <Compile Include="ProjectSystem\RMsBuildFileSystemFilter.cs" />
-    <Compile Include="ProjectSystem\RProjectFactory.cs" />
+    <Compile Include="ProjectSystem\RProjectFileGenerator.cs" />
     <Compile Include="Interop\CommandTargetToOleShim.cs" />
     <Compile Include="Interop\CommandTargetToOleShimVariantStacks.cs" />
     <Compile Include="Interop\ConnectionPoint.cs" />
@@ -938,6 +938,7 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
     <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>

--- a/src/Package/Impl/ProjectSystem/RProjectFileGenerator.cs
+++ b/src/Package/Impl/ProjectSystem/RProjectFileGenerator.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.R.Components.ContentTypes;
+using Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.MsBuild;
 using Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Project;
 using Microsoft.VisualStudio.R.Packages.R;
 
@@ -16,6 +18,15 @@ namespace Microsoft.VisualStudio.R.Package.ProjectSystem {
 
         public RProjectFileGenerator()
             : base(RGuidList.CpsProjectFactoryGuid, null, RContentTypeDefinition.VsRProjectExtension, _imports) {
+        }
+
+        protected override XPropertyGroup CreateProjectSpecificPropertyGroup(string cpsProjFileName) {
+            var scripts = Directory.GetFiles(Path.GetDirectoryName(cpsProjFileName), "*.R");
+            if (scripts.Length > 0) {
+                var startupFile = Path.GetFileName(scripts[0]);
+                return new XPropertyGroup(new XProperty("StartupFile", startupFile));
+            }
+            return null;
         }
     }
 }

--- a/src/ProjectSystem/Impl/Project/FileSystemMirroringProjectFileGenerator.cs
+++ b/src/ProjectSystem/Impl/Project/FileSystemMirroringProjectFileGenerator.cs
@@ -58,6 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Project {
                         new XDefaultValueProperty("Configuration", "Debug"),
                         new XDefaultValueProperty("Platform", "AnyCPU")
                     ),
+                    CreateProjectSpecificPropertyGroup(cpsProjFileName),
                     CreateProjectUiSubcaption(),
                     new XProjElement("ProjectExtensions",
                         new XProjElement("VisualStudio",
@@ -73,6 +74,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Project {
             using (var writer = fileInfo.CreateText()) {
                 xProjDocument.Save(writer);
             }
+        }
+
+        protected virtual XPropertyGroup CreateProjectSpecificPropertyGroup(string cpsProjFileName) {
+            return null;
         }
 
         private XPropertyGroup CreateProjectUiSubcaption() {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/RTVS/issues/1893

The advantage of fixing it in the project file generator is that projects created from RStudio that are later opened in VS will have a startup file set automatically.

Changing the template to create the .rxproj with the startup file set as part of the template would allow each template to set whatever startup file they want, instead of relying on the project file generator to pick one.  However, I haven't been able to get this to work, VS complains "The template specified cannot be found. Please check that the full path is correct."  The template looks valid to me, it's likely that we are missing project type registrations of some sort, and VS doesn't know what to do with a .rxproj project template.

Since we only have one project template, with only one .R file in it, the fix in the generator seems appropriate enough, and has the advantage of setting a startup file for RStudio projects.

