### PR TITLE
Fix #1916, #1955

### DIFF
--- a/src/Package/Impl/DataInspect/VisualGrid/SortOrder.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/SortOrder.cs
@@ -59,21 +59,16 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         /// where minus tells R that the column sort order is descending rather than ascending.
         /// </remarks>
         public string GetRowSelector() {
-            var sb = new StringBuilder("function(x) order(");
+            var sb = new StringBuilder("function(x) rtvs:::grid_order(x");
 
-            bool first = true;
             foreach (var s in _sortOrderList) {
-                if (!first) {
-                    sb.Append(", ");
-                } else {
-                    first = false;
-                }
+                sb.Append(", ");
 
                 if (s.Descending) {
                     sb.Append('-');
                 }
 
-                sb.Append(Invariant($"x[,{s.ColumnIndex + 1}]"));
+                sb.Append(s.ColumnIndex + 1);
             }
 
             sb.Append(")");

--- a/src/Package/Impl/DataInspect/VisualGrid/TextVisual.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/TextVisual.cs
@@ -60,6 +60,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         public Size Size { get; set; }
 
+        public Rect CellBounds { get; set; }
+
         private bool _drawValid = false;
         public bool Draw() {
             if (_drawValid) {

--- a/src/Package/Impl/DataInspect/VisualGrid/VisualGrid.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/VisualGrid.cs
@@ -178,8 +178,14 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                     Debug.Assert(r == visual.Row && c == visual.Column);
                     Debug.Assert(points.Width[c] >= visual.Size.Width && points.Height[r] >= visual.Size.Height);
 
-                    double x = points.xPosition[c] + (alignRight ? (points.Width[c] - visual.Size.Width - visual.Margin - GridLineThickness) : 0.0);
-                    double y = points.yPosition[r];
+                    double cellX = points.xPosition[c];
+                    double cellY = points.yPosition[r];
+                    double cellW = points.Width[c];
+                    double cellH = points.Height[r];
+                    visual.CellBounds = new Rect(cellX, cellY, cellW, cellH);
+
+                    double x = cellX + (alignRight ? (cellW - visual.Size.Width - visual.Margin - GridLineThickness) : 0.0);
+                    double y = cellY;
 
                     var transform = visual.Transform as TranslateTransform;
                     if (transform == null) {
@@ -231,12 +237,9 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                 var pt = e.GetPosition(this);
                 foreach (var viz in _visualChildren) {
                     var v = viz as HeaderTextVisual;
-                    if (v != null) {
-                        Rect rc = new Rect(v.X, v.Y, v.Size.Width, v.Size.Height);
-                        if (rc.Contains(pt)) {
-                            ToggleSort(v, Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift));
-                            break;
-                        }
+                    if (v?.CellBounds.Contains(pt) == true) {
+                        ToggleSort(v, Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift));
+                        break;
                     }
                 }
             }

--- a/src/Package/TestApp/Data/GridDataTest.cs
+++ b/src/Package/TestApp/Data/GridDataTest.cs
@@ -211,6 +211,15 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Data {
 
         [Test]
         [Category.R.DataGrid]
+        public Task MatrixCharSortedGrid() => Test("matrix(c('a', 'b', 'c', 1, 1, 2), 3, 2)", 1, 1, new[,] {
+            { null,     "[,1]",     "[,2]" },
+            { "[1,]",   "c",        "2" },
+            { "[2,]",   "b",        "1" },
+            { "[3,]",   "a",        "1" },
+        }, sort: new[] { -2, -1 });
+
+        [Test]
+        [Category.R.DataGrid]
         public Task VectorGrid() => Test("1:10", 2, 1, new[,] {
             { null,     "[]" },
             { "[2]",    "2"  },
@@ -253,5 +262,16 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Data {
             { "[3]",    "8"  },
             { "[4]",    "7"  },
         }, sort: new[] { -1 });
+
+
+        [Test]
+        [Category.R.DataGrid]
+        public Task GridUnsortableColumn() => Test("matrix(list(2, 'a', 1, 20, 10, 20), 3, 2)", 1, 1, new[,] {
+            { null,     "[,1]",     "[,2]" },
+            { "[1,]",   "2",        "20" },
+            { "[2,]",   "a",        "10" },
+            { "[3,]",   "1",        "20" },
+        }, sort: new[] { 1, 2 });
+
     }
 }


### PR DESCRIPTION
Fix #1916: Data grid sorting - clicking anywhere on column header should work

Accept clicks anywhere within the boundaries of the header cell for sorting purposes.

Fix #1955: Character columns cannot be sorted in descending order

Use xtfrm() to convert non-numeric columns to sort-equivalent numeric sequences for sorting purposes. Gracefully handle errors when column cannot be sorted.