### PR TITLE
Fixes #1959 This change detaches RSession Mutated event from VariableGridHost

### DIFF
--- a/src/Package/Impl/DataInspect/VariableGridHost.xaml.cs
+++ b/src/Package/Impl/DataInspect/VariableGridHost.xaml.cs
@@ -31,6 +31,10 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             _rSession.Mutated += RSession_Mutated;
         }
 
+        public void CleanUp() {
+            _rSession.Mutated -= RSession_Mutated;
+        }
+
         private void RSession_Mutated(object sender, System.EventArgs e) {
             if (_evaluation != null) {
                 EvaluateAsync().DoNotWait();

--- a/src/Package/Impl/DataInspect/VariableGridWindowPane.cs
+++ b/src/Package/Impl/DataInspect/VariableGridWindowPane.cs
@@ -24,5 +24,10 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
             _gridHost.SetEvaluation(evaluation);
         }
+
+        protected override void OnClose() {
+            base.OnClose();
+            _gridHost.CleanUp();
+        }
     }
 }


### PR DESCRIPTION
Detaches RSession Mutated event from VariableGridHost when VariableGridWindowPane is closed. Previously the event handler for RSession Mutated in VariableGridHost re-evaluated the expression even after closing the view window.