### PR TITLE
Broker session management improvements

### DIFF
--- a/src/Host/Broker/Impl/Sessions/Session.cs
+++ b/src/Host/Broker/Impl/Sessions/Session.cs
@@ -98,9 +98,8 @@ namespace Microsoft.R.Host.Broker.Sessions {
             };
 
             _process.ErrorDataReceived += (sender, e) => {
-                if (outputLogger != null) {
-                    outputLogger.LogTrace(e.Data);
-                }
+                var process = (Process)sender;
+                outputLogger?.LogTrace($"(pid {process.Id} stderr):{Environment.NewLine} {e.Data}");
             };
 
             _process.Exited += delegate {

--- a/src/Host/Broker/Impl/Sessions/Session.cs
+++ b/src/Host/Broker/Impl/Sessions/Session.cs
@@ -99,7 +99,7 @@ namespace Microsoft.R.Host.Broker.Sessions {
 
             _process.ErrorDataReceived += (sender, e) => {
                 var process = (Process)sender;
-                outputLogger?.LogTrace($"(pid {process.Id} stderr):{Environment.NewLine} {e.Data}");
+                outputLogger?.LogTrace($"|{process.Id}|: {e.Data}");
             };
 
             _process.Exited += delegate {
@@ -110,7 +110,7 @@ namespace Microsoft.R.Host.Broker.Sessions {
             _process.BeginErrorReadLine();
 
             _pipe = new MessagePipe(messageLogger);
-            var hostEnd = _pipe.ConnectHost();
+            var hostEnd = _pipe.ConnectHost(_process.Id);
 
             ClientToHostWorker(_process.StandardInput.BaseStream, hostEnd).DoNotWait();
             HostToClientWorker(_process.StandardOutput.BaseStream, hostEnd).DoNotWait();

--- a/src/Host/Broker/Impl/Sessions/SessionManager.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionManager.cs
@@ -46,8 +46,8 @@ namespace Microsoft.R.Host.Broker.Sessions {
         public Session CreateSession(IIdentity user, string id, Interpreter interpreter, SecureString password, string commandLineArguments) {
             Session session;
 
-            List<Session> userSessions;
             lock (_sessions) {
+                List<Session> userSessions;
                 _sessions.TryGetValue(user.Name, out userSessions);
                 if (userSessions == null) {
                     _sessions[user.Name] = userSessions = new List<Session>();
@@ -60,16 +60,13 @@ namespace Microsoft.R.Host.Broker.Sessions {
                 }
 
                 session = new Session(this, user, id, interpreter, commandLineArguments);
+                userSessions.Add(session);
             }
 
             session.StartHost(
                 password,
                 _loggingOptions.LogHostOutput ? _hostOutputLogger : null,
                 _loggingOptions.LogPackets ? _messageLogger : null);
-
-            lock (_sessions) {
-                userSessions.Add(session);
-            }
 
             return session;
         }

--- a/src/Host/Broker/Impl/Sessions/SessionsController.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionsController.cs
@@ -49,6 +49,10 @@ namespace Microsoft.R.Host.Broker.Sessions {
         [HttpGet("{id}/pipe")]
         public IActionResult GetPipe(string id) {
             var session = _sessionManager.GetSession(User.Identity, id);
+            if (session?.Process?.HasExited ?? true) {
+                return NotFound();
+            }
+
             return new WebSocketPipeAction(session);
         }
     }

--- a/src/Host/Broker/Impl/Startup/Program.cs
+++ b/src/Host/Broker/Impl/Startup/Program.cs
@@ -86,14 +86,14 @@ namespace Microsoft.R.Host.Broker.Startup {
                 applicationLifetime.ApplicationStarted.Register(() => Task.Run(() => {
                     using (pipe) {
                         string serverUriStr = JsonConvert.SerializeObject(serverAddresses.Addresses);
-                        _logger.LogInformation($"Writing server.urls to pipe '{pipeName}':{Environment.NewLine}{serverUriStr}");
+                        _logger.LogTrace($"Writing server.urls to pipe '{pipeName}':{Environment.NewLine}{serverUriStr}");
 
                         var serverUriData = Encoding.UTF8.GetBytes(serverUriStr);
                         pipe.Write(serverUriData, 0, serverUriData.Length);
                         pipe.Flush();
                     }
 
-                    _logger.LogInformation($"Wrote server.urls to pipe '{pipeName}'.");
+                    _logger.LogTrace($"Wrote server.urls to pipe '{pipeName}'.");
                 }));
             }
 

--- a/src/Host/Client/Impl/Host/LocalRHostConnector.cs
+++ b/src/Host/Client/Impl/Host/LocalRHostConnector.cs
@@ -93,6 +93,9 @@ namespace Microsoft.R.Host.Client.Host {
                         FileName = rhostBrokerExe,
                         UseShellExecute = false,
                         Arguments =
+#if DEBUG
+                            $" --logging:logHostOutput true" +
+#endif
                             $" --server.urls http://127.0.0.1:0" + // :0 means first available ephemeral port
                             $" --startup:name \"{_name}\"" +
                             $" --startup:writeServerUrlsToPipe {pipeName}" +

--- a/src/Host/Client/Impl/Host/LocalRHostConnector.cs
+++ b/src/Host/Client/Impl/Host/LocalRHostConnector.cs
@@ -93,9 +93,8 @@ namespace Microsoft.R.Host.Client.Host {
                         FileName = rhostBrokerExe,
                         UseShellExecute = false,
                         Arguments =
-#if DEBUG
                             $" --logging:logHostOutput true" +
-#endif
+                            $" --logging:logPackets true" +
                             $" --server.urls http://127.0.0.1:0" + // :0 means first available ephemeral port
                             $" --startup:name \"{_name}\"" +
                             $" --startup:writeServerUrlsToPipe {pipeName}" +


### PR DESCRIPTION
Don't register session until it has been started.

When handling pipe request, check for non-existent sessions or those for which the process is not running, and report error accordingly.

Add host process PID when logging host messages and stderr in broker.

Enable stderr and packet logging by default for local connections.