### PR TITLE
Fix assembly strong name issues

### DIFF
--- a/src/Host/Broker/Impl/Microsoft.R.Host.Broker.csproj
+++ b/src/Host/Broker/Impl/Microsoft.R.Host.Broker.csproj
@@ -88,6 +88,17 @@
     <Compile Include="Pipes\ProcessHelpers.cs" />
     <Compile Include="Pipes\WebSocketPipeAction.cs" />
     <Compile Include="Security\Claims.cs" />
+    <Compile Include="Security\HttpBasicAuth\BaseBasicContext.cs" />
+    <Compile Include="Security\HttpBasicAuth\BasicAppBuilderExtensions.cs" />
+    <Compile Include="Security\HttpBasicAuth\BasicCredential.cs" />
+    <Compile Include="Security\HttpBasicAuth\BasicDefaults.cs" />
+    <Compile Include="Security\HttpBasicAuth\BasicEvents.cs" />
+    <Compile Include="Security\HttpBasicAuth\BasicExceptionContext.cs" />
+    <Compile Include="Security\HttpBasicAuth\BasicHandler.cs" />
+    <Compile Include="Security\HttpBasicAuth\BasicMiddleware.cs" />
+    <Compile Include="Security\HttpBasicAuth\BasicOptions.cs" />
+    <Compile Include="Security\HttpBasicAuth\BasicSignInContext.cs" />
+    <Compile Include="Security\HttpBasicAuth\IBasicEvents.cs" />
     <Compile Include="Security\SecurityManager.cs" />
     <Compile Include="Security\Policies.cs" />
     <Compile Include="Startup\StartupOptions.cs" />

--- a/src/Host/Broker/Impl/Security/HttpBasicAuth/BaseBasicContext.cs
+++ b/src/Host/Broker/Impl/Security/HttpBasicAuth/BaseBasicContext.cs
@@ -1,0 +1,25 @@
+﻿// From https://github.com/Kukkimonsuta/Odachi/tree/master/src/Odachi.AspNetCore.Authentication.Basic
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Odachi.AspNetCore.Authentication.Basic
+{
+	public class BaseBasicContext : BaseControlContext
+	{
+		public BaseBasicContext(HttpContext context, BasicOptions options)
+			: base(context)
+		{
+			if (options == null)
+				throw new ArgumentNullException(nameof(options));
+
+			Options = options;
+		}
+
+		public BasicOptions Options { get; }
+	}
+}

--- a/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicAppBuilderExtensions.cs
+++ b/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicAppBuilderExtensions.cs
@@ -1,0 +1,65 @@
+﻿// From https://github.com/Kukkimonsuta/Odachi/tree/master/src/Odachi.AspNetCore.Authentication.Basic
+
+using Microsoft.Extensions.Options;
+using Odachi.AspNetCore.Authentication.Basic;
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Basic authentication extensions for <see cref="IApplicationBuilder"/>.
+    /// </summary>
+    public static class BasicAppBuilderExtensions
+    {
+        /// <summary>
+        /// Adds a basic authentication middleware to your web application pipeline. This method attempts to obtain options though `IOptions`.
+        /// </summary>
+        /// <param name="app">The IApplicationBuilder passed to your configuration method</param>
+        /// <returns>The original app parameter</returns>
+        public static IApplicationBuilder UseBasicAuthentication(this IApplicationBuilder app)
+        {
+            if (app == null)
+                throw new ArgumentNullException(nameof(app));
+
+			var options = app.ApplicationServices.GetService<IOptions<BasicOptions>>();
+
+			return app.UseBasicAuthentication(options?.Value ?? new BasicOptions());
+        }
+
+		/// <summary>
+		/// Adds a basic authentication middleware to your web application pipeline. This method does not attempt to obtain options though `IOptions`.
+		/// </summary>
+		/// <param name="app">The IApplicationBuilder passed to your configuration method</param>
+		/// <param name="configureOptions">Used to configure the options for the middleware</param>
+		/// <returns>The original app parameter</returns>
+		public static IApplicationBuilder UseBasicAuthentication(this IApplicationBuilder app, Action<BasicOptions> configureOptions)
+        {
+            if (app == null)
+                throw new ArgumentNullException(nameof(app));
+
+            var options = new BasicOptions();
+            if (configureOptions != null)
+                configureOptions(options);
+
+            return app.UseBasicAuthentication(options);
+        }
+
+		/// <summary>
+		/// Adds a basic authentication middleware to your web application pipeline.  This method does not attempt to obtain options though `IOptions`.
+		/// </summary>
+		/// <param name="app">The IApplicationBuilder passed to your configuration method</param>
+		/// <param name="options">Used to configure the middleware</param>
+		/// <returns>The original app parameter</returns>
+		public static IApplicationBuilder UseBasicAuthentication(this IApplicationBuilder app, BasicOptions options)
+        {
+            if (app == null)
+                throw new ArgumentNullException(nameof(app));
+
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            return app.UseMiddleware<BasicMiddleware>(options);
+        }
+    }
+}

