### PR TITLE
Improve protocol to simplify remoting

### DIFF
--- a/src/Host/Client/Impl/Definitions/IRCallbacks.cs
+++ b/src/Host/Client/Impl/Definitions/IRCallbacks.cs
@@ -51,7 +51,7 @@ namespace Microsoft.R.Host.Client {
         /// </summary>
         /// <param name="url"></param>
         /// <returns></returns>
-        Task Browser(string url);
+        Task WebBrowser(string url);
 
         /// <summary>
         /// Invoked in response of parameter-less library call

--- a/src/Host/Client/Impl/Host/RHost.EvaluationRequest.cs
+++ b/src/Host/Client/Impl/Host/RHost.EvaluationRequest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.R.Host.Client {
                 Expression = expression;
                 Kind = kind;
 
-                var nameBuilder = new StringBuilder("=");
+                var nameBuilder = new StringBuilder("?=");
                 if (kind.HasFlag(REvaluationKind.Reentrant)) {
                     nameBuilder.Append('@');
                 }

--- a/src/Host/Client/Impl/Host/RHost.Message.cs
+++ b/src/Host/Client/Impl/Host/RHost.Message.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using Microsoft.Common.Core;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.R.Host.Client {
@@ -29,14 +30,13 @@ namespace Microsoft.R.Host.Client {
                 Name = GetString(1, "name");
                 _argsOffset = 2;
 
-                if (Name == ":") {
-                    if (_body.Count < 4) {
-                        throw ProtocolError($"Response message must have form [id, ':', request_id, name, ...]:", token);
+                if (Name.StartsWithOrdinal(":")) {
+                    if (_body.Count < 3) {
+                        throw ProtocolError($"Response message must have form [id, name, request_id, ...]:", token);
                     }
 
                     RequestId = GetString(0, "request_id");
-                    Name = GetString(1, "request_name");
-                    _argsOffset += 2;
+                    ++_argsOffset;
                 }
             }
 

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -131,7 +131,10 @@ namespace Microsoft.R.Host.Client {
             }
         }
 
-        private async Task<string> SendAsync(string name, CancellationToken ct, params object[] args) {
+        private async Task<string> NotifyAsync(string name, CancellationToken ct, params object[] args) {
+            Debug.Assert(name.StartsWithOrdinal("!"));
+            TaskUtilities.AssertIsOnBackgroundThread();
+
             string id;
             var message = CreateMessage(out id, name, args);
             await SendAsync(message, ct);
@@ -139,10 +142,11 @@ namespace Microsoft.R.Host.Client {
         }
 
         private async Task<string> RespondAsync(Message request, CancellationToken ct, params object[] args) {
+            Debug.Assert(request.Name.StartsWithOrdinal("?"));
             TaskUtilities.AssertIsOnBackgroundThread();
 
             string id;
-            var message = CreateMessage(out id, ":", request.Id, request.Name, args);
+            var message = CreateMessage(out id, ":" + request.Name.Substring(1), request.Id, args);
             await SendAsync(message, ct);
             return id;
         }
@@ -233,7 +237,7 @@ namespace Microsoft.R.Host.Client {
         }
 
         private void ProcessEvaluationResult(Message response) {
-            EvaluationRequest request; ;
+            EvaluationRequest request;
             if (!_evalRequests.TryRemove(response.RequestId, out request)) {
                 throw ProtocolError($"Unexpected response to evaluation request {response.RequestId} that is not pending.");
             }
@@ -244,8 +248,8 @@ namespace Microsoft.R.Host.Client {
                 request.CompletionSource.SetCanceled();
             }
 
-            if (response.Name != request.MessageName) {
-                throw ProtocolError($"Mismatched host response ['{response.Id}',':','{response.Name}',...] to evaluation request ['{request.Id}','{request.MessageName}','{request.Expression}']");
+            if (response.Name.Substring(1) != request.MessageName.Substring(1)) {
+                throw ProtocolError($"Mismatched host response ['{response.Id}',':{response.Name.Substring(1)}',...] to evaluation request ['{request.Id}','{request.MessageName}','{request.Expression}']");
             }
 
             response.ExpectArguments(3);
@@ -283,7 +287,7 @@ namespace Microsoft.R.Host.Client {
                 _cancelAllCts.Cancel();
 
                 try {
-                    await SendAsync("/", _cts.Token, null);
+                    await NotifyAsync("!/", _cts.Token, null);
                 } catch (OperationCanceledException) {
                     return;
                 } catch (MessageTransportException) {
@@ -336,7 +340,7 @@ namespace Microsoft.R.Host.Client {
                     if (message == null) {
                         return null;
                     } else if (message.RequestId != null) {
-                        if (message.Name.StartsWithIgnoreCase("=")) {
+                        if (message.Name.StartsWithOrdinal(":=")) {
                             ProcessEvaluationResult(message);
                             continue;
                         } else {
@@ -346,29 +350,29 @@ namespace Microsoft.R.Host.Client {
 
                     try {
                         switch (message.Name) {
-                            case "\\":
+                            case "!CanceledAll":
                                 CancelAll();
                                 break;
 
-                            case "?":
+                            case "?YesNoCancel":
                                 ShowDialog(message, MessageButtons.YesNoCancel, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token)
                                     .SilenceException<MessageTransportException>()
                                     .DoNotWait();
                                 break;
 
-                            case "??":
+                            case "?YesNo":
                                 ShowDialog(message, MessageButtons.YesNo, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token)
                                     .SilenceException<MessageTransportException>()
                                     .DoNotWait();
                                 break;
 
-                            case "???":
+                            case "?OkCancel":
                                 ShowDialog(message, MessageButtons.OKCancel, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token)
                                     .SilenceException<MessageTransportException>()
                                     .DoNotWait();
                                 break;
 
-                            case ">":
+                            case "?>":
                                 ReadConsole(message, CancellationTokenSource.CreateLinkedTokenSource(ct, _cancelAllCts.Token).Token)
                                     .SilenceException<MessageTransportException>()
                                     .DoNotWait();
@@ -383,27 +387,27 @@ namespace Microsoft.R.Host.Client {
                                     ct);
                                 break;
 
-                            case "![]":
+                            case "!ShowMessage":
                                 message.ExpectArguments(1);
                                 await _callbacks.ShowMessage(message.GetString(0, "s", allowNull: true), ct);
                                 break;
 
-                            case "~+":
+                            case "!+":
                                 await _callbacks.Busy(true, ct);
                                 break;
-                            case "~-":
+                            case "!-":
                                 await _callbacks.Busy(false, ct);
                                 break;
 
-                            case "setwd":
+                            case "!SetWD":
                                 _callbacks.DirectoryChanged();
                                 break;
 
-                            case "library":
+                            case "!Library":
                                 await _callbacks.ViewLibrary();
                                 break;
 
-                            case "show_file":
+                            case "!ShowFile":
                                 message.ExpectArguments(3);
                                 await _callbacks.ShowFile(
                                     message.GetString(0, "file"),
@@ -411,12 +415,12 @@ namespace Microsoft.R.Host.Client {
                                     message.GetBoolean(2, "delete.file"));
                                 break;
 
-                            case "View":
+                            case "!View":
                                 message.ExpectArguments(2);
                                 _callbacks.ViewObject(message.GetString(0, "x"), message.GetString(1, "title"));
                                 break;
 
-                            case "Plot":
+                            case "!Plot":
                                 await _callbacks.Plot(
                                     new PlotMessage(
                                         message.GetString(0, "xaml_file_path"),
@@ -425,14 +429,14 @@ namespace Microsoft.R.Host.Client {
                                     ct);
                                 break;
 
-                            case "Locator":
+                            case "?Locator":
                                 var locatorResult = await _callbacks.Locator(ct);
                                 ct.ThrowIfCancellationRequested();
                                 await RespondAsync(message, ct, locatorResult.Clicked, locatorResult.X, locatorResult.Y);
                                 break;
 
-                            case "open_url":
-                                await _callbacks.Browser(message.GetString(0, "help_url"));
+                            case "!WebBrowser":
+                                await _callbacks.WebBrowser(message.GetString(0, "help_url"));
                                 break;
 
                             default:
@@ -454,7 +458,7 @@ namespace Microsoft.R.Host.Client {
 
             try {
                 var message = await ReceiveMessageAsync(ct);
-                if (message.Name != "Microsoft.R.Host" || message.RequestId != null) {
+                if (message.Name != "!Microsoft.R.Host" || message.RequestId != null) {
                     throw ProtocolError($"Microsoft.R.Host handshake expected:", message);
                 }
 

--- a/src/Host/Client/Impl/Program.cs
+++ b/src/Host/Client/Impl/Program.cs
@@ -95,7 +95,7 @@ namespace Microsoft.R.Host.Client {
             await Console.Error.WriteLineAsync(plot.FilePath);
         }
 
-        public async Task Browser(string url) {
+        public async Task WebBrowser(string url) {
             await Console.Error.WriteLineAsync("Browser: " + url);
         }
 

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -514,7 +514,7 @@ namespace Microsoft.R.Host.Client.Session {
         /// </summary>
         /// <param name="url"></param>
         /// <returns></returns>
-        Task IRCallbacks.Browser(string url) {
+        Task IRCallbacks.WebBrowser(string url) {
             var callback = _callback;
             return callback != null ? callback.ShowHelp(url) : Task.CompletedTask;
         }

--- a/src/Host/Client/Impl/rtvs/R/overrides.R
+++ b/src/Host/Client/Impl/rtvs/R/overrides.R
@@ -8,19 +8,19 @@ view <- function(x, title) {
     if (missing(title)) {
       title <- dep[1]
     }
-    invisible(rtvs:::send_message('View', dep, title))
+    invisible(rtvs:::send_notification('!View', dep, title))
   } else {
     print(x)
   }
 }
 
 open_url <- function(url) {
-  rtvs:::send_message('open_url', url)
+  rtvs:::send_notification('!WebBrowser', url)
 }
 
 setwd <- function(dir) {
   old <- .Internal(setwd(dir))
-  rtvs:::send_message('setwd', dir)
+  rtvs:::send_notification('!SetWD', dir)
   invisible(old)
 }
 
@@ -32,13 +32,13 @@ redirect_functions <- function(...) {
 
 library <- function(...) {
   if (nargs() == 0) {
-    invisible(rtvs:::send_message('library'))
+    invisible(rtvs:::send_notification('!Library'))
   } else {
     base::library(...)
   }
 }
 
-show_file <- function (files, header, title, delete.file) {
+show_file <- function(files, header, title, delete.file) {
   cFiles <- length(files)
   for (i in cFiles) {
     if ((i > length(header)) || !nzchar(header[[i]])) {
@@ -46,6 +46,6 @@ show_file <- function (files, header, title, delete.file) {
     } else {
       tabName <- header[[i]]
     }
-    invisible(rtvs:::send_message('show_file', files[[i]], tabName, delete.file))
+    invisible(rtvs:::send_notification('!ShowFile', files[[i]], tabName, delete.file))
   }
 }

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -9,12 +9,12 @@ external_embedded <- function(name, ...) {
   .External(paste0('Microsoft.R.Host::External.', name, collapse = ''), ..., PACKAGE = '(embedding)')
 }
 
-send_message <- function(name, ...) {
-    call_embedded('send_message', name, list(...))
+send_notification <- function(name, ...) {
+    call_embedded('send_notification', name, list(...))
 }
 
-send_message_and_get_response <- function(name, ...) {
-    call_embedded('send_message_and_get_response', name, list(...))
+send_request_and_get_response <- function(name, ...) {
+    call_embedded('send_request_and_get_response', name, list(...))
 }
 
 memory_connection <- function(max_length = NA, expected_length = NA, overflow_suffix = '', eof_marker = '') {


### PR DESCRIPTION
Change protocol so that the type of every message (one-way notification, request, response) is encoded in the message name in a uniform way.

Rename associated APIs (send_message etc) for clarity.