### PR TITLE
#2023  Host can send binary blobs.

### DIFF
--- a/src/Host/Client/Impl/Definitions/IMessageTransport.cs
+++ b/src/Host/Client/Impl/Definitions/IMessageTransport.cs
@@ -9,5 +9,6 @@ namespace Microsoft.R.Host.Client {
     public interface IMessageTransport {
         Task SendAsync(string message, CancellationToken ct = default(CancellationToken));
         Task<string> ReceiveAsync(CancellationToken ct = default(CancellationToken));
+        Task<byte[]> ReceiveRawAsync(CancellationToken ct = default(CancellationToken));
     }
 }

--- a/src/Host/Client/Impl/Definitions/PlotMessage.cs
+++ b/src/Host/Client/Impl/Definitions/PlotMessage.cs
@@ -25,6 +25,6 @@ namespace Microsoft.R.Host.Client {
         /// <summary>
         /// The plot could not be rendered id length is 0.
         /// </summary>
-        public bool IsError => (Data == null) || Data.Length == 0;
+        public bool IsError => Data.Length == 0;
     }
 }

--- a/src/Host/Client/Impl/Definitions/PlotMessage.cs
+++ b/src/Host/Client/Impl/Definitions/PlotMessage.cs
@@ -9,27 +9,22 @@ namespace Microsoft.R.Host.Client {
         public string FilePath { get; }
         public int ActivePlotIndex { get; }
         public int PlotCount { get; }
+        public byte[] Data { get; }
 
-        public PlotMessage(string filePath, int activePlotIndex, int plotCount) {
+        public PlotMessage(string filePath, int activePlotIndex, int plotCount, byte[] data) {
             FilePath = filePath;
             ActivePlotIndex = activePlotIndex;
             PlotCount = plotCount;
+            Data = data;
         }
 
         public bool IsClearAll => string.IsNullOrEmpty(FilePath);
 
-        public bool IsPlot {
-            get {
-                try {
-                    return new FileInfo(FilePath).Length > 0;
-                } catch (IOException) { } catch (AccessViolationException) { }
-                return false;
-            }
-        }
+        public bool IsPlot => Data.Length > 0;
 
         /// <summary>
-        /// A zero-sized file means a blank image, ie. the plot could not be rendered.
+        /// The plot could not be rendered id length is 0.
         /// </summary>
-        public bool IsError => !File.Exists(FilePath) || new FileInfo(FilePath).Length == 0;
+        public bool IsError => (Data == null) || Data.Length == 0;
     }
 }

--- a/src/Host/Client/Impl/Definitions/REvaluationKind.cs
+++ b/src/Host/Client/Impl/Definitions/REvaluationKind.cs
@@ -46,6 +46,12 @@ namespace Microsoft.R.Host.Client {
         /// </remarks>
         /// <seealso cref="RExpressionEvaluatorExtensions.ExecuteAsync"/>
         NoResult = 1 << 8,
+        /// <summary>
+        /// Returns result explicitly in Raw format.
+        /// </summary>
+        /// <remarks>
+        /// Used for data that cannot be represented in JSON.</remarks>
+        RawBytes = 1 << 9,
     }
 }
 

--- a/src/Host/Client/Impl/Definitions/REvaluationKind.cs
+++ b/src/Host/Client/Impl/Definitions/REvaluationKind.cs
@@ -51,7 +51,7 @@ namespace Microsoft.R.Host.Client {
         /// </summary>
         /// <remarks>
         /// Used for data that cannot be represented in JSON.</remarks>
-        RawBytes = 1 << 9,
+        Raw = 1 << 9,
     }
 }
 