--- a/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicCredential.cs
+++ b/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicCredential.cs
@@ -1,0 +1,23 @@
+﻿// From https://github.com/Kukkimonsuta/Odachi/tree/master/src/Odachi.AspNetCore.Authentication.Basic
+
+using Microsoft.AspNetCore.Authentication;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+
+namespace Odachi.AspNetCore.Authentication.Basic
+{
+	public class BasicCredential
+	{
+		public string Username { get; set; }
+		public string Password { get; set; }
+		public BasicCredentialClaim[] Claims { get; set; } = new BasicCredentialClaim[0];
+	}
+
+	public class BasicCredentialClaim
+	{
+		public string Type { get; set; }
+		public string Value { get; set; }
+	}
+}

--- a/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicDefaults.cs
+++ b/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicDefaults.cs
@@ -1,0 +1,20 @@
+﻿// From https://github.com/Kukkimonsuta/Odachi/tree/master/src/Odachi.AspNetCore.Authentication.Basic
+
+namespace Odachi.AspNetCore.Authentication.Basic
+{
+    /// <summary>
+    /// Default values used by <see cref="BasicMiddleware"/> when not defined in <see cref="BasicOptions"/>.
+    /// </summary>
+    public static class BasicDefaults
+    {
+        /// <summary>
+        /// The default authentication scheme used by basic authentication.
+        /// </summary>
+        public const string AuthenticationScheme = "Basic";
+
+        /// <summary>
+        /// The default realm used by basic authentication.
+        /// </summary>
+        public const string Realm = "Protected Area";
+    }
+}

--- a/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicEvents.cs
+++ b/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicEvents.cs
@@ -1,0 +1,44 @@
+﻿// From https://github.com/Kukkimonsuta/Odachi/tree/master/src/Odachi.AspNetCore.Authentication.Basic
+
+using System;
+using System.Threading.Tasks;
+
+namespace Odachi.AspNetCore.Authentication.Basic
+{
+    /// <summary>
+    /// This default implementation of the <see cref="IBasicEvents"/> may be used if the
+    /// application only needs to override a few of the interface methods. This may be used as a base class
+    /// or may be instantiated directly.
+    /// </summary>
+    public class BasicEvents : IBasicEvents
+    {
+        /// <summary>
+        /// Create a new instance of the default notifications.
+        /// </summary>
+        public BasicEvents()
+        {
+        }
+
+		/// <summary>
+		/// A delegate assigned to this property will be invoked when the related method is called
+		/// </summary>
+		public Func<BasicSignInContext, Task> OnSignIn { get; set; } = context => Task.FromResult(0);
+
+		/// <summary>
+		/// A delegate assigned to this property will be invoked when the related method is called
+		/// </summary>
+		public Func<BasicExceptionContext, Task> OnException { get; set; } = context => Task.FromResult(0);
+
+        /// <summary>
+        /// Implements the interface method by invoking the related delegate method
+        /// </summary>
+        /// <param name="context"></param>
+        public virtual Task SignIn(BasicSignInContext context) => OnSignIn(context);
+
+        /// <summary>
+        /// Implements the interface method by invoking the related delegate method
+        /// </summary>
+        /// <param name="context">Contains information about the event</param>
+        public virtual Task Exception(BasicExceptionContext context) => OnException(context);
+    }
+}

--- a/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicExceptionContext.cs
+++ b/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicExceptionContext.cs
@@ -1,0 +1,35 @@
+﻿// From https://github.com/Kukkimonsuta/Odachi/tree/master/src/Odachi.AspNetCore.Authentication.Basic
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using System;
+
+namespace Odachi.AspNetCore.Authentication.Basic
+{
+    /// <summary>
+    /// Context object used to control flow of basic authentication.
+    /// </summary>
+    public class BasicExceptionContext : BaseControlContext
+    {
+        /// <summary>
+        /// Creates a new instance of the context object.
+        /// </summary>
+        /// <param name="context">The HTTP request context</param>
+        /// <param name="options">The middleware options</param>
+        /// <param name="exception">The exception thrown.</param>
+        /// <param name="ticket">The current ticket, if any.</param>
+        public BasicExceptionContext(
+            HttpContext context,
+            BasicOptions options,
+            Exception exception)
+            : base(context)
+        {
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// The exception thrown.
+        /// </summary>
+        public Exception Exception { get; private set; }
+    }
+}

--- a/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicHandler.cs
+++ b/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicHandler.cs
@@ -1,0 +1,118 @@
+﻿// From https://github.com/Kukkimonsuta/Odachi/tree/master/src/Odachi.AspNetCore.Authentication.Basic
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http.Authentication;
+using Microsoft.AspNetCore.Http.Features.Authentication;
+using Microsoft.AspNetCore.Http.Features;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Security.Claims;
+
+namespace Odachi.AspNetCore.Authentication.Basic
+{
+    internal class BasicHandler : AuthenticationHandler<BasicOptions>
+    {
+        public const string RequestHeader = "Authorization";
+        public const string ChallengeHeader = "WWW-Authenticate";
+		public const string RequestHeaderPrefix = "Basic ";
+
+        public BasicHandler()
+        {
+        }
+
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            try
+            {
+				var feat = Context.Features.OfType<HttpRequestFeature>();
+
+                var headers = Request.Headers[RequestHeader];
+                if (headers.Count <= 0)
+					return AuthenticateResult.Fail("No authorization header.");
+
+				var header = headers.Where(h => h.StartsWith(RequestHeaderPrefix, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                if (header == null)
+					return AuthenticateResult.Fail("Not basic authentication header.");
+
+				var encoded = header.Substring(RequestHeaderPrefix.Length);
+				var decoded = default(string);
+				try
+				{
+					decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+				}
+				catch (Exception)
+				{
+					return AuthenticateResult.Fail("Invalid basic authentication header encoding.");
+				}
+
+                var index = decoded.IndexOf(':');
+                if (index == -1)
+					return AuthenticateResult.Fail("Invalid basic authentication header format.");
+
+				var username = decoded.Substring(0, index);
+                var password = decoded.Substring(index + 1);
+
+                var signInContext = new BasicSignInContext(Context, Options, username, password);
+                await Options.Events.SignIn(signInContext);
+
+				if (signInContext.HandledResponse)
+				{
+					if (signInContext.Ticket != null)
+						return AuthenticateResult.Success(signInContext.Ticket);
+					else
+						return AuthenticateResult.Fail("Invalid basic authentication credentials.");
+				}
+
+				if (signInContext.Skipped)
+					return AuthenticateResult.Success(null);
+
+				var credentials = Options.Credentials.Where(c => c.Username == username && c.Password == password).FirstOrDefault();
+				if (credentials == null)
+					return AuthenticateResult.Fail("Invalid basic authentication credentials.");
+
+				var claims = credentials.Claims.Select(c => new Claim(c.Type, c.Value)).ToList();
+				if (!claims.Any(c => c.Type == ClaimTypes.Name))
+					claims.Add(new Claim(ClaimTypes.Name, username));
+
+				var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, Options.AuthenticationScheme));
+
+				var ticket = new AuthenticationTicket(principal, new AuthenticationProperties(), Options.AuthenticationScheme);
+
+                return AuthenticateResult.Success(ticket);
+            }
+            catch (Exception ex)
+            {
+                var exceptionContext = new BasicExceptionContext(Context, Options, ex);
+
+				await Options.Events.Exception(exceptionContext);
+
+				if (exceptionContext.HandledResponse)
+					return AuthenticateResult.Success(exceptionContext.Ticket);
+
+				if (exceptionContext.Skipped)
+					return AuthenticateResult.Success(null);
+
+				throw;
+            }
+        }
+
+        protected override Task<bool> HandleUnauthorizedAsync(ChallengeContext context)
+        {
+			Response.StatusCode = 401;
+			Response.Headers[ChallengeHeader] = "Basic realm=\"" + Options.Realm + "\"";
+			return Task.FromResult(false);
+		}
+
+		protected override Task HandleSignOutAsync(SignOutContext context)
+		{
+			throw new NotSupportedException();
+		}
+
+		protected override Task HandleSignInAsync(SignInContext context)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicMiddleware.cs
+++ b/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicMiddleware.cs
@@ -1,0 +1,39 @@
+﻿// From https://github.com/Kukkimonsuta/Odachi/tree/master/src/Odachi.AspNetCore.Authentication.Basic
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.WebEncoders;
+using System.Text.Encodings.Web;
+
+namespace Odachi.AspNetCore.Authentication.Basic
+{
+    /// <summary>
+    /// Middleware for basic authentication.
+    /// </summary>
+    public class BasicMiddleware : AuthenticationMiddleware<BasicOptions>
+    {
+        public BasicMiddleware(
+            RequestDelegate next,
+			BasicOptions options,
+			ILoggerFactory loggerFactory,
+            UrlEncoder encoder)
+            : base(next, options, loggerFactory, encoder)
+        {
+			if (Options.Events == null)
+				Options.Events = new BasicEvents();
+
+            if (string.IsNullOrEmpty(Options.Realm))
+                Options.Realm = BasicDefaults.Realm;
+
+			if (Options.Credentials == null)
+				Options.Credentials = new BasicCredential[0];
+        }
+
+        protected override AuthenticationHandler<BasicOptions> CreateHandler()
+        {
+            return new BasicHandler();
+        }
+    }
+}

--- a/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicOptions.cs
+++ b/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicOptions.cs
@@ -1,0 +1,51 @@
+﻿// From https://github.com/Kukkimonsuta/Odachi/tree/master/src/Odachi.AspNetCore.Authentication.Basic
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System;
+using Microsoft.AspNetCore.Builder;
+
+namespace Odachi.AspNetCore.Authentication.Basic
+{
+	/// <summary>
+	/// Contains the options used by the <see cref="BasicMiddleware"/>.
+	/// </summary>
+	public class BasicOptions : AuthenticationOptions, IOptions<BasicOptions>
+	{
+		public BasicOptions()
+		{
+			AuthenticationScheme = BasicDefaults.AuthenticationScheme;
+			AutomaticAuthenticate = true;
+			AutomaticChallenge = true;
+		}
+
+		/// <summary>
+		/// The default realm used by basic authentication.
+		/// </summary>
+		public string Realm { get; set; } = BasicDefaults.Realm;
+
+		/// <summary>
+		/// Allowed credentials.
+		/// </summary>
+		public BasicCredential[] Credentials { get; set; } = new BasicCredential[0];
+
+		/// <summary>
+		/// The Provider may be assigned to an instance of an object created by the application at startup time. The middleware
+		/// calls methods on the provider which give the application control at certain points where processing is occuring.
+		/// If it is not provided a default instance is supplied which does nothing when the methods are called.
+		/// </summary>
+		public IBasicEvents Events { get; set; } = new BasicEvents();
+
+		BasicOptions IOptions<BasicOptions>.Value
+		{
+			get
+			{
+				return this;
+			}
+		}
+	}
+}

--- a/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicSignInContext.cs
+++ b/src/Host/Broker/Impl/Security/HttpBasicAuth/BasicSignInContext.cs
@@ -1,0 +1,43 @@
+﻿// From https://github.com/Kukkimonsuta/Odachi/tree/master/src/Odachi.AspNetCore.Authentication.Basic
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+
+namespace Odachi.AspNetCore.Authentication.Basic
+{
+    /// <summary>
+    /// Context object used to control flow of basic authentication.
+    /// </summary>
+    public class BasicSignInContext : BaseBasicContext
+    {
+        /// <summary>
+        /// Creates a new instance of the context object.
+        /// </summary>
+        /// <param name="context">The HTTP request context</param>
+        /// <param name="options">The middleware options</param>
+        /// <param name="username">The username</param>
+        /// <param name="password">The password</param>
+        public BasicSignInContext(
+            HttpContext context,
+            BasicOptions options,
+            string username,
+            string password
+        )
+            : base(context, options)
+        {
+            Username = username;
+            Password = password;
+        }
+
+        /// <summary>
+        /// Contains the username used in basic authentication.
+        /// </summary>
+        public string Username { get; set; }
+
+        /// <summary>
+        /// Contains the password used in basic authentication.
+        /// </summary>
+        public string Password { get; set; }
+    }
+}

--- a/src/Host/Broker/Impl/Security/HttpBasicAuth/IBasicEvents.cs
+++ b/src/Host/Broker/Impl/Security/HttpBasicAuth/IBasicEvents.cs
@@ -1,0 +1,25 @@
+﻿// From https://github.com/Kukkimonsuta/Odachi/tree/master/src/Odachi.AspNetCore.Authentication.Basic
+
+using System.Threading.Tasks;
+
+namespace Odachi.AspNetCore.Authentication.Basic
+{
+    /// <summary>
+    /// Specifies callback methods which the <see cref="BasicMiddleware"></see> invokes to enable developer control over the authentication process.
+    /// </summary>
+    public interface IBasicEvents
+    {
+        /// <summary>
+        /// Called when a request came with basic authentication credentials. By implementing this method the credentials can be converted to
+        /// a principal.
+        /// </summary>
+        /// <param name="context">Contains information about the sign in request.</param>
+        Task SignIn(BasicSignInContext context);
+
+        /// <summary>
+        /// Called when an exception occurs during request or response processing.
+        /// </summary>
+        /// <param name="context">Contains information about the exception that occurred</param>
+        Task Exception(BasicExceptionContext context);
+    }
+}

--- a/src/Host/Broker/Impl/project.json
+++ b/src/Host/Broker/Impl/project.json
@@ -15,8 +15,7 @@
     "Microsoft.Extensions.Logging.TraceSource": "1.0.0",
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0",
     "Microsoft.Tpl.Dataflow": "4.5.24",
-    "Newtonsoft.Json": "9.0.1",
-    "Odachi.AspNetCore.Authentication.Basic": "1.0.0"
+    "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {
     "net46": {}

--- a/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
+++ b/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
@@ -1485,7 +1485,6 @@
       <VSIXSourceItem Include="$(OutputPath)\Microsoft.DotNet.InternalAbstractions.dll" />
       <VSIXSourceItem Include="$(OutputPath)\Microsoft.CodeAnalysis.CSharp.dll" />
       <VSIXSourceItem Include="$(OutputPath)\Microsoft.CodeAnalysis.dll" />
-      <VSIXSourceItem Include="$(OutputPath)\Odachi.AspNetCore.Authentication.Basic.dll" />
       <VSIXSourceItem Include="$(OutputPath)\libuv.dll" />
       <VSIXSourceItem Include="$(OutputPath)\zip.dll" />
       <VSIXSourceItem Include="$(OutputPath)\ItemTemplates\**\*.*">

--- a/src/Package/Impl/source.extension.vsixmanifest
+++ b/src/Package/Impl/source.extension.vsixmanifest
@@ -118,7 +118,6 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Xml.XmlDocument.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Xml.XPath.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Xml.XPath.XDocument.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Odachi.AspNetCore.Authentication.Basic.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="libuv.dll" />
 
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.R.Host.exe" />

--- a/src/Setup/Assemblies.wxi
+++ b/src/Setup/Assemblies.wxi
@@ -134,7 +134,6 @@
       <File Source="$(var.BinDir)\System.Xml.XmlDocument.dll" />
       <File Source="$(var.BinDir)\System.Xml.XPath.dll" />
       <File Source="$(var.BinDir)\System.Xml.XPath.XDocument.dll" />
-      <File Source="$(var.BinDir)\Odachi.AspNetCore.Authentication.Basic.dll" />
       <File Source="$(var.BinDir)\libuv.dll" />
       <File Source="$(var.BinDir)\Images\RFile.ico" />
       <File Source="$(var.BinDir)\vstheme.pkgdef" />


### PR DESCRIPTION
Remove references to Odachi.AspNetCore.Authentication.Basic, and move the corresponding code directly into the broker assembly, to avoid strong name / no strong name mix-up issues.