### PR TITLE
Remote package lock state check

### DIFF
--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -198,3 +198,24 @@ rmarkdown_publish <- function(blob_id, output_format, encoding) {
     rmarkdown::render(rmdpath, output_format = output_format, output_file = output_filepath,  output_dir = tempdir(), encoding = encoding);
     readBin(output_filepath, 'raw', file.info(output_filepath)$size);
 }
+
+package_lock_state <- function(package_name, package_lib) {
+    file_path_i386 <- paste0(package_lib, '/', package_name, '/libs/i386/', package_name, '.dll');
+    file_path_x64 <- paste0(package_lib, '/', package_name, '/libs/x64/', package_name, '.dll');
+    
+    lock_state <- if (file.exists(file_path_x64)) {
+        call_embedded('get_package_lock_state', file_path_x64);
+    } else {
+        'unlocked'
+    }
+
+    if (identical(lock_state, 'unlocked')) {
+        lock_state <- if (file.exists(file_path_i386)) {
+        call_embedded('get_package_lock_state', file_path_i386);
+        } else {
+            'unlocked'
+        }
+    }
+
+    lock_state
+}

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -199,10 +199,14 @@ rmarkdown_publish <- function(blob_id, output_format, encoding) {
     readBin(output_filepath, 'raw', file.info(output_filepath)$size);
 }
 
