### PR TITLE
This change moves the plot resolution tool tip to the Image UI element.

### DIFF
--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotManagerControl.xaml
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotManagerControl.xaml
@@ -10,6 +10,15 @@
     <Grid>
         <TextBlock Visibility="{Binding Path=ShowWatermark, Converter={x:Static rwpf:Converters.FalseIsHidden}}" Foreground="DarkGray" TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" TextWrapping="Wrap">Run plotting command in R Interactive Window</TextBlock>
         <TextBlock Visibility="{Binding Path=ShowError, Converter={x:Static rwpf:Converters.FalseIsHidden}}" TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" TextWrapping="Wrap">Error rendering plot</TextBlock>
-        <Image x:Name="plotImage" Cursor="{Binding Path=LocatorMode, Converter={x:Static rwpf:Converters.TrueIsCrossCursor}}" Source="{Binding Path=PlotImage}" Visibility="{Binding Path=PlotImage, Converter={x:Static rwpf:Converters.NullIsCollapsed}}" MouseLeftButtonUp="Image_MouseLeftButtonUp"></Image>
+        <Image x:Name="plotImage" Cursor="{Binding Path=LocatorMode, Converter={x:Static rwpf:Converters.TrueIsCrossCursor}}" Source="{Binding Path=PlotImage}" Visibility="{Binding Path=PlotImage, Converter={x:Static rwpf:Converters.NullIsCollapsed}}" MouseLeftButtonUp="Image_MouseLeftButtonUp">
+            <Image.ToolTip>
+                <TextBlock>
+                    <Run Text="{Binding Path=PlotImage.PixelWidth, Mode=OneWay}"/>
+                    <Run Text=" x "/>
+                    <Run Text="{Binding Path=PlotImage.PixelHeight, Mode=OneWay}"/>
+                    <Run Text=" px"/>
+                </TextBlock>
+            </Image.ToolTip>
+        </Image>
     </Grid>
 </UserControl>

--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotManagerControl.xaml
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotManagerControl.xaml
@@ -10,6 +10,6 @@
     <Grid>
         <TextBlock Visibility="{Binding Path=ShowWatermark, Converter={x:Static rwpf:Converters.FalseIsHidden}}" Foreground="DarkGray" TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" TextWrapping="Wrap">Run plotting command in R Interactive Window</TextBlock>
         <TextBlock Visibility="{Binding Path=ShowError, Converter={x:Static rwpf:Converters.FalseIsHidden}}" TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" TextWrapping="Wrap">Error rendering plot</TextBlock>
-        <Image Cursor="{Binding Path=LocatorMode, Converter={x:Static rwpf:Converters.TrueIsCrossCursor}}" Source="{Binding Path=PlotImage}" Visibility="{Binding Path=PlotImage, Converter={x:Static rwpf:Converters.NullIsCollapsed}}" MouseLeftButtonUp="Image_MouseLeftButtonUp"></Image>
+        <Image x:Name="plotImage" Cursor="{Binding Path=LocatorMode, Converter={x:Static rwpf:Converters.TrueIsCrossCursor}}" Source="{Binding Path=PlotImage}" Visibility="{Binding Path=PlotImage, Converter={x:Static rwpf:Converters.NullIsCollapsed}}" MouseLeftButtonUp="Image_MouseLeftButtonUp"></Image>
     </Grid>
 </UserControl>

--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotManagerControl.xaml
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotManagerControl.xaml
@@ -10,7 +10,7 @@
     <Grid>
         <TextBlock Visibility="{Binding Path=ShowWatermark, Converter={x:Static rwpf:Converters.FalseIsHidden}}" Foreground="DarkGray" TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" TextWrapping="Wrap">Run plotting command in R Interactive Window</TextBlock>
         <TextBlock Visibility="{Binding Path=ShowError, Converter={x:Static rwpf:Converters.FalseIsHidden}}" TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" TextWrapping="Wrap">Error rendering plot</TextBlock>
-        <Image x:Name="plotImage" Cursor="{Binding Path=LocatorMode, Converter={x:Static rwpf:Converters.TrueIsCrossCursor}}" Source="{Binding Path=PlotImage}" Visibility="{Binding Path=PlotImage, Converter={x:Static rwpf:Converters.NullIsCollapsed}}" MouseLeftButtonUp="Image_MouseLeftButtonUp">
+        <Image Cursor="{Binding Path=LocatorMode, Converter={x:Static rwpf:Converters.TrueIsCrossCursor}}" Source="{Binding Path=PlotImage}" Visibility="{Binding Path=PlotImage, Converter={x:Static rwpf:Converters.NullIsCollapsed}}" MouseLeftButtonUp="Image_MouseLeftButtonUp">
             <Image.ToolTip>
                 <TextBlock>
                     <Run Text="{Binding Path=PlotImage.PixelWidth, Mode=OneWay}"/>

--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotManagerControl.xaml.cs
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotManagerControl.xaml.cs
@@ -27,7 +27,6 @@ namespace Microsoft.R.Components.Plots.Implementation.View {
             int pixelWidth = Math.Max((int)unadjustedPixelSize.Width, MinPixelWidth);
             int pixelHeight = Math.Max((int)unadjustedPixelSize.Height, MinPixelHeight);
             int resolution = WpfUnitsConversion.GetResolution(Content as Visual);
-            plotImage.ToolTip = string.Format($"{pixelWidth} x {pixelHeight}px");
 
             Model?.ResizePlotAfterDelay(pixelWidth, pixelHeight, resolution);
         }

--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotManagerControl.xaml.cs
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotManagerControl.xaml.cs
@@ -27,7 +27,7 @@ namespace Microsoft.R.Components.Plots.Implementation.View {
             int pixelWidth = Math.Max((int)unadjustedPixelSize.Width, MinPixelWidth);
             int pixelHeight = Math.Max((int)unadjustedPixelSize.Height, MinPixelHeight);
             int resolution = WpfUnitsConversion.GetResolution(Content as Visual);
-            this.ToolTip = string.Format($"{pixelWidth} x {pixelHeight}px");
+            plotImage.ToolTip = string.Format($"{pixelWidth} x {pixelHeight}px");
 
             Model?.ResizePlotAfterDelay(pixelWidth, pixelHeight, resolution);
         }


### PR DESCRIPTION
This change moves the plot resolution tool tip to the Image UI element. This is to fix the following problem @huguesv identified:
![image](https://cloud.githubusercontent.com/assets/3840081/16093048/30529132-32ef-11e6-883d-f260810203b0.png)
Tool tip is shown when there is no plot.