### PR TITLE
Fix enumeration of interpreters for non-local scenarios:

### DIFF
--- a/src/Host/Broker/Impl/Interpreters/Interpreter.cs
+++ b/src/Host/Broker/Impl/Interpreters/Interpreter.cs
@@ -10,6 +10,8 @@ namespace Microsoft.R.Host.Broker.Interpreters {
 
         public string Id { get; }
 
+        public string Name { get; }
+
         public string Path { get; }
 
         public string BinPath { get; }
@@ -18,14 +20,16 @@ namespace Microsoft.R.Host.Broker.Interpreters {
 
         public InterpreterInfo Info => new InterpreterInfo {
             Id = Id,
+            Name = Name,
             Path = Path,
             BinPath = BinPath,
             Version = Version
         };
 
-        public Interpreter(InterpreterManager manager, string id, string path, string binPath, Version version) {
+        public Interpreter(InterpreterManager manager, string id, string name, string path, string binPath, Version version) {
             Manager = manager;
             Id = id;
+            Name = name;
             Path = path;
             BinPath = binPath;
             Version = version;

--- a/src/Host/Broker/Impl/Interpreters/InterpreterManager.cs
+++ b/src/Host/Broker/Impl/Interpreters/InterpreterManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Microsoft.Common.Core.IO;
@@ -19,51 +18,55 @@ namespace Microsoft.R.Host.Broker.Interpreters {
         private readonly ROptions _options;
         private readonly ILogger _logger;
         private IFileSystem _fs;
+
         public IReadOnlyCollection<Interpreter> Interpreters { get; private set; }
 
         [ImportingConstructor]
-        public InterpreterManager(IOptions<ROptions> options, ILogger<InterpreterManager> logger) {
+        public InterpreterManager(IOptions<ROptions> options, ILogger<InterpreterManager> logger, IFileSystem fs) {
             _options = options.Value;
             _logger = logger;
+            _fs = fs;
         }
 
-        public void Initialize(IFileSystem fs) {
-            _fs = fs;
+        public void Initialize() {
+            Interpreters = GetInterpreters().ToArray();
 
-            if (_options.AutoDetect) {
-                Interpreters = GetInterpreters().ToArray();
-                var sb = new StringBuilder($"{Interpreters.Count} interpreters configured:");
-                foreach (var interp in Interpreters) {
-                    sb.Append(Environment.NewLine + $"'{interp.Id}': {interp.Version} at \"{interp.Path}\"");
-                }
-                _logger.LogInformation(sb.ToString());
-            } else {
-                var opt = _options.Interpreters.FirstOrDefault();
-                if (!string.IsNullOrEmpty(opt.Value.BasePath) && _fs.DirectoryExists(opt.Value.BasePath)) {
-                    var e = new RInterpreterInfo(string.Empty, opt.Value.BasePath);
-                    if (e.VerifyInstallation()) { 
-                        Interpreters = new List<Interpreter>() { new Interpreter(this, _localId, e.InstallPath, e.BinPath, e.Version) };
-                    } else {
-                        Debug.Fail("Specified interpreter is missing or incompatible.");
-                    }
-                } else {
-                    Debug.Fail("Specified interpreter does not exist.");
-                }
+            var sb = new StringBuilder($"{Interpreters.Count} interpreters configured:");
+            foreach (var interp in Interpreters) {
+                sb.Append(Environment.NewLine + $"'{interp.Id}': {interp.Version} at \"{interp.Path}\"");
             }
+            _logger.LogInformation(sb.ToString());
         }
 
         private IEnumerable<Interpreter> GetInterpreters() {
-            _logger.LogTrace("Auto-detecting R ...");
+            if (_options.AutoDetect) {
+                _logger.LogTrace("Auto-detecting R ...");
 
-            var engines = new RInstallation().GetCompatibleEngines();
-            if (engines.Any()) {
-                foreach (var e in engines) {
-                    var detected = new Interpreter(this, _localId, e.InstallPath, e.BinPath, e.Version);
-                    _logger.LogTrace($"R {detected.Version} detected at \"{detected.Path}\".");
-                    yield return detected;
+                var engines = new RInstallation().GetCompatibleEngines();
+                if (engines.Any()) {
+                    foreach (var e in engines) {
+                        var detected = new Interpreter(this, Guid.NewGuid().ToString(), e.Name, e.InstallPath, e.BinPath, e.Version);
+                        _logger.LogTrace($"R {detected.Version} detected at \"{detected.Path}\".");
+                        yield return detected;
+                    }
+                } else {
+                    _logger.LogWarning("No R interpreters auto-detected.");
                 }
-            } else {
-                _logger.LogWarning("No R interpreters found.");
+            }
+
+            foreach (var kv in _options.Interpreters) {
+                string id = kv.Key;
+                InterpreterOptions options = kv.Value;
+
+                if (!string.IsNullOrEmpty(options.BasePath) && _fs.DirectoryExists(options.BasePath)) {
+                    var interpInfo = new RInterpreterInfo(string.Empty, options.BasePath);
+                    if (interpInfo.VerifyInstallation()) {
+                        yield return new Interpreter(this, id, options.Name, interpInfo.InstallPath, interpInfo.BinPath, interpInfo.Version);
+                        continue;
+                    }
+                }
+
+                _logger.LogError($"Failed to retrieve R installation data for interpreter \"{id}\" at \"{options.BasePath}\"");
             }
         }
     }

--- a/src/Host/Broker/Impl/Interpreters/InterpreterOptions.cs
+++ b/src/Host/Broker/Impl/Interpreters/InterpreterOptions.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.R.Host.Broker.Interpreters {
     public class InterpreterOptions {
+        public string Name { get; set; }
+
         public string BasePath { get; set; }
     }
 }

--- a/src/Host/Broker/Impl/Sessions/SessionsController.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionsController.cs
@@ -38,7 +38,10 @@ namespace Microsoft.R.Host.Broker.Sessions {
                 }
             }
 
-            var interp = _interpManager.Interpreters.First(ip => ip.Info.Id ==  request.InterpreterId);
+            var interp = string.IsNullOrEmpty(request.InterpreterId)
+                ? _interpManager.Interpreters.First()
+                : _interpManager.Interpreters.First(ip => ip.Id == request.InterpreterId);
+
             var session = _sessionManager.CreateSession(User.Identity, id, interp, securePassword, request.CommandLineArguments);
             return Task.FromResult(session.Info);
         }

--- a/src/Host/Broker/Impl/Startup/Startup.cs
+++ b/src/Host/Broker/Impl/Startup/Startup.cs
@@ -25,6 +25,8 @@ namespace Microsoft.R.Host.Broker.Startup {
                 .Configure<SecurityOptions>(Program.Configuration.GetSection("security"))
                 .Configure<ROptions>(Program.Configuration.GetSection("R"));
 
+            services.AddSingleton<IFileSystem>(new FileSystem());
+
             services.AddSingleton<LifetimeManager>();
 
             services.AddSingleton<SecurityManager>();
@@ -50,7 +52,7 @@ namespace Microsoft.R.Host.Broker.Startup {
             SecurityManager securityManager
         ) {
             lifetimeManager.Initialize();
-            interpreterManager.Initialize(new FileSystem());
+            interpreterManager.Initialize();
 
             app.UseWebSockets(new WebSocketOptions {
                 ReplaceFeature = true,

--- a/src/Host/Protocol/Impl/InterpreterInfo.cs
+++ b/src/Host/Protocol/Impl/InterpreterInfo.cs
@@ -9,6 +9,8 @@ namespace Microsoft.R.Host.Protocol {
     public struct InterpreterInfo {
         public string Id { get; set; }
 
+        public string Name { get; set; }
+
         public string Path { get; set; }
 
         public string BinPath { get; set; }


### PR DESCRIPTION
- any interpreters that were manually specified in broker config are added to the list if they verify successfully;
- all auto-detected interpreters are also added to the list, using GUIDs as identifiers;
- if interpreter ID is not specified in an incoming connection, the first interpreter from the list is used.

Add interpreter names (for use in any future UI that would list all available interpreters for the broker when configuring connection).