### PR TITLE
#1851 Solution Explorer should not show temporary files

### DIFF
--- a/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.DirectoryCreated.cs
+++ b/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.DirectoryCreated.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Collections.Generic;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.IO;
+using Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Utilities;
 #if VS14
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 #endif
@@ -57,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
                             continue;
                         }
 
-                        _entries.AddDirectory(relativeDirectoryPath);
+                        _entries.AddDirectory(relativeDirectoryPath, directoryPath.ToShortRelativePath(_rootDirectory));
                     }
 
                     foreach (var entry in directory.EnumerateFileSystemInfos()) {
@@ -67,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
                             var relativeFilePath = PathHelper.MakeRelative(_rootDirectory, entry.FullName);
 
                             if (_fileSystemFilter.IsFileAllowed(relativeFilePath, entry.Attributes)) {
-                                _entries.AddFile(relativeFilePath);
+                                _entries.AddFile(relativeFilePath, entry.FullName.ToShortRelativePath(_rootDirectory));
                             }
                         }
                     }

--- a/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.DirectoryDeleted.cs
+++ b/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.DirectoryDeleted.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
                     return;
                 }
 
-                var relativePath = PathHelper.EnsureTrailingSlash(PathHelper.MakeRelative(_rootDirectory, _fullPath));
+                var relativePath = PathHelper.MakeRelative(_rootDirectory, _fullPath);
                 _entries.DeleteDirectory(relativePath);
             }
 

--- a/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.DirectoryRenamed.cs
+++ b/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.DirectoryRenamed.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.IO;
+using Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Utilities;
 #if VS14
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 #endif
@@ -41,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
                 }
 
                 var oldRelativePath = PathHelper.EnsureTrailingSlash(PathHelper.MakeRelative(_rootDirectory, _oldFullPath));
-                var newRelativePaths = _entries.RenameDirectory(oldRelativePath, newRelativePath);
+                var newRelativePaths = _entries.RenameDirectory(oldRelativePath, newRelativePath, _fullPath.ToShortRelativePath(_rootDirectory));
             }
 
             private void DeleteInsteadOfRename() {

--- a/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.DirectoryRenamed.cs
+++ b/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.DirectoryRenamed.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
                     return;
                 }
 
-                var oldRelativePath = PathHelper.EnsureTrailingSlash(PathHelper.MakeRelative(_rootDirectory, _oldFullPath));
+                var oldRelativePath = PathHelper.MakeRelative(_rootDirectory, _oldFullPath);
                 var newRelativePaths = _entries.RenameDirectory(oldRelativePath, newRelativePath, _fullPath.ToShortRelativePath(_rootDirectory));
             }
 
@@ -49,9 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
                 if (!_oldFullPath.StartsWithIgnoreCase(_rootDirectory)) {
                     return;
                 }
-
-                var relativePath = PathHelper.EnsureTrailingSlash(PathHelper.MakeRelative(_rootDirectory, _fullPath));
-                _entries.DeleteDirectory(relativePath);
+                _entries.DeleteDirectory(PathHelper.MakeRelative(_rootDirectory, _fullPath));
             }
 
             public override string ToString() {

--- a/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.FileCreated.cs
+++ b/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.FileCreated.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.Common.Core.IO;
+using Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Utilities;
 using static System.FormattableString;
 
 namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
@@ -27,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
                     return;
                 }
 
-                _entries.AddFile(relativePath);
+                _entries.AddFile(relativePath, _fullPath.ToShortRelativePath(_rootDirectory));
             }
 
             public override string ToString() {

--- a/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.FileDeleted.cs
+++ b/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.FileDeleted.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.Common.Core;
+using Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Utilities;
 #if VS14
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 #endif
@@ -27,12 +28,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
 
                 var relativePath = PathHelper.MakeRelative(_rootDirectory, _fullPath);
                 _entries.DeleteFile(relativePath);
+
+                var shortPath = PathHelper.MakeRelative(_rootDirectory.ToShortPath(), _fullPath.ToShortPath());
+                _entries.DeleteFile(shortPath);
             }
 
             public override string ToString() {
                 return Invariant($"File deleted: {_fullPath}");
             }
         }
-
     }
 }

--- a/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.FileDeleted.cs
+++ b/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.FileDeleted.cs
@@ -28,9 +28,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
 
                 var relativePath = PathHelper.MakeRelative(_rootDirectory, _fullPath);
                 _entries.DeleteFile(relativePath);