+as.lock_state <- function(x) {
+    factor(x, levels = c(0, 1, 2), labels = c('unlocked', 'locked_by_r_session', 'locked_by_other'));
+}
+
 package_lock_state <- function(package_name, lib_path) {
     files <- dir(path = paste0(lib_path,'/', package_name), pattern = '\\.', recursive = TRUE, ignore.case = TRUE, full.names = TRUE)
-    lock_state <- call_embedded('get_file_lock_state', files);
-    factor(lock_state, levels = c(0, 1, 2), labels = c('unlocked', 'locked_by_r_session', 'locked_by_other'));
+    fstate <- call_embedded('get_file_lock_state', files);
+    as.lock_state(fstate);
 }
 
 package_uninstall <- function(package_name, lib_path) {

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -199,23 +199,17 @@ rmarkdown_publish <- function(blob_id, output_format, encoding) {
     readBin(output_filepath, 'raw', file.info(output_filepath)$size);
 }
 
-package_lock_state <- function(package_name, package_lib) {
-    file_path_i386 <- paste0(package_lib, '/', package_name, '/libs/i386/', package_name, '.dll');
-    file_path_x64 <- paste0(package_lib, '/', package_name, '/libs/x64/', package_name, '.dll');
+package_lock_state <- function(package_name, lib_path) {
+    dlls <- dir(path = paste0(lib_path,'/', package_name), pattern = '.dll', recursive = TRUE, ignore.case = TRUE, full.names = TRUE)
     
-    lock_state <- if (file.exists(file_path_x64)) {
-        call_embedded('get_package_lock_state', file_path_x64);
-    } else {
-        'unlocked'
-    }
-
-    if (identical(lock_state, 'unlocked')) {
-        lock_state <- if (file.exists(file_path_i386)) {
-        call_embedded('get_package_lock_state', file_path_i386);
+    lock_state <- 'unlocked'
+    for(dll in dlls) {
+        if(identical(lock_state, 'unlocked')) {
+            lock_state <- call_embedded('get_package_lock_state', dll);
         } else {
-            'unlocked'
+            break;
         }
     }
-
+    
     lock_state
 }

--- a/src/R/Components/Impl/PackageManager/IRPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/IRPackageManager.cs
@@ -105,6 +105,6 @@ namespace Microsoft.R.Components.PackageManager {
         /// <param name="name">Package name.</param>
         /// <param name="libraryPath">Library path (in any format).</param>
         /// <returns>Lock state.</returns>
-        PackageLockState GetPackageLockState(string name, string libraryPath);
+        Task<PackageLockState> GetPackageLockState(string name, string libraryPath);
     }
 }

--- a/src/R/Components/Impl/PackageManager/IRPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/IRPackageManager.cs
@@ -51,14 +51,36 @@ namespace Microsoft.R.Components.PackageManager {
         Task InstallPackageAsync(string name, string libraryPath);
 
         /// <summary>
-        /// Uninstall a package by sending remove.packages() to the REPL.
+        /// Uninstall a package by evaluating rtvs:::package_uninstall.
         /// </summary>
         /// <param name="name">Package name.</param>
         /// <param name="libraryPath">
         ///     Optional library path (in any format) where the package is installed.
         ///     Pass null to use the defaults for the session ie. in .libPaths().
         /// </param>
-        Task UninstallPackageAsync(string name, string libraryPath);
+        /// <returns>
+        /// <see cref="PackageLockState.Unlocked"/>  if the package was successfully 
+        /// installed. <see cref="PackageLockState.LockedByRSession"/> or <see cref="PackageLockState.LockedByOther"/> 
+        /// if the package was found to be installed and loaded in the REPL or 
+        /// loaded by another process.
+        /// </returns>
+        Task<PackageLockState> UninstallPackageAsync(string name, string libraryPath);
+
+        /// <summary>
+        /// Uninstall and Install a package by evaluating rtvs:::package_update.
+        /// </summary>
+        /// <param name="name">Package name.</param>
+        /// <param name="libraryPath">
+        ///     Optional library path (in any format) where the package is installed.
+        ///     Pass null to use the defaults for the session ie. in .libPaths().
+        /// </param>
+        /// <returns>
+        /// <see cref="PackageLockState.Unlocked"/>  if the package was successfully 
+        /// installed. <see cref="PackageLockState.LockedByRSession"/> or <see cref="PackageLockState.LockedByOther"/> 
+        /// if the package was found to be installed and loaded in the REPL or 
+        /// loaded by another process.
+        /// </returns>
+        Task<PackageLockState> UpdatePackageAsync(string name, string libraryPath);
 
         /// <summary>
         /// Load a package by sending library() to the REPL.
@@ -105,6 +127,6 @@ namespace Microsoft.R.Components.PackageManager {
         /// <param name="name">Package name.</param>
         /// <param name="libraryPath">Library path (in any format).</param>
         /// <returns>Lock state.</returns>
-        Task<PackageLockState> GetPackageLockState(string name, string libraryPath);
+        Task<PackageLockState> GetPackageLockStateAsync(string name, string libraryPath);
     }
 }

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -144,7 +144,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             }
         }
 
-        public  async Task<PackageLockState> GetPackageLockState(string name, string libraryPath) {
+        public async Task<PackageLockState> GetPackageLockState(string name, string libraryPath) {
             var pkgStateresult =  await _interactiveWorkflow.RSession.EvaluateAsync($"rtvs:::package_lock_state({name.ToRStringLiteral()}, {libraryPath.ToRStringLiteral()})", REvaluationKind.Normal);
 
             string pkgState = pkgStateresult.Result.Value<string>();

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -51,52 +51,24 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
         }
 
         public async Task InstallPackageAsync(string name, string libraryPath) {
-            if (!_interactiveWorkflow.RSession.IsHostRunning) {
-                throw new RPackageManagerException(Resources.PackageManager_EvalSessionNotAvailable);
-            }
-
-            try {
-                using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync()) {
-                    if (string.IsNullOrEmpty(libraryPath)) {
-                        await request.InstallPackageAsync(name);
-                    } else {
-                        await request.InstallPackageAsync(name, libraryPath);
-                    }
+            using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync()) {
+                if (string.IsNullOrEmpty(libraryPath)) {
+                    await request.InstallPackageAsync(name);
+                } else {
+                    await request.InstallPackageAsync(name, libraryPath);
                 }
-            } catch (RHostDisconnectedException ex) {
-                throw new RPackageManagerException(Resources.PackageManager_TransportError, ex);
             }
         }
 
         public async Task<PackageLockState> UninstallPackageAsync(string name, string libraryPath) {
-            if (!_interactiveWorkflow.RSession.IsHostRunning) {
-                throw new RPackageManagerException(Resources.PackageManager_EvalSessionNotAvailable);
-            }
-
-            try {
-                using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync()) {
-                    using (var eval = await _interactiveWorkflow.RSession.BeginEvaluationAsync()) {
-                        return await eval.EvaluateAsync<PackageLockState>($"rtvs:::package_uninstall({name.ToRStringLiteral()}, {libraryPath.ToRStringLiteral()})", REvaluationKind.Normal);
-                    }
-                }
-            } catch (RHostDisconnectedException ex) {
-                throw new RPackageManagerException(Resources.PackageManager_TransportError, ex);
+            using (var eval = await _interactiveWorkflow.RSession.BeginEvaluationAsync()) {
+                return await eval.EvaluateAsync<PackageLockState>($"rtvs:::package_uninstall({name.ToRStringLiteral()}, {libraryPath.ToRStringLiteral()})", REvaluationKind.Normal);
             }
         }
 
         public async Task<PackageLockState> UpdatePackageAsync(string name, string libraryPath) {
-            if (!_interactiveWorkflow.RSession.IsHostRunning) {
-                throw new RPackageManagerException(Resources.PackageManager_EvalSessionNotAvailable);
-            }
-
-            try {
-                using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync()) {
-                    using (var eval = await _interactiveWorkflow.RSession.BeginEvaluationAsync()) {
-                        return await eval.EvaluateAsync<PackageLockState>($"rtvs:::package_update({name.ToRStringLiteral()}, {libraryPath.ToRStringLiteral()})", REvaluationKind.Normal);
-                    }
-                }
-            } catch (RHostDisconnectedException ex) {
-                throw new RPackageManagerException(Resources.PackageManager_TransportError, ex);
+            using (var eval = await _interactiveWorkflow.RSession.BeginEvaluationAsync()) {
+                return await eval.EvaluateAsync<PackageLockState>($"rtvs:::package_update({name.ToRStringLiteral()}, {libraryPath.ToRStringLiteral()})", REvaluationKind.Normal);
             }
         }
 

--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
@@ -188,7 +188,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             if (!package.IsLoaded) {
                 try {
                     var libPath = package.LibraryPath.ToRPath();
-                    var packageLockState = _packageManager.GetPackageLockState(package.Name, libPath);
+                    var packageLockState = await _packageManager.GetPackageLockState(package.Name, libPath);
                     if (packageLockState == PackageLockState.Unlocked) {
                         await _packageManager.UninstallPackageAsync(package.Name, libPath);
                         await _packageManager.InstallPackageAsync(package.Name, libPath);
@@ -242,7 +242,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             if (!package.IsLoaded) {
                 try {
                     var libPath = package.LibraryPath.ToRPath();
-                    var packageLockState = _packageManager.GetPackageLockState(package.Name, libPath);
+                    var packageLockState = await _packageManager.GetPackageLockState(package.Name, libPath);
                     if (packageLockState == PackageLockState.Unlocked) {
                         await _packageManager.UninstallPackageAsync(package.Name, libPath);
                     } else {

--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
@@ -188,11 +188,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             if (!package.IsLoaded) {
                 try {
                     var libPath = package.LibraryPath.ToRPath();
-                    var packageLockState = await _packageManager.GetPackageLockState(package.Name, libPath);
-                    if (packageLockState == PackageLockState.Unlocked) {
-                        await _packageManager.UninstallPackageAsync(package.Name, libPath);
-                        await _packageManager.InstallPackageAsync(package.Name, libPath);
-                    } else {
+                    var packageLockState = await _packageManager.UpdatePackageAsync(package.Name, libPath);
+                    if (packageLockState != PackageLockState.Unlocked) {
                         ShowPackageLockedMessage(packageLockState, package.Name);
                     }
                 } catch (RPackageManagerException ex) {
@@ -242,10 +239,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             if (!package.IsLoaded) {
                 try {
                     var libPath = package.LibraryPath.ToRPath();
-                    var packageLockState = await _packageManager.GetPackageLockState(package.Name, libPath);
-                    if (packageLockState == PackageLockState.Unlocked) {
-                        await _packageManager.UninstallPackageAsync(package.Name, libPath);
-                    } else {
+                    var packageLockState = await _packageManager.UninstallPackageAsync(package.Name, libPath);
+                    if (packageLockState != PackageLockState.Unlocked) {
                         ShowPackageLockedMessage(packageLockState, package.Name);
                     }
                 } catch (RPackageManagerException ex) {

--- a/src/R/Components/Impl/PackageManager/Model/PackageLockState.cs
+++ b/src/R/Components/Impl/PackageManager/Model/PackageLockState.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.R.Components.PackageManager.Model {
     public enum PackageLockState {
-        Unlocked,
-        LockedByRSession,
-        LockedByOther,
+        Unlocked = 1,
+        LockedByRSession = 2,
+        LockedByOther = 3,
     }
 }

--- a/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
+++ b/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
@@ -269,10 +269,10 @@ namespace Microsoft.R.Components.Test.PackageManager {
             var abn = pkgs.Should().ContainSingle(pkg => pkg.Package == "abn").Which;
             var cairo = pkgs.Should().ContainSingle(pkg => pkg.Package == "Cairo").Which;
 
-            var abn_state = await _workflow.Packages.GetPackageLockStateAsync(abn.Package, abn.LibPath);
-            abn_state.Should().Be(PackageLockState.LockedByRSession);
-            var cairo_state = await _workflow.Packages.GetPackageLockStateAsync(cairo.Package, cairo.LibPath);
-            cairo_state.Should().Be(PackageLockState.LockedByRSession);
+            var abnState = await _workflow.Packages.GetPackageLockStateAsync(abn.Package, abn.LibPath);
+            abnState.Should().Be(PackageLockState.LockedByRSession);
+            var cairoState = await _workflow.Packages.GetPackageLockStateAsync(cairo.Package, cairo.LibPath);
+            cairoState.Should().Be(PackageLockState.LockedByRSession);
         }
 
         [Test]
@@ -286,8 +286,8 @@ namespace Microsoft.R.Components.Test.PackageManager {
             var pkgs = await _workflow.Packages.GetInstalledPackagesAsync();
             var abn = pkgs.Should().ContainSingle(pkg => pkg.Package == "abn").Which;
 
-            var abn_state = await _workflow.Packages.GetPackageLockStateAsync(abn.Package, abn.LibPath);
-            abn_state.Should().Be(PackageLockState.Unlocked);
+            var abnState = await _workflow.Packages.GetPackageLockStateAsync(abn.Package, abn.LibPath);
+            abnState.Should().Be(PackageLockState.Unlocked);
         }
 
         private async Task EvaluateCode(string code, string expectedResult = null, string expectedError = null) {

--- a/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
+++ b/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
@@ -269,8 +269,10 @@ namespace Microsoft.R.Components.Test.PackageManager {
             var abn = pkgs.Should().ContainSingle(pkg => pkg.Package == "abn").Which;
             var cairo = pkgs.Should().ContainSingle(pkg => pkg.Package == "Cairo").Which;
 
-            _workflow.Packages.GetPackageLockState(abn.Package, abn.LibPath).Should().Be(PackageLockState.LockedByRSession);
-            _workflow.Packages.GetPackageLockState(cairo.Package, cairo.LibPath).Should().Be(PackageLockState.LockedByRSession);
+            var abn_state = await _workflow.Packages.GetPackageLockState(abn.Package, abn.LibPath);
+            abn_state.Should().Be(PackageLockState.LockedByRSession);
+            var cairo_state = await _workflow.Packages.GetPackageLockState(cairo.Package, cairo.LibPath);
+            cairo_state.Should().Be(PackageLockState.LockedByRSession);
         }
 
         [Test]
@@ -284,7 +286,8 @@ namespace Microsoft.R.Components.Test.PackageManager {
             var pkgs = await _workflow.Packages.GetInstalledPackagesAsync();
             var abn = pkgs.Should().ContainSingle(pkg => pkg.Package == "abn").Which;
 
-            _workflow.Packages.GetPackageLockState(abn.Package, abn.LibPath).Should().Be(PackageLockState.Unlocked);
+            var abn_state = await _workflow.Packages.GetPackageLockState(abn.Package, abn.LibPath);
+            abn_state.Should().Be(PackageLockState.Unlocked);
         }
 
         private async Task EvaluateCode(string code, string expectedResult = null, string expectedError = null) {

--- a/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
+++ b/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
@@ -269,9 +269,9 @@ namespace Microsoft.R.Components.Test.PackageManager {
             var abn = pkgs.Should().ContainSingle(pkg => pkg.Package == "abn").Which;
             var cairo = pkgs.Should().ContainSingle(pkg => pkg.Package == "Cairo").Which;
 
-            var abn_state = await _workflow.Packages.GetPackageLockState(abn.Package, abn.LibPath);
+            var abn_state = await _workflow.Packages.GetPackageLockStateAsync(abn.Package, abn.LibPath);
             abn_state.Should().Be(PackageLockState.LockedByRSession);
-            var cairo_state = await _workflow.Packages.GetPackageLockState(cairo.Package, cairo.LibPath);
+            var cairo_state = await _workflow.Packages.GetPackageLockStateAsync(cairo.Package, cairo.LibPath);
             cairo_state.Should().Be(PackageLockState.LockedByRSession);
         }
 
@@ -286,7 +286,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
             var pkgs = await _workflow.Packages.GetInstalledPackagesAsync();
             var abn = pkgs.Should().ContainSingle(pkg => pkg.Package == "abn").Which;
 
-            var abn_state = await _workflow.Packages.GetPackageLockState(abn.Package, abn.LibPath);
+            var abn_state = await _workflow.Packages.GetPackageLockStateAsync(abn.Package, abn.LibPath);
             abn_state.Should().Be(PackageLockState.Unlocked);
         }
 


### PR DESCRIPTION
Moved the code that checks for the package lock state to R-host. Added a rtvs util function to retrieve lock state. Generalized the search for dlls in a library. 