### PR TITLE
SQL fixes

### DIFF
--- a/src/Package/Impl/ProjectSystem/Configuration/ProjectConfigurationSettingsProvider.cs
+++ b/src/Package/Impl/ProjectSystem/Configuration/ProjectConfigurationSettingsProvider.cs
@@ -12,6 +12,9 @@ using Microsoft.Common.Core.Disposables;
 using Microsoft.R.Components.Application.Configuration;
 using Microsoft.R.Host.Client.Extensions;
 using Microsoft.VisualStudio.ProjectSystem;
+#if VS15
+using IThreadHandling = Microsoft.VisualStudio.ProjectSystem.IProjectThreadingService;
+#endif
 
 namespace Microsoft.VisualStudio.R.Package.ProjectSystem.Configuration {
     /// <summary>
@@ -43,7 +46,8 @@ namespace Microsoft.VisualStudio.R.Package.ProjectSystem.Configuration {
                 string projectFolder = Path.GetDirectoryName(unconfiguredProject.FullPath);
                 if (!_settings.TryGetValue(projectFolder, out access)) {
                     var settings = await OpenCollectionAsync(projectFolder, propertes);
-                    access = new SettingsAccess(this, projectFolder, settings);
+                    var th = unconfiguredProject.Services.ExportProvider.GetExportedValue<IThreadHandling>();
+                    access = new SettingsAccess(this, th, projectFolder, propertes, settings);
                     _settings[projectFolder] = access;
                 }
                 access.Counter.Increment();
@@ -70,7 +74,7 @@ namespace Microsoft.VisualStudio.R.Package.ProjectSystem.Configuration {
             return null;
         }
 
-        private void ReleaseSettings(string projectPath, bool save) {
+        private void ReleaseSettings(string projectPath, IThreadHandling threadHandling, IRProjectProperties propertes, bool save) {
             _semaphore.Wait();
             try {
                 var access = _settings[projectPath];
@@ -81,6 +85,14 @@ namespace Microsoft.VisualStudio.R.Package.ProjectSystem.Configuration {
                 if (save) {
                     access.Settings.Save(settingsFile);
                 }
+
+                threadHandling.ExecuteSynchronously(async () => {
+                    var currentSettingsFile = await propertes.GetSettingsFileAsync();
+                    if (string.IsNullOrEmpty(currentSettingsFile)) {
+                        settingsFile = settingsFile.MakeRRelativePath(projectPath);
+                        await propertes.SetSettingsFileAsync(settingsFile);
+                    }
+                });
                 _settings.Remove(projectPath);
             } finally {
                 _semaphore.Release();
@@ -88,14 +100,19 @@ namespace Microsoft.VisualStudio.R.Package.ProjectSystem.Configuration {
         }
 
         class SettingsAccess : IProjectConfigurationSettingsAccess {
+            private readonly IThreadHandling _threadHandling;
             private readonly ProjectConfigurationSettingsProvider _provider;
             private readonly CountdownDisposable _counter;
             private readonly string _projectPath;
+            private readonly IRProjectProperties _properties;
             private bool _changed;
 
-            public SettingsAccess(ProjectConfigurationSettingsProvider provider, string projectPath, ConfigurationSettingCollection settings) {
+            public SettingsAccess(ProjectConfigurationSettingsProvider provider, IThreadHandling threadHandling,
+                                  string projectPath, IRProjectProperties propertes, ConfigurationSettingCollection settings) {
                 _provider = provider;
+                _threadHandling = threadHandling;
                 _projectPath = projectPath;
+                _properties = propertes;
 
                 _counter = new CountdownDisposable(Release);
 
@@ -119,7 +136,7 @@ namespace Microsoft.VisualStudio.R.Package.ProjectSystem.Configuration {
 
             private void Release() {
                 Settings.CollectionChanged -= OnCollectionChanged;
-                _provider.ReleaseSettings(_projectPath, _changed);
+                _provider.ReleaseSettings(_projectPath, _threadHandling, _properties, _changed);
             }
         }
     }

--- a/src/Package/Impl/Sql/Commands/PublishSProcCommand.cs
+++ b/src/Package/Impl/Sql/Commands/PublishSProcCommand.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.R.Package.ProjectSystem;
 using Microsoft.VisualStudio.R.Package.Sql.Publish;
 using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using EnvDTE;
 #if VS14
 using Microsoft.VisualStudio.ProjectSystem.Designers;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
@@ -29,7 +30,7 @@ namespace Microsoft.VisualStudio.R.Package.Sql {
         private readonly IDacPackageServices _dacServices;
 
         [ImportingConstructor]
-        public PublishSProcCommand(IApplicationShell appShell, IProjectSystemServices pss) : 
+        public PublishSProcCommand(IApplicationShell appShell, IProjectSystemServices pss) :
             this(appShell, pss, new FileSystem(), new DacPackageServices()) {
         }
 
@@ -61,10 +62,14 @@ namespace Microsoft.VisualStudio.R.Package.Sql {
                 var sprocFiles = project.GetSProcFiles(_pss);
                 if (sprocFiles.Any()) {
                     try {
+                        // Make sure all files are saved and up to date on disk.
+                        var dte = _appShell.GetGlobalService<DTE>(typeof(DTE));
+                        dte.ExecuteCommand("File.SaveAll");
+
                         var publisher = new SProcPublisher(_appShell, _pss, _fs, _dacServices);
                         var settings = new SqlSProcPublishSettings(_appShell.SettingsStorage);
                         publisher.Publish(settings, sprocFiles);
-                    } catch(Exception ex) {
+                    } catch (Exception ex) {
                         _appShell.ShowErrorMessage(string.Format(CultureInfo.InvariantCulture, Resources.SqlPublish_PublishError, ex.Message));
                     }
                 } else {

--- a/src/Package/Impl/Sql/Publish/SqlPublshOptionsDialog.xaml.cs
+++ b/src/Package/Impl/Sql/Publish/SqlPublshOptionsDialog.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using System.Windows.Controls;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.IO;
+using Microsoft.R.Components.Extensions;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.R.Package.Commands;
 using Microsoft.VisualStudio.R.Package.ProjectSystem;
@@ -36,10 +37,14 @@ namespace Microsoft.VisualStudio.R.Package.Sql.Publish {
             this(appShell, pss, new FileSystem(), pcsp) {
             InitializeComponent();
 
-            TargetTypeList.SelectedIndex = _model.SelectedTargetTypeIndex;
-            TargetList.SelectedIndex = _model.SelectedTargetIndex;
-            CodePlacementList.SelectedIndex = _model.SelectedQuoteTypeIndex;
-            QuoteTypeList.SelectedIndex = _model.SelectedQuoteTypeIndex;
+            InitializeAsync().ContinueWith(async (t) => {
+                await _appShell.SwitchToMainThreadAsync();
+
+                TargetTypeList.SelectedIndex = _model.SelectedTargetTypeIndex;
+                TargetList.SelectedIndex = _model.SelectedTargetIndex;
+                CodePlacementList.SelectedIndex = _model.SelectedQuoteTypeIndex;
+                QuoteTypeList.SelectedIndex = _model.SelectedQuoteTypeIndex;
+            }).DoNotWait();
         }
 
         private SqlPublshOptionsDialog(IApplicationShell appShell, IProjectSystemServices pss, IFileSystem fs, IProjectConfigurationSettingsProvider pcsp) {

--- a/src/Package/Impl/Sql/Publish/SqlPublshOptionsDialog.xaml.cs
+++ b/src/Package/Impl/Sql/Publish/SqlPublshOptionsDialog.xaml.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using EnvDTE;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.IO;
 using Microsoft.R.Components.Extensions;
@@ -60,6 +61,10 @@ namespace Microsoft.VisualStudio.R.Package.Sql.Publish {
         private void SaveSettingsAndClose() {
             _model.Settings.Save(_appShell.SettingsStorage);
 
+            // Make sure all files are saved and up to date on disk.
+            var dte = _appShell.GetGlobalService<DTE>(typeof(DTE));
+            dte.ExecuteCommand("File.SaveAll");
+
             var uiShell = _appShell.GetGlobalService<IVsUIShell>(typeof(SVsUIShell));
             var guid = RGuidList.RCmdSetGuid;
             var o = new object();
@@ -73,7 +78,10 @@ namespace Microsoft.VisualStudio.R.Package.Sql.Publish {
 
         private void TargetTypeList_SelectionChanged(object sender, SelectionChangedEventArgs e) {
             _model.SelectTargetTypeAsync(TargetTypeList.SelectedIndex).ContinueWith(t => {
-                _appShell.DispatchOnUIThread(() => TargetList.SelectedIndex = _model.SelectedTargetIndex);
+                _appShell.DispatchOnUIThread(() => {
+                    TargetList.SelectedIndex = _model.SelectedTargetIndex;
+                    _model.SelectTarget(TargetList.SelectedIndex);
+                });
             }).DoNotWait();
         }
 

--- a/src/Package/Impl/Templates/ItemTemplates/SqlSProc/SqlSProc.R
+++ b/src/Package/Impl/Templates/ItemTemplates/SqlSProc/SqlSProc.R
@@ -3,9 +3,8 @@
 
 # Test code
 # library(RODBC)
-# dbConnection <- 'Driver={SQL Server};Server=SERVER;Database=DATABASE;Trusted_Connection=yes'
 # channel <- odbcDriverConnect(dbConnection)
-# InputDataSet <- sqlQuery(channel, 'SQL QUERY')
+# InputDataSet <- sqlQuery(channel, )
 # odbcClose(channel)
 
 OutputDataSet <- InputDataSet


### PR DESCRIPTION
Small fixes for SQL SProc scenarios:

1. Properly populate database connection list when target changes
2. Save files before building DACPAC
3. Make sure new DB connection and new settings file appears in the project properties.