--- a/src/Host/Client/Impl/Definitions/REvaluationResult.cs
+++ b/src/Host/Client/Impl/Definitions/REvaluationResult.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using static System.FormattableString;
+using System.Collections.Generic;
 
 namespace Microsoft.R.Host.Client {
     /// <summary>
@@ -31,6 +32,14 @@ namespace Microsoft.R.Host.Client {
         /// </remarks>
         public JToken Result { get; }
         /// <summary>
+        /// Result of evaluation for 'raw'
+        /// </summary>
+        /// <remarks>
+        /// Computed by serializing the immediate result of evaluation, as if by <c>serialize(x,NULL)</c>
+        /// </remarks>
+        public List<byte[]> Raw { get; }
+
+        /// <summary>
         /// If evaluation failed because of an R runtime error, text of the error message.
         /// Otherwise, <see langword="null"/>.
         /// </summary>
@@ -46,11 +55,19 @@ namespace Microsoft.R.Host.Client {
             Error = error;
             ParseStatus = parseStatus;
             Result = null;
+            Raw = null;
         }
 
         public REvaluationResult(JToken result, string error, RParseStatus parseStatus)
             : this(error, parseStatus) {
             Result = result;
+            Raw = null;
+        }
+
+        public REvaluationResult(JToken result, string error, RParseStatus parseStatus, List<byte[]> raw)
+            : this(error, parseStatus) {
+            Result = result;
+            Raw = raw;
         }
 
         public override string ToString() {

--- a/src/Host/Client/Impl/Definitions/REvaluationResult.cs
+++ b/src/Host/Client/Impl/Definitions/REvaluationResult.cs
@@ -35,7 +35,8 @@ namespace Microsoft.R.Host.Client {
         /// Result of evaluation for 'raw'
         /// </summary>
         /// <remarks>
-        /// Computed by serializing the immediate result of evaluation, as if by <c>serialize(x,NULL)</c>
+        /// Contains the result of <see cref="RHost.EvaluateAsync(string, REvaluationKind, CancellationToken)"/>, 
+        /// with <see cref="REvaluationKind.Raw"/>.
         /// </remarks>
         public List<byte[]> Raw { get; }
 
@@ -61,7 +62,6 @@ namespace Microsoft.R.Host.Client {
         public REvaluationResult(JToken result, string error, RParseStatus parseStatus)
             : this(error, parseStatus) {
             Result = result;
-            Raw = null;
         }
 
         public REvaluationResult(JToken result, string error, RParseStatus parseStatus, List<byte[]> raw)

--- a/src/Host/Client/Impl/Extensions/RawEvalResultExtensions.cs
+++ b/src/Host/Client/Impl/Extensions/RawEvalResultExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.R.Host.Client.Extensions {
+    public static class RawEvalResultExtensions {
+        public static bool HasRawData(this REvaluationResult result) {
+            return result.Raw.Count > 0;
+        }
+
+        public static void SaveRawDataToFile(this REvaluationResult result, string filepath) {
+            if (result.HasRawData()) {
+                using (BinaryWriter writer = new BinaryWriter(File.OpenWrite(filepath))) {
+                    foreach (var data in result.Raw) {
+                        writer.Write(data);
+                    }
+                    writer.Flush();
+                }
+            }
+        }
+    }
+}

--- a/src/Host/Client/Impl/Host/RHost.EvaluationRequest.cs
+++ b/src/Host/Client/Impl/Host/RHost.EvaluationRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.R.Host.Client {
                 if (kind.HasFlag(REvaluationKind.NoResult)) {
                     nameBuilder.Append('0');
                 }
-                if (kind.HasFlag(REvaluationKind.RawBytes)) {
+                if (kind.HasFlag(REvaluationKind.Raw)) {
                     nameBuilder.Append('r');
                 }
                 MessageName = nameBuilder.ToString();

--- a/src/Host/Client/Impl/Host/RHost.EvaluationRequest.cs
+++ b/src/Host/Client/Impl/Host/RHost.EvaluationRequest.cs
@@ -34,11 +34,14 @@ namespace Microsoft.R.Host.Client {
                 if (kind.HasFlag(REvaluationKind.NoResult)) {
                     nameBuilder.Append('0');
                 }
+                if (kind.HasFlag(REvaluationKind.RawBytes)) {
+                    nameBuilder.Append('r');
+                }
                 MessageName = nameBuilder.ToString();
 
                 expression = expression.Replace("\r\n", "\n");
 
-                message = host.CreateMessage(out Id, MessageName, expression);
+                message = host.CreateMessage(host.CreateMessageHeader(out Id, MessageName, null), expression);
             }
         }
     }

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -89,8 +89,6 @@ namespace Microsoft.R.Host.Client {
         }
 
         private async Task<Message> ReceiveMessageAsync(CancellationToken ct) {
-            var sb = new StringBuilder();
-
             string json;
             try {
                 json = await _transport.ReceiveAsync(ct);
@@ -108,13 +106,25 @@ namespace Microsoft.R.Host.Client {
                 return null;
             }
 
-            return new Message(token);
+            var message = new Message(token);
+
+            for(int i = 0; i < message.ExpectedBlobs; ++i) {
+                message.Blobs.Enqueue(_transport.ReceiveRawAsync().GetAwaiter().GetResult());
+            }
+
+            return message;
         }
 
-        private JArray CreateMessage(out string id, string name, params object[] args) {
+        private JArray CreateMessageHeader(out string id, string name, string requestId) {
             long n = Interlocked.Add(ref _lastMessageId, 2);
             id = "#" + n + "#";
-            return new JArray(id, name, args);
+            int blob_count = 0;
+            var header = String.IsNullOrWhiteSpace(requestId) ? new JArray(id, name, blob_count) : new JArray(id, name, blob_count, requestId);
+            return header;
+        }
+
+        private JArray CreateMessage(JArray header, params object[] args) {
+            return new JArray(header, args);
         }
 
         private async Task SendAsync(JToken token, CancellationToken ct) {
@@ -136,7 +146,7 @@ namespace Microsoft.R.Host.Client {
             TaskUtilities.AssertIsOnBackgroundThread();
 
             string id;
-            var message = CreateMessage(out id, name, args);
+            var message = CreateMessage(CreateMessageHeader(out id, name, null), args);
             await SendAsync(message, ct);
             return id;
         }
@@ -146,7 +156,7 @@ namespace Microsoft.R.Host.Client {
             TaskUtilities.AssertIsOnBackgroundThread();
 
             string id;
-            var message = CreateMessage(out id, ":" + request.Name.Substring(1), request.Id, args);
+            var message = CreateMessage(CreateMessageHeader(out id, ":" + request.Name.Substring(1), request.Id), args);
             await SendAsync(message, ct);
             return id;
         }
@@ -259,6 +269,8 @@ namespace Microsoft.R.Host.Client {
             REvaluationResult result;
             if (request.Kind.HasFlag(REvaluationKind.NoResult)) {
                 result = new REvaluationResult(error, parseStatus);
+            } else if(request.Kind.HasFlag(REvaluationKind.RawBytes) && response.Blobs.Count > 0) {
+                result = new REvaluationResult(response[2], error, parseStatus, response.Blobs.ToList());
             } else {
                 result = new REvaluationResult(response[2], error, parseStatus);
             }
@@ -421,11 +433,14 @@ namespace Microsoft.R.Host.Client {
                                 break;
 
                             case "!Plot":
+                                byte[] data;
+                                message.Blobs.TryDequeue(out data);
                                 await _callbacks.Plot(
                                     new PlotMessage(
                                         message.GetString(0, "xaml_file_path"),
                                         message.GetInt32(1, "active_plot_index"),
-                                        message.GetInt32(2, "plot_count")),
+                                        message.GetInt32(2, "plot_count"),
+                                        data),
                                     ct);
                                 break;
 

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -270,7 +270,7 @@ namespace Microsoft.R.Host.Client {
             REvaluationResult result;
             if (request.Kind.HasFlag(REvaluationKind.NoResult)) {
                 result = new REvaluationResult(error, parseStatus);
-            } else if(request.Kind.HasFlag(REvaluationKind.RawBytes) && response.Blobs.Count > 0) {
+            } else if(request.Kind.HasFlag(REvaluationKind.Raw) && response.Blobs.Count > 0) {
                 result = new REvaluationResult(response[2], error, parseStatus, response.Blobs.ToList());
             } else {
                 result = new REvaluationResult(response[2], error, parseStatus);

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -109,7 +109,8 @@ namespace Microsoft.R.Host.Client {
             var message = new Message(token);
 
             for(int i = 0; i < message.ExpectedBlobs; ++i) {
-                message.Blobs.Enqueue(_transport.ReceiveRawAsync().GetAwaiter().GetResult());
+                var blob_slices = await _transport.ReceiveRawAsync();
+                message.Blobs.Enqueue(blob_slices);
             }
 
             return message;

--- a/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
+++ b/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
@@ -73,6 +73,7 @@
     <Compile Include="ExecutionTracing\RExecutionTracer.cs" />
     <Compile Include="ExecutionTracing\RSessionExtensions.cs" />
     <Compile Include="ExecutionTracing\RSourceLocation.cs" />
+    <Compile Include="Extensions\RawEvalResultExtensions.cs" />
     <Compile Include="Install\IMicrosoftRClientInstaller.cs" />
     <Compile Include="Install\ISupportedRVersionRange.cs" />
     <Compile Include="Install\RInstallation.cs" />

--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -126,19 +126,19 @@ grDevices::deviceIsInteractive('ide')
             return evaluation.EvaluateAsync<JArray>(script, REvaluationKind.Normal);
         }
 
-        public static Task ExportToBitmapAsync(this IRExpressionEvaluator evaluation, string deviceName, string outputFilePath, int widthInPixels, int heightInPixels, int resolution) {
-            string script = Invariant($"rtvs:::graphics.ide.exportimage({outputFilePath.ToRPath().ToRStringLiteral()}, {deviceName}, {widthInPixels}, {heightInPixels}, {resolution})");
-            return evaluation.ExecuteAsync(script, REvaluationKind.Normal);
+        public static Task<REvaluationResult> ExportToBitmapAsync(this IRExpressionEvaluator evaluation, string deviceName, string outputFilePath, int widthInPixels, int heightInPixels, int resolution) {
+            string script = Invariant($"rtvs:::export_to_image({deviceName}, {widthInPixels}, {heightInPixels}, {resolution})");
+            return evaluation.EvaluateAsync(script, REvaluationKind.Raw);
         }
 
-        public static Task ExportToMetafileAsync(this IRExpressionEvaluator evaluation, string outputFilePath, double widthInInches, double heightInInches, int resolution) {
-            string script = Invariant($"rtvs:::graphics.ide.exportimage({outputFilePath.ToRPath().ToRStringLiteral()}, win.metafile, {widthInInches}, {heightInInches}, {resolution})");
-            return evaluation.ExecuteAsync(script, REvaluationKind.Normal);
+        public static Task<REvaluationResult> ExportToMetafileAsync(this IRExpressionEvaluator evaluation, string outputFilePath, double widthInInches, double heightInInches, int resolution) {
+            string script = Invariant($"rtvs:::export_to_image(win.metafile, {widthInInches}, {heightInInches}, {resolution})");
+            return evaluation.EvaluateAsync(script, REvaluationKind.Raw);
         }
 
-        public static Task ExportToPdfAsync(this IRExpressionEvaluator evaluation, string outputFilePath, double widthInInches, double heightInInches) {
-            string script = Invariant($"rtvs:::graphics.ide.exportpdf({outputFilePath.ToRPath().ToRStringLiteral()}, {widthInInches}, {heightInInches})");
-            return evaluation.ExecuteAsync(script, REvaluationKind.Normal);
+        public static Task<REvaluationResult> ExportToPdfAsync(this IRExpressionEvaluator evaluation, string outputFilePath, double widthInInches, double heightInInches) {
+            string script = Invariant($"rtvs:::export_to_pdf({widthInInches}, {heightInInches})");
+            return evaluation.EvaluateAsync(script, REvaluationKind.Raw);
         }
 
         public static async Task SetVsCranSelectionAsync(this IRExpressionEvaluator evaluation, string mirrorUrl) {

--- a/src/Host/Client/Impl/rtvs/R/graphics.R
+++ b/src/Host/Client/Impl/rtvs/R/graphics.R
@@ -13,16 +13,6 @@ graphics.ide.new <- function() {
    invisible(external_embedded('ide_graphicsdevice_new'))
 }
 
-graphics.ide.exportimage <- function(filename, device, width, height, resolution) {
-    dev.copy(device=device,filename=filename,width=width,height=height,res=resolution)
-    dev.off()
-}
-
-graphics.ide.exportpdf <- function(filename, width, height) {
-    dev.copy(device=pdf,file=filename,width=width,height=height)
-    dev.off()
-}
-
 graphics.ide.nextplot <- function() {
    invisible(external_embedded('ide_graphicsdevice_next_plot'))
 }

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -128,3 +128,12 @@ safe_eval <- function(expr, env) {
         set_rdebug(env, debug);
     });
 }
+
+# Helper to export variable to CSV
+export_to_csv <- function(expr, sep, dec) {
+	res <- expr
+	ln <- length(res) + 1
+	filepath <- tempfile('export_', fileext='.csv')
+	write.table(res, file=filepath, qmethod='double', col.names=NA, sep=sep, dec=dec)
+	list(filepath, ln, file.info(filepath)$size)
+}

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -135,5 +135,27 @@ export_to_csv <- function(expr, sep, dec) {
 	ln <- length(res) + 1
 	filepath <- tempfile('export_', fileext='.csv')
 	write.table(res, file=filepath, qmethod='double', col.names=NA, sep=sep, dec=dec)
-	list(filepath, ln, file.info(filepath)$size)
+	data <- readBin(filepath, 'raw', file.info(filepath)$size)
+	file.remove(filepath)
+	data
+}
+
+# Helper to export current plot to image
+export_to_image <- function(device, width, height, resolution) {
+	filepath <- tempfile('plot_', fileext='.dat')
+	dev.copy(device=device,filename=filepath,width=width,height=height,res=resolution)
+	dev.off()
+	data <- readBin(filepath, 'raw', file.info(filepath)$size)
+	file.remove(filepath)
+	data
+}
+
+# Helper to export current plot to pdf
+export_to_pdf <- function(width, height) {
+	filepath <- tempfile('plot_',fileext='.pdf')
+	dev.copy(device=pdf,file=filepath,width=width,height=height)
+	dev.off()
+	data <- readBin(filepath, 'raw', file.info(filepath)$size)
+	file.remove(filepath)
+	data
 }

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -131,31 +131,28 @@ safe_eval <- function(expr, env) {
 
 # Helper to export variable to CSV
 export_to_csv <- function(expr, sep, dec) {
-	res <- expr
-	ln <- length(res) + 1
-	filepath <- tempfile('export_', fileext='.csv')
-	write.table(res, file=filepath, qmethod='double', col.names=NA, sep=sep, dec=dec)
-	data <- readBin(filepath, 'raw', file.info(filepath)$size)
-	file.remove(filepath)
-	data
+    res <- expr
+    ln <- length(res) + 1
+    filepath <- tempfile('export_', fileext='.csv')
+    on.exit(unlink(filepath))
+    write.table(res, file=filepath, qmethod='double', col.names=NA, sep=sep, dec=dec)
+    readBin(filepath, 'raw', file.info(filepath)$size)
 }
 
 # Helper to export current plot to image
 export_to_image <- function(device, width, height, resolution) {
-	filepath <- tempfile('plot_', fileext='.dat')
-	dev.copy(device=device,filename=filepath,width=width,height=height,res=resolution)
-	dev.off()
-	data <- readBin(filepath, 'raw', file.info(filepath)$size)
-	file.remove(filepath)
-	data
+    filepath <- tempfile('plot_', fileext='.dat')
+    on.exit(unlink(filepath))
+    dev.copy(device=device,filename=filepath,width=width,height=height,res=resolution)
+    dev.off()
+    readBin(filepath, 'raw', file.info(filepath)$size)
 }
 
 # Helper to export current plot to pdf
 export_to_pdf <- function(width, height) {
-	filepath <- tempfile('plot_',fileext='.pdf')
-	dev.copy(device=pdf,file=filepath,width=width,height=height)
-	dev.off()
-	data <- readBin(filepath, 'raw', file.info(filepath)$size)
-	file.remove(filepath)
-	data
+    filepath <- tempfile('plot_',fileext='.pdf')
+    on.exit(unlink(filepath))
+    dev.copy(device=pdf,file=filepath,width=width,height=height)
+    dev.off()
+    readBin(filepath, 'raw', file.info(filepath)$size)
 }

--- a/src/Host/Client/Test/Microsoft.R.Host.Client.Test.csproj
+++ b/src/Host/Client/Test/Microsoft.R.Host.Client.Test.csproj
@@ -36,6 +36,7 @@
     <Compile Include="BreakpointHitDetector.cs" />
     <Compile Include="ExecutionTracing\BreakpointsTest.cs" />
     <Compile Include="Install\RInstallationTest.cs" />
+    <Compile Include="RtvsPackage\BlobsTest.cs" />
     <Compile Include="StackTracing\CallStackTest.cs" />
     <Compile Include="ExecutionTracing\DebugReplTest.cs" />
     <Compile Include="EventTaskSources.cs" />

--- a/src/Host/Client/Test/RtvsPackage/BlobsTest.cs
+++ b/src/Host/Client/Test/RtvsPackage/BlobsTest.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.R.Host.Client.Install;
+using Microsoft.R.Host.Client.Session;
+using Microsoft.R.Host.Client.Test.Script;
+using Microsoft.UnitTests.Core.XUnit;
+using Microsoft.UnitTests.Core.XUnit.MethodFixtures;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.R.Host.Client.Test.RtvsPackage {
+    [ExcludeFromCodeCoverage]
+    public class BlobsTest : IAsyncLifetime {
+        private readonly MethodInfo _testMethod;
+        private readonly IRSessionProvider _sessionProvider;
+        private readonly IRSession _session;
+
+        public BlobsTest(TestMethodFixture testMethod) {
+            _testMethod = testMethod.MethodInfo;
+            _sessionProvider = new RSessionProvider();
+            _session = _sessionProvider.GetOrCreate(Guid.NewGuid());
+        }
+
+        public async Task InitializeAsync() {
+            await _session.StartHostAsync(new RHostStartupInfo {
+                Name = _testMethod.Name,
+                RBasePath = new RInstallation().GetRInstallPath()
+            }, new RHostClientTestApp(), 50000);
+        }
+
+        public async Task DisposeAsync() {
+            await _session.StopHostAsync();
+            _sessionProvider.Dispose();
+        }
+
+        [CompositeTest]
+        [Category.R.RtvsPackage]
+        [InlineData("serialize(1:10, NULL)", "null")]
+        public async Task Serialize(string expr, string json) {
+            using (var eval = await _session.BeginEvaluationAsync()) {
+                var res = await eval.EvaluateAsync(expr, REvaluationKind.RawBytes);
+                var actualJson = JsonConvert.SerializeObject(res.Result).ToUnicodeQuotes();
+                actualJson.Should().Be(json);
+                res.Raw.Should().NotBeNull();
+                res.Raw.Count.Should().Be(1);
+            }
+        }
+    }
+}

--- a/src/Host/Client/Test/RtvsPackage/BlobsTest.cs
+++ b/src/Host/Client/Test/RtvsPackage/BlobsTest.cs
@@ -41,14 +41,22 @@ namespace Microsoft.R.Host.Client.Test.RtvsPackage {
 
         [CompositeTest]
         [Category.R.RtvsPackage]
-        [InlineData("serialize(1:10, NULL)", "null")]
-        public async Task Serialize(string expr, string json) {
+        [InlineData("serialize(1:10, NULL)", "null", new int[] { 62 })]
+        [InlineData("NULL", "null", null)]
+        public async Task Serialize(string expr, string json, int[] sizes) {
             using (var eval = await _session.BeginEvaluationAsync()) {
                 var res = await eval.EvaluateAsync(expr, REvaluationKind.RawBytes);
                 var actualJson = JsonConvert.SerializeObject(res.Result).ToUnicodeQuotes();
                 actualJson.Should().Be(json);
-                res.Raw.Should().NotBeNull();
-                res.Raw.Count.Should().Be(1);
+                if (sizes != null) {
+                    res.Raw.Should().NotBeNull();
+                    res.Raw.Count.Should().Be(sizes.Length);
+                    for (int i = 0; i < sizes.Length; ++i) {
+                        res.Raw[i].Length.Should().Be(sizes[i]);
+                    }
+                } else {
+                    res.Raw.Should().BeNull();
+                }
             }
         }
     }

--- a/src/Host/Client/Test/RtvsPackage/BlobsTest.cs
+++ b/src/Host/Client/Test/RtvsPackage/BlobsTest.cs
@@ -41,22 +41,26 @@ namespace Microsoft.R.Host.Client.Test.RtvsPackage {
 
         [CompositeTest]
         [Category.R.RtvsPackage]
-        [InlineData("serialize(1:10, NULL)", "null", new int[] { 62 })]
-        [InlineData("NULL", "null", null)]
-        public async Task Serialize(string expr, string json, int[] sizes) {
+        [InlineData("charToRaw('0123456789')", "null", new int[] { 10 })]
+        public async Task RawTest(string expr, string json, int[] sizes) {
             using (var eval = await _session.BeginEvaluationAsync()) {
-                var res = await eval.EvaluateAsync(expr, REvaluationKind.RawBytes);
+                var res = await eval.EvaluateAsync(expr, REvaluationKind.Raw);
                 var actualJson = JsonConvert.SerializeObject(res.Result).ToUnicodeQuotes();
                 actualJson.Should().Be(json);
-                if (sizes != null) {
-                    res.Raw.Should().NotBeNull();
-                    res.Raw.Count.Should().Be(sizes.Length);
-                    for (int i = 0; i < sizes.Length; ++i) {
-                        res.Raw[i].Length.Should().Be(sizes[i]);
-                    }
-                } else {
-                    res.Raw.Should().BeNull();
-                }
+                res.Raw.Should().NotBeNull();
+                res.Raw.Should().Equal(sizes, (a, e) => a.Length == e);
+            }
+        }
+
+        [CompositeTest]
+        [Category.R.RtvsPackage]
+        [InlineData("NULL", "null")]
+        public async Task NullTest(string expr, string json) {
+            using (var eval = await _session.BeginEvaluationAsync()) {
+                var res = await eval.EvaluateAsync(expr, REvaluationKind.Raw);
+                var actualJson = JsonConvert.SerializeObject(res.Result).ToUnicodeQuotes();
+                actualJson.Should().Be(json);
+                res.Raw.Should().BeNull();
             }
         }
     }

--- a/src/Host/Client/Test/RtvsPackage/JsonTest.cs
+++ b/src/Host/Client/Test/RtvsPackage/JsonTest.cs
@@ -81,6 +81,7 @@ namespace Microsoft.R.RtvsPackage.Test {
                 var res = await eval.EvaluateAsync(expr, REvaluationKind.Normal);
                 res.Error.Should().BeNullOrEmpty();
                 res.Result.Should().NotBeNull();
+                res.Raw.Should().BeNull();
                 var actualJson = JsonConvert.SerializeObject(res.Result).ToUnicodeQuotes();
                 actualJson.Should().Be(json);
             }
@@ -102,6 +103,7 @@ namespace Microsoft.R.RtvsPackage.Test {
                 var res = await eval.EvaluateAsync(expr, REvaluationKind.Normal);
                 res.Error.Should().BeNullOrEmpty();
                 res.Result.Should().NotBeNull();
+                res.Raw.Should().BeNull();
                 var actualJson = JsonConvert.SerializeObject(res.Result).ToUnicodeQuotes();
                 actualJson.Should().Be(json);
             }
@@ -125,6 +127,7 @@ namespace Microsoft.R.RtvsPackage.Test {
             using (var eval = await _session.BeginEvaluationAsync()) {
                 var res = await eval.EvaluateAsync($"rtvs::toJSON({expr})", REvaluationKind.Normal);
                 res.Error.Should().NotBeNullOrEmpty();
+                res.Raw.Should().BeNull();
             }
         }
     }

--- a/src/Package/Impl/DataInspect/Office/CsvAppFileIO.cs
+++ b/src/Package/Impl/DataInspect/Office/CsvAppFileIO.cs
@@ -21,6 +21,7 @@ using Microsoft.VisualStudio.R.Package.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Utilities;
 using Task = System.Threading.Tasks.Task;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect.Office {
     internal static class CsvAppFileIO {
@@ -74,7 +75,20 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Office {
             var dec = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
 
             using (var e = await session.BeginEvaluationAsync()) {
-                await e.EvaluateAsync($"write.table({result.Expression}, qmethod='double', col.names=NA, file={file.ToRPath().ToRStringLiteral()}, sep={sep.ToRStringLiteral()}, dec={dec.ToRStringLiteral()})", REvaluationKind.Normal);
+                var fileinfo = await e.EvaluateAsync($"rtvs:::export_to_csv({result.Expression}, sep={sep.ToRStringLiteral()}, dec={dec.ToRStringLiteral()})", REvaluationKind.Normal);
+                JArray arr = fileinfo.Result.ToObject<JArray>();
+                string filepath = arr[0].Value<string>();
+                int bytes = arr[2].Value<int>();
+                var csvdata = await e.EvaluateAsync($"charToRaw(readChar({filepath.ToRStringLiteral()}, {bytes}, useBytes=TRUE))", REvaluationKind.RawBytes);
+
+                if (csvdata.Raw.Count > 0) {
+                    using (BinaryWriter writer = new BinaryWriter(File.OpenWrite(file))) {
+                        foreach (var data in csvdata.Raw) {
+                            writer.Write(data);
+                        }
+                        writer.Flush();
+                    }
+                }
             }
 
             if (File.Exists(file)) {

--- a/src/R/Components/Impl/Plots/Implementation/PlotMessageExtensions.cs
+++ b/src/R/Components/Impl/Plots/Implementation/PlotMessageExtensions.cs
@@ -4,11 +4,12 @@
 using System.Windows.Media.Imaging;
 using Microsoft.Common.Wpf.Imaging;
 using Microsoft.R.Host.Client;
+using System.IO;
 
 namespace Microsoft.R.Components.Plots.Implementation {
     internal static class PlotMessageExtensions {
         public static BitmapImage ToBitmapImage(this PlotMessage plot) {
-            return BitmapImageFactory.Load(plot.FilePath);
+            return BitmapImageFactory.Load(new MemoryStream(plot.Data));
         }
     }
 }

--- a/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
@@ -10,6 +10,7 @@ using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Components.Plots.Implementation.Commands;
 using Microsoft.R.Components.Settings;
 using Microsoft.R.Host.Client;
+using Microsoft.R.Host.Client.Extensions;
 using Microsoft.R.Host.Client.Session;
 
 namespace Microsoft.R.Components.Plots.Implementation {
@@ -172,7 +173,8 @@ namespace Microsoft.R.Components.Plots.Implementation {
 
         public async Task ExportToBitmapAsync(string deviceName, string outputFilePath) {
             try {
-                await _interactiveWorkflow.RSession.ExportToBitmapAsync(deviceName, outputFilePath, _lastPixelWidth, _lastPixelHeight, _lastResolution);
+                var bitmapResult = await _interactiveWorkflow.RSession.ExportToBitmapAsync(deviceName, outputFilePath, _lastPixelWidth, _lastPixelHeight, _lastResolution);
+                bitmapResult.SaveRawDataToFile(outputFilePath);
             } catch (MessageTransportException ex) {
                 throw new RPlotManagerException(Resources.Plots_TransportError, ex);
             } catch (RException ex) {
@@ -182,7 +184,8 @@ namespace Microsoft.R.Components.Plots.Implementation {
 
         public async Task ExportToMetafileAsync(string outputFilePath) {
             try {
-                await _interactiveWorkflow.RSession.ExportToMetafileAsync(outputFilePath, PixelsToInches(_lastPixelWidth), PixelsToInches(_lastPixelHeight), _lastResolution);
+                var metafileResult = await _interactiveWorkflow.RSession.ExportToMetafileAsync(outputFilePath, PixelsToInches(_lastPixelWidth), PixelsToInches(_lastPixelHeight), _lastResolution);
+                metafileResult.SaveRawDataToFile(outputFilePath);
             } catch (MessageTransportException ex) {
                 throw new RPlotManagerException(Resources.Plots_TransportError, ex);
             } catch (RException ex) {
@@ -192,7 +195,8 @@ namespace Microsoft.R.Components.Plots.Implementation {
 
         public async Task ExportToPdfAsync(string outputFilePath) {
             try {
-                await _interactiveWorkflow.RSession.ExportToPdfAsync(outputFilePath, PixelsToInches(_lastPixelWidth), PixelsToInches(_lastPixelHeight));
+                var pdfResult = await _interactiveWorkflow.RSession.ExportToPdfAsync(outputFilePath, PixelsToInches(_lastPixelWidth), PixelsToInches(_lastPixelHeight));
+                pdfResult.SaveRawDataToFile(outputFilePath);
             } catch (MessageTransportException ex) {
                 throw new RPlotManagerException(Resources.Plots_TransportError, ex);
             } catch (RException ex) {

--- a/src/R/Components/Test/Plots/PlotIntegrationTest.cs
+++ b/src/R/Components/Test/Plots/PlotIntegrationTest.cs
@@ -223,26 +223,6 @@ namespace Microsoft.R.Components.Test.Plots {
 
         [Test(ThreadType.UI)]
         [Category.Plots]
-        public async Task ExportAsPdfInvalidFilename() {
-            using (await _workflow.GetOrCreateVisualComponent(_componentContainerFactory)) {
-                await ExecuteAndWaitForPlotsAsync(new string[] {
-                    "plot(1:10)",
-                });
-
-                var outputFilePath = _testFiles.GetDestinationPath("invalid%.pdf");
-                CoreShell.SaveFilePath = outputFilePath;
-
-                _workflow.Plots.Commands.ExportAsPdf.Should().BeEnabled();
-                await _workflow.Plots.Commands.ExportAsPdf.InvokeAsync();
-
-                // Ensure that RException was caught and message displayed to the user
-                File.Exists(CoreShell.SaveFilePath).Should().BeFalse();
-                CoreShell.LastShownErrorMessage.Should().Contain("invalid 'file' argument");
-            }
-        }
-
-        [Test(ThreadType.UI)]
-        [Category.Plots]
         public async Task ExportAsImage() {
             using (await _workflow.GetOrCreateVisualComponent(_componentContainerFactory)) {
                 // We set an initial size for plots, because export as image command
@@ -276,6 +256,10 @@ namespace Microsoft.R.Components.Test.Plots {
         [Category.Plots]
         public async Task ExportAsImageUnsupportedExtension() {
             using (await _workflow.GetOrCreateVisualComponent(_componentContainerFactory)) {
+                // We set an initial size for plots, because export as image command
+                // will use the current size of plot control as export parameter.
+                await _workflow.Plots.ResizeAsync(600, 500, 96);
+
                 await ExecuteAndWaitForPlotsAsync(new string[] {
                     "plot(1:10)",
                 });
@@ -291,26 +275,6 @@ namespace Microsoft.R.Components.Test.Plots {
 
                 File.Exists(CoreShell.SaveFilePath).Should().BeFalse();
                 CoreShell.LastShownErrorMessage.Should().Contain(".unsupportedextension");
-            }
-        }
-
-        [Test(ThreadType.UI)]
-        [Category.Plots]
-        public async Task ExportAsImageInvalidFilename() {
-            using (await _workflow.GetOrCreateVisualComponent(_componentContainerFactory)) {
-                await ExecuteAndWaitForPlotsAsync(new string[] {
-                    "plot(1:10)",
-                });
-
-                var outputFilePath = _testFiles.GetDestinationPath("invalid%.png");
-                CoreShell.SaveFilePath = outputFilePath;
-
-                _workflow.Plots.Commands.ExportAsImage.Should().BeEnabled();
-                await _workflow.Plots.Commands.ExportAsImage.InvokeAsync();
-
-                // Ensure that RException was caught and message displayed to the user
-                File.Exists(CoreShell.SaveFilePath).Should().BeFalse();
-                CoreShell.LastShownErrorMessage.Should().Contain("invalid 'filename'");
             }
         }
 


### PR DESCRIPTION
#2023  Host can send binary blobs. Plots updated to use blobs. Added =r (raw) eval kind. First element in the message json now has the header [id, name, blob_count, <optional>request_id].