### PR TITLE
Fix #1938: REPL steals focus from editor after breaking in debugger

### DIFF
--- a/src/Package/Impl/Repl/Workspace/InterruptRCommand.cs
+++ b/src/Package/Impl/Repl/Workspace/InterruptRCommand.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Workspace {
             var window = _interactiveWorkflow.ActiveWindow;
             if (window != null) {
                 Visible = true;
-                Enabled = _session.IsHostRunning && _enabled && !_debuggerModeTracker.IsEnteredBreakMode;
+                Enabled = _session.IsHostRunning && _enabled && !_debuggerModeTracker.IsInBreakMode;
             } else {
                 Visible = false;
                 Enabled = false;

--- a/src/Package/Impl/Utilities/VsDebuggerModeTracker.cs
+++ b/src/Package/Impl/Utilities/VsDebuggerModeTracker.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -10,14 +11,26 @@ namespace Microsoft.VisualStudio.R.Package.Utilities {
     [Export(typeof(IDebuggerModeTracker))]
     internal class VsDebuggerModeTracker : IDebuggerModeTracker, IVsDebuggerEvents {
         public int OnModeChange(DBGMODE dbgmodeNew) {
-            IsEnteredBreakMode = dbgmodeNew == DBGMODE.DBGMODE_Break;
+            if (IsInBreakMode) {
+                LeaveBreakMode?.Invoke(this, EventArgs.Empty);
+            }
+
+            IsInBreakMode = dbgmodeNew == DBGMODE.DBGMODE_Break;
             IsDebugging = dbgmodeNew != DBGMODE.DBGMODE_Design;
+
+            if (IsInBreakMode) {
+                EnterBreakMode?.Invoke(this, EventArgs.Empty);
+            }
+
             return VSConstants.S_OK;
         }
 
-        public bool IsEnteredBreakMode { get; private set; }
+        public bool IsInBreakMode { get; private set; }
 
         public bool IsDebugging { get; private set; }
 
+        public event EventHandler EnterBreakMode;
+
+        public event EventHandler LeaveBreakMode;
     }
 }

--- a/src/R/Components/Impl/InteractiveWorkflow/IDebuggerModeTracker.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/IDebuggerModeTracker.cs
@@ -1,13 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
+
 namespace Microsoft.R.Components.InteractiveWorkflow {
     public interface IDebuggerModeTracker {
-        bool IsEnteredBreakMode { get; }
+        bool IsInBreakMode { get; }
 
         /// <summary>
         /// If true, the application is in debug mode
         /// </summary>
         bool IsDebugging { get; }
+
+        event EventHandler EnterBreakMode;
+
+        event EventHandler LeaveBreakMode;
     }
 }

--- a/src/R/Components/Test/Fakes/Trackers/TestDebuggerModeTracker.cs
+++ b/src/R/Components/Test/Fakes/Trackers/TestDebuggerModeTracker.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.R.Components.InteractiveWorkflow;
 
@@ -8,8 +9,12 @@ namespace Microsoft.R.Components.Test.Fakes.Trackers {
     [Export(typeof(IDebuggerModeTracker))]
     [Export(typeof(TestDebuggerModeTracker))]
     public sealed class TestDebuggerModeTracker : IDebuggerModeTracker {
-        public bool IsEnteredBreakMode { get; set; }
+        public bool IsInBreakMode { get; set; }
 
         public bool IsDebugging { get; set; }
+
+        public event EventHandler EnterBreakMode;
+
+        public event EventHandler LeaveBreakMode;
     }
 }


### PR DESCRIPTION
Move focus from editor back to REPL no more than once per debugger break mode change.