### PR TITLE
2 bug fixes

### DIFF
--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -318,8 +318,8 @@ namespace Microsoft.R.Host.Client.Session {
                 // Load RTVS R package before doing anything in R since the calls
                 // below calls may depend on functions exposed from the RTVS package
                 var libPath = BrokerConnector.IsRemote 
-                    ? Path.GetDirectoryName(Assembly.GetExecutingAssembly().GetAssemblyPath()) 
-                    : ".";
+                    ? "."
+                    : Path.GetDirectoryName(Assembly.GetExecutingAssembly().GetAssemblyPath());
 
                 await LoadRtvsPackage(evaluation, libPath);
 

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
@@ -126,7 +126,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
                 await Task.WhenAll(sessions.Select(s => s.StopHostAsync()));
             }
 
-            if (ActiveConnection != null && ActiveConnection.Id != _brokerConnector.BrokerUri) {
+            if (ActiveConnection != null && ActiveConnection.Id != connection.Id) {
                 SwitchBroker(connection);
             }
 


### PR DESCRIPTION
- `libPath` for local and remote were accidentally swapped
- `ActiveConnection` should be compared with the new connection rather than with `BrokerConnector.BrokerUri` (they are actually the same)