### PR TITLE
Export to Excel restrictions relaxed.  Fixes #2155

### DIFF
--- a/src/Package/Impl/DataInspect/VariableViewModel.cs
+++ b/src/Package/Impl/DataInspect/VariableViewModel.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                 ShowDetailCommandTooltip = Resources.ShowDetailCommandTooltip;
             }
 
-            CanShowOpenCsv = result.CanCoerceToDataFrame && (result.Length > 1 || (result.Length == 1 && result.TypeName == "S4"));
+            CanShowOpenCsv = result.CanCoerceToDataFrame && (result.Length > 1 || result.TypeName == "S4");
             if (CanShowOpenCsv) {
                 OpenInCsvAppCommand = new DelegateCommand(OpenInCsvApp, o => CanShowOpenCsv);
                 OpenInCsvAppCommandTooltip = Resources.OpenCsvAppCommandTooltip;

--- a/src/Package/Impl/DataInspect/VariableViewModel.cs
+++ b/src/Package/Impl/DataInspect/VariableViewModel.cs
@@ -61,8 +61,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                 ShowDetailCommandTooltip = Resources.ShowDetailCommandTooltip;
             }
 
-            const ViewerCapabilities tableCaps = (ViewerCapabilities.Table | ViewerCapabilities.List);
-            CanShowOpenCsv = CanShowDetail && result.CanCoerceToDataFrame && _detailsViewer.Capabilities.HasFlag(tableCaps) && result.Length > 0;
+            CanShowOpenCsv = result.CanCoerceToDataFrame && result.Length > 1;
             if (CanShowOpenCsv) {
                 OpenInCsvAppCommand = new DelegateCommand(OpenInCsvApp, o => CanShowOpenCsv);
                 OpenInCsvAppCommandTooltip = Resources.OpenCsvAppCommandTooltip;

--- a/src/Package/Impl/DataInspect/VariableViewModel.cs
+++ b/src/Package/Impl/DataInspect/VariableViewModel.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                 ShowDetailCommandTooltip = Resources.ShowDetailCommandTooltip;
             }
 
-            CanShowOpenCsv = result.CanCoerceToDataFrame && result.Length > 1;
+            CanShowOpenCsv = result.CanCoerceToDataFrame && (result.Length > 1 || (result.Length == 1 && result.TypeName == "S4"));
             if (CanShowOpenCsv) {
                 OpenInCsvAppCommand = new DelegateCommand(OpenInCsvApp, o => CanShowOpenCsv);
                 OpenInCsvAppCommandTooltip = Resources.OpenCsvAppCommandTooltip;


### PR DESCRIPTION
If a variable can be coerced to data.frame, and length is greater than 1, export to excel button is shown for that variable.
![image](https://cloud.githubusercontent.com/assets/3840081/17489957/7749ea28-5d55-11e6-9e66-3133a3202d33.png)