-
-                var shortPath = PathHelper.MakeRelative(_rootDirectory.ToShortPath(), _fullPath.ToShortPath());
-                _entries.DeleteFile(shortPath);
             }
 
             public override string ToString() {

--- a/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.FileRenamed.cs
+++ b/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcher.FileRenamed.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.IO;
+using Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Utilities;
 #if VS14
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 #endif
@@ -31,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
                 string newRelativePath;
                 if (!_oldFullPath.StartsWithIgnoreCase(_rootDirectory)) {
                     if (IsFileAllowed(_rootDirectory, _fullPath, _fileSystem, _fileSystemFilter, out newRelativePath)) {
-                        _entries.AddFile(newRelativePath);
+                        _entries.AddFile(newRelativePath, _fullPath.ToShortRelativePath(_rootDirectory));
                     }
 
                     return;
@@ -39,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
 
                 var oldRelativePath = PathHelper.MakeRelative(_rootDirectory, _oldFullPath);
                 if (IsFileAllowed(_rootDirectory, _fullPath, _fileSystem, _fileSystemFilter, out newRelativePath)) {
-                    _entries.RenameFile(oldRelativePath, newRelativePath);
+                    _entries.RenameFile(oldRelativePath, newRelativePath, _fullPath.ToShortRelativePath(_rootDirectory));
                 } else {
                     _entries.DeleteFile(oldRelativePath);
                 }

--- a/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcherEntries.cs
+++ b/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcherEntries.cs
@@ -42,15 +42,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
         }
 
         public void AddDirectory(string relativePath, string shortPath) {
-            relativePath = PathHelper.EnsureTrailingSlash(relativePath);
-            AddEntry(relativePath, shortPath, Directory);
+             AddEntry(relativePath, shortPath, Directory);
         }
 
         public void DeleteDirectory(string relativePath) {
             try {
                 relativePath = PathHelper.EnsureTrailingSlash(relativePath);
                 foreach (var entry in _entries.Values.Where(v => v.RelativePath.StartsWithIgnoreCase(relativePath) ||
-                                                            v.ShortPath.StartsWithIgnoreCase(relativePath)).ToList()) {
+                                                                 v.ShortPath.StartsWithIgnoreCase(relativePath)).ToList()) {
                     DeleteEntry(entry);
                 }
             } catch (InvalidStateException) {
@@ -102,6 +101,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
         }
 
         private Entry AddEntry(string relativeFilePath, string shortPath, EntryType type) {
+            relativeFilePath = PathHelper.EnsureTrailingSlash(relativeFilePath);
+            shortPath = PathHelper.EnsureTrailingSlash(shortPath);
+
             Entry entry;
             if (!_entries.TryGetValue(relativeFilePath, out entry)) {
                 entry = new Entry(relativeFilePath, shortPath, type) {

--- a/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcherEntries.cs
+++ b/src/ProjectSystem/Impl/IO/MsBuildFileSystemWatcherEntries.cs
@@ -61,10 +61,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
             try {
                 previousRelativePath = PathHelper.EnsureTrailingSlash(previousRelativePath);
                 relativePath = PathHelper.EnsureTrailingSlash(relativePath);
+                shortPath = PathHelper.EnsureTrailingSlash(shortPath);
                 var newPaths = new HashSet<string>();
                 var entriesToRename = _entries.Values
                     .Where(v => v.State == Unchanged || v.State == Added || v.State == RenamedThenAdded)
-                    .Where(v => v.RelativePath.StartsWithIgnoreCase(previousRelativePath) |
+                    .Where(v => v.RelativePath.StartsWithIgnoreCase(previousRelativePath) ||
                                 v.ShortPath.StartsWithIgnoreCase(previousRelativePath)).ToList();
                 foreach (var entry in entriesToRename) {
                     var newEntryPath = entry.RelativePath.Replace(previousRelativePath, relativePath, 0, previousRelativePath.Length);
@@ -101,8 +102,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.IO {
         }
 
         private Entry AddEntry(string relativeFilePath, string shortPath, EntryType type) {
-            relativeFilePath = PathHelper.EnsureTrailingSlash(relativeFilePath);
-            shortPath = PathHelper.EnsureTrailingSlash(shortPath);
+            if (type == EntryType.Directory) {
+                relativeFilePath = PathHelper.EnsureTrailingSlash(relativeFilePath);
+                shortPath = PathHelper.EnsureTrailingSlash(shortPath);
+            }
 
             Entry entry;
             if (!_entries.TryGetValue(relativeFilePath, out entry)) {

--- a/src/ProjectSystem/Impl/Interop/NativeMethods.cs
+++ b/src/ProjectSystem/Impl/Interop/NativeMethods.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Interop {
+    internal static class NativeMethods {
+        public const int MAX_PATH = 260;
+ 
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        public static extern uint GetLongPathName([MarshalAs(UnmanagedType.LPWStr)] string lpFileName, 
+                                                  [MarshalAs(UnmanagedType.LPWStr)] StringBuilder lpBuffer, 
+                                                  int nBufferLength);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        public static extern uint GetShortPathName([MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+                                                   [MarshalAs(UnmanagedType.LPWStr)] StringBuilder lpBuffer,
+                                                   int nBufferLength);
+    }
+}

--- a/src/ProjectSystem/Impl/Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.csproj
+++ b/src/ProjectSystem/Impl/Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.csproj
@@ -29,6 +29,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Extensions\ProjectTreeExtensions.cs" />
+    <Compile Include="Interop\NativeMethods.cs" />
     <Compile Include="IO\IMsBuildFileSystemFilter.cs" />
     <Compile Include="IO\MsBuildFileSystemWatcher.AttributesChanged.cs" />
     <Compile Include="IO\MsBuildFileSystemWatcher.DirectoryCreated.cs" />
@@ -64,6 +65,7 @@
     <Compile Include="Shell\IVsProjectGenerator.cs" />
     <Compile Include="Shell\IVsRegisterProjectGenerators.cs" />
     <Compile Include="Utilities\DictionaryExtensions.cs" />
+    <Compile Include="Utilities\PathExtensions.cs" />
     <Compile Include="Utilities\ServiceProviderExtensions.cs" />
     <Compile Include="Utilities\VsSolutionBuildManagerExtensions.cs" />
   </ItemGroup>

--- a/src/ProjectSystem/Impl/Utilities/PathExtensions.cs
+++ b/src/ProjectSystem/Impl/Utilities/PathExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Interop;
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
+
+namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Utilities {
+    public static class PathExtensions {
+        public static string ToLongPath(this string path) {
+            var sb = new StringBuilder(NativeMethods.MAX_PATH);
+            NativeMethods.GetLongPathName(path, sb, sb.Capacity);
+            return sb.ToString();
+        }
+
+        public static string ToShortPath(this string path) {
+            var sb = new StringBuilder(NativeMethods.MAX_PATH);
+            NativeMethods.GetShortPathName(path, sb, sb.Capacity);
+            return sb.ToString();
+        }
+
+        public static string ToShortRelativePath(this string path, string rootFolder) {
+            return PathHelper.MakeRelative(path.ToShortPath(), rootFolder.ToShortPath());
+        }
+    }
+}

--- a/src/ProjectSystem/Impl/Utilities/PathExtensions.cs
+++ b/src/ProjectSystem/Impl/Utilities/PathExtensions.cs
@@ -22,7 +22,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.Utilities {
         }
 
         public static string ToShortRelativePath(this string path, string rootFolder) {
-            return PathHelper.MakeRelative(path.ToShortPath(), rootFolder.ToShortPath());
+            var shortPath = path.ToShortPath();
+            var rootShortPath = rootFolder.ToShortPath();
+            return PathHelper.MakeRelative(rootShortPath, shortPath);
         }
     }
 }

--- a/src/ProjectSystem/Test/IO/MsBuildFileSystemWatcherEntriesTest.cs
+++ b/src/ProjectSystem/Test/IO/MsBuildFileSystemWatcherEntriesTest.cs
@@ -47,39 +47,39 @@ Basic relative path structure
 ├─.x
 └─.y
 */
-            _entries.AddDirectory(@"A");
-            _entries.AddDirectory(@"A\A");
-            _entries.AddDirectory(@"A\A\A");
-            _entries.AddDirectory(@"A\A\B");
-            _entries.AddDirectory(@"A\B");
-            _entries.AddDirectory(@"A\B\A");
-            _entries.AddDirectory(@"B");
-            _entries.AddDirectory(@"B\A");
-            _entries.AddDirectory(@"B\A\A");
-            _entries.AddDirectory(@"B\A\B");
-            _entries.AddDirectory(@"B\B");
-            _entries.AddDirectory(@"B\B\A");
+            _entries.AddDirectory(@"A", @"A");
+            _entries.AddDirectory(@"A\A", @"A\A");
+            _entries.AddDirectory(@"A\A\A", @"A\A\A");
+            _entries.AddDirectory(@"A\A\B", @"A\A\B");
+            _entries.AddDirectory(@"A\B", @"A\B");
+            _entries.AddDirectory(@"A\B\A", @"A\B\A");
+            _entries.AddDirectory(@"B", @"B");
+            _entries.AddDirectory(@"B\A", @"B\A");
+            _entries.AddDirectory(@"B\A\A", @"B\A\A");
+            _entries.AddDirectory(@"B\A\B", @"B\A\B");
+            _entries.AddDirectory(@"B\B", @"B\B");
+            _entries.AddDirectory(@"B\B\A", @"B\B\A");
 
-            _entries.AddFile(@"A\A\A\a.x");
-            _entries.AddFile(@"A\A\A\a.y");
-            _entries.AddFile(@"A\A\B\a.x");
-            _entries.AddFile(@"A\A\B\a.y");
-            _entries.AddFile(@"A\A\c.x");
-            _entries.AddFile(@"A\A\c.y");
-            _entries.AddFile(@"A\B\b.x");
-            _entries.AddFile(@"A\B\b.y");
-            _entries.AddFile(@"A\c.x");
-            _entries.AddFile(@"A\c.y");
-            _entries.AddFile(@"B\A\A\a.x");
-            _entries.AddFile(@"B\A\A\a.y");
-            _entries.AddFile(@"B\A\B\a.x");
-            _entries.AddFile(@"B\A\B\a.y");
-            _entries.AddFile(@"B\A\c.x");
-            _entries.AddFile(@"B\A\c.y");
-            _entries.AddFile(@"B\B\b.x");
-            _entries.AddFile(@"B\B\b.y");
-            _entries.AddFile(@".x");
-            _entries.AddFile(@".y");
+            _entries.AddFile(@"A\A\A\a.x", @"A\A\A\a.x");
+            _entries.AddFile(@"A\A\A\a.y", @"A\A\A\a.y");
+            _entries.AddFile(@"A\A\B\a.x", @"A\A\B\a.x");
+            _entries.AddFile(@"A\A\B\a.y", @"A\A\B\a.y");
+            _entries.AddFile(@"A\A\c.x", @"A\A\c.x");
+            _entries.AddFile(@"A\A\c.y", @"A\A\c.y");
+            _entries.AddFile(@"A\B\b.x", @"A\B\b.x");
+            _entries.AddFile(@"A\B\b.y", @"A\B\b.y");
+            _entries.AddFile(@"A\c.x", @"A\c.x");
+            _entries.AddFile(@"A\c.y", @"A\c.y");
+            _entries.AddFile(@"B\A\A\a.x", @"B\A\A\a.x");
+            _entries.AddFile(@"B\A\A\a.y", @"B\A\A\a.y");
+            _entries.AddFile(@"B\A\B\a.x", @"B\A\B\a.x");
+            _entries.AddFile(@"B\A\B\a.y", @"B\A\B\a.y");
+            _entries.AddFile(@"B\A\c.x", @"B\A\c.x");
+            _entries.AddFile(@"B\A\c.y", @"B\A\c.y");
+            _entries.AddFile(@"B\B\b.x", @"B\B\b.x");
+            _entries.AddFile(@"B\B\b.y", @"B\B\b.y");
+            _entries.AddFile(@".x", @".x");
+            _entries.AddFile(@".y", @".y");
 
             _entries.ProduceChangeset();
         }
@@ -89,9 +89,9 @@ Basic relative path structure
         [InlineArray(@".x", @"a.x", @"A\D\b.y", @"A\D\.y")]
         public void FileRenameRoundtrip(string[] renames) {
             for (var i = 0; i < renames.Length - 1; i++) {
-                _entries.RenameFile(renames[i], renames[i + 1]);
+                _entries.RenameFile(renames[i], renames[i + 1], renames[i + 1]);
             }
-            _entries.RenameFile(renames[renames.Length - 1], renames[0]);
+            _entries.RenameFile(renames[renames.Length - 1], renames[0], renames[0]);
 
             var changeset = _entries.ProduceChangeset();
             changeset.Should().NotBeNull().And.NoOtherChanges();
@@ -103,9 +103,9 @@ Basic relative path structure
         [InlineArray(@"A\B", @"A\C", @"B\C")]
         public void DirectoryRenameRoundtrip(string[] renames) {
             for (var i = 0; i < renames.Length - 1; i++) {
-                _entries.RenameDirectory(renames[i], renames[i + 1]);
+                _entries.RenameDirectory(renames[i], renames[i + 1], renames[i + 1]);
             }
-            _entries.RenameDirectory(renames[renames.Length - 1], renames[0]);
+            _entries.RenameDirectory(renames[renames.Length - 1], renames[0], renames[0]);
 
             var changeset = _entries.ProduceChangeset();
             changeset.Should().NotBeNull().And.NoOtherChanges();
@@ -132,7 +132,7 @@ Basic relative path structure
                     new[] { @"D\A\a.x", @"D\A\a.y", @"D\B\a.x", @"D\B\a.y", @"D\C\b.x", @"D\C\b.y", @"D\c.x", @"D\c.y" })]
         public void RenameDirectoryMultipleTimes(string[] from, string[] to, string[] expectedFromDirectories, string[] expectedToDirectories, string[] expectedFromFiles, string[] expectedToFiles) {
             for (var i = 0; i < from.Length; i++) {
-                _entries.RenameDirectory(from[i], to[i]);
+                _entries.RenameDirectory(from[i], to[i], to[i]);
             }
 
             var changeset = _entries.ProduceChangeset();
@@ -144,10 +144,10 @@ Basic relative path structure
 
         [Test]
         public void Directory_RenameAddRenameRename() {
-            _entries.RenameDirectory(@"B\B", @"C");
-            _entries.AddDirectory(@"B\B");
-            _entries.RenameDirectory(@"B\B", @"B\D");
-            _entries.RenameDirectory(@"A\B", @"B\B");
+            _entries.RenameDirectory(@"B\B", @"C", @"C");
+            _entries.AddDirectory(@"B\B", @"B\B");
+            _entries.RenameDirectory(@"B\B", @"B\D", @"B\D");
+            _entries.RenameDirectory(@"A\B", @"B\B", @"B\D");
 
             var changeset = _entries.ProduceChangeset();
             changeset.Should().NotBeNull()
@@ -159,12 +159,12 @@ Basic relative path structure
 
         [Test]
         public void TripleDirectoryRenameAdd() {
-            _entries.RenameDirectory(@"B\B", @"B\C");
-            _entries.AddDirectory(@"B\B");
-            _entries.RenameDirectory(@"B\B", @"B\D");
-            _entries.AddDirectory(@"B\B");
-            _entries.RenameDirectory(@"B\C", @"A\C");
-            _entries.AddDirectory(@"B\C");
+            _entries.RenameDirectory(@"B\B", @"B\C", @"B\C");
+            _entries.AddDirectory(@"B\B", @"B\B");
+            _entries.RenameDirectory(@"B\B", @"B\D", @"B\D");
+            _entries.AddDirectory(@"B\B", @"B\B");
+            _entries.RenameDirectory(@"B\C", @"A\C", @"A\C");
+            _entries.AddDirectory(@"B\C", @"B\C");
 
             var changeset = _entries.ProduceChangeset();
             changeset.Should().NotBeNull()
@@ -177,11 +177,11 @@ Basic relative path structure
         [Test]
         public void File_DeleteAddRenameRenameAddRename() {
             _entries.DeleteFile(@".x");
-            _entries.AddFile(@"C\a.x");
-            _entries.RenameFile(@"C\a.x", @".x");
-            _entries.RenameFile(@".x", @"D\a.x");
-            _entries.AddFile(@"D\b.y");
-            _entries.RenameFile(@"D\b.y", @".x");
+            _entries.AddFile(@"C\a.x", @"C\a.x");
+            _entries.RenameFile(@"C\a.x", @".x", @".x");
+            _entries.RenameFile(@".x", @"D\a.x", @"D\a.x");
+            _entries.AddFile(@"D\b.y", @"D\b.y");
+            _entries.RenameFile(@"D\b.y", @".x", @".x");
 
             var changeset = _entries.ProduceChangeset();
             changeset.Should().NotBeNull()


### PR DESCRIPTION
Maybe there is a better fix... Problem is that short path must be stored since after item is deleted, GetShortFilePath and GetLongFilePath no longer work. Alternative is to pass full path and root down to AddEntry...