### PR TITLE
Fix for environment variables for the logged on user

### DIFF
--- a/src/Host/Broker/Impl/Interpreters/InterpreterManager.cs
+++ b/src/Host/Broker/Impl/Interpreters/InterpreterManager.cs
@@ -40,17 +40,17 @@ namespace Microsoft.R.Host.Broker.Interpreters {
 
         private IEnumerable<Interpreter> GetInterpreters() {
             if (_options.AutoDetect) {
-                _logger.LogTrace("Auto-detecting R ...");
+                _logger.LogTrace(Resources.Trace_AutoDetectingR);
 
                 var engines = new RInstallation().GetCompatibleEngines();
                 if (engines.Any()) {
                     foreach (var e in engines) {
                         var detected = new Interpreter(this, Guid.NewGuid().ToString(), e.Name, e.InstallPath, e.BinPath, e.Version);
-                        _logger.LogTrace($"R {detected.Version} detected at \"{detected.Path}\".");
+                        _logger.LogTrace(string.Format(Resources.Trace_DetectedR, detected.Version, detected.Path));
                         yield return detected;
                     }
                 } else {
-                    _logger.LogWarning("No R interpreters auto-detected.");
+                    _logger.LogWarning(Resources.Warning_NoRInterpreters);
                 }
             }
 
@@ -66,7 +66,7 @@ namespace Microsoft.R.Host.Broker.Interpreters {
                     }
                 }
 
-                _logger.LogError($"Failed to retrieve R installation data for interpreter \"{id}\" at \"{options.BasePath}\"");
+                _logger.LogError(string.Format(Resources.Error_FailedRInstallationData, id, options.BasePath));
             }
         }
     }

--- a/src/Host/Broker/Impl/Interpreters/InterpreterManager.cs
+++ b/src/Host/Broker/Impl/Interpreters/InterpreterManager.cs
@@ -46,7 +46,7 @@ namespace Microsoft.R.Host.Broker.Interpreters {
                 if (engines.Any()) {
                     foreach (var e in engines) {
                         var detected = new Interpreter(this, Guid.NewGuid().ToString(), e.Name, e.InstallPath, e.BinPath, e.Version);
-                        _logger.LogTrace(string.Format(Resources.Trace_DetectedR, detected.Version, detected.Path));
+                        _logger.LogTrace(Resources.Trace_DetectedR, detected.Version, detected.Path);
                         yield return detected;
                     }
                 } else {
@@ -66,7 +66,7 @@ namespace Microsoft.R.Host.Broker.Interpreters {
                     }
                 }
 
-                _logger.LogError(string.Format(Resources.Error_FailedRInstallationData, id, options.BasePath));
+                _logger.LogError(Resources.Error_FailedRInstallationData, id, options.BasePath);
             }
         }
     }

--- a/src/Host/Broker/Impl/Lifetime/LifetimeManager.cs
+++ b/src/Host/Broker/Impl/Lifetime/LifetimeManager.cs
@@ -28,14 +28,14 @@ namespace Microsoft.R.Host.Broker.Lifetime {
                     process = Process.GetProcessById(pid);
                     process.EnableRaisingEvents = true;
                 } catch (ArgumentException) {
-                    _logger.LogCritical($"Designated parent process {pid} not found");
+                    _logger.LogCritical(string.Format(Resources.Critical_ParentProcessNotFound, pid));
                     Program.Exit();
                     return;
                 }
 
-                _logger.LogInformation($"Monitoring parent process {pid}");
+                _logger.LogInformation(string.Format(Resources.Info_MonitoringParentProcess, pid));
                 process.Exited += delegate {
-                    _logger.LogInformation($"Parent process {pid} exited, shutting down.");
+                    _logger.LogInformation(string.Format(Resources.Info_ParentProcessExited, pid));
                     Program.Exit();
                 };
             }
@@ -51,7 +51,7 @@ namespace Microsoft.R.Host.Broker.Lifetime {
             var cts = new CancellationTokenSource(_options.PingTimeout.Value);
             cts.Token.Register(() => {
                 if (_cts == cts) {
-                    _logger.LogCritical("Ping timed out, terminating");
+                    _logger.LogCritical(Resources.Critical_PingTimeOut);
                     Program.Exit();
                 }
             });

--- a/src/Host/Broker/Impl/Lifetime/LifetimeManager.cs
+++ b/src/Host/Broker/Impl/Lifetime/LifetimeManager.cs
@@ -28,14 +28,14 @@ namespace Microsoft.R.Host.Broker.Lifetime {
                     process = Process.GetProcessById(pid);
                     process.EnableRaisingEvents = true;
                 } catch (ArgumentException) {
-                    _logger.LogCritical(string.Format(Resources.Critical_ParentProcessNotFound, pid));
+                    _logger.LogCritical(Resources.Critical_ParentProcessNotFound, pid);
                     Program.Exit();
                     return;
                 }
 
-                _logger.LogInformation(string.Format(Resources.Info_MonitoringParentProcess, pid));
+                _logger.LogInformation(Resources.Info_MonitoringParentProcess, pid);
                 process.Exited += delegate {
-                    _logger.LogInformation(string.Format(Resources.Info_ParentProcessExited, pid));
+                    _logger.LogInformation(Resources.Info_ParentProcessExited, pid);
                     Program.Exit();
                 };
             }

--- a/src/Host/Broker/Impl/NativeMethods.cs
+++ b/src/Host/Broker/Impl/NativeMethods.cs
@@ -213,7 +213,7 @@ namespace Microsoft.R.Host.Broker {
             out IntPtr phToken);
 
         [DllImport("credui.dll", CharSet = CharSet.Unicode)]
-        public static extern int CredUIParseUserName(
+        public static extern uint CredUIParseUserName(
                 string userName,
                 StringBuilder user,
                 int userMaxChars,
@@ -233,7 +233,5 @@ namespace Microsoft.R.Host.Broker {
             StringBuilder pszProfilePath,
             ref uint cchProfilePath);
 
-        [DllImport("kernel32.dll")]
-        public static extern uint GetLastError();
     }
 }

--- a/src/Host/Broker/Impl/NativeMethods.cs
+++ b/src/Host/Broker/Impl/NativeMethods.cs
@@ -83,6 +83,22 @@ namespace Microsoft.R.Host.Broker {
         LOGON32_PROVIDER_WINNT50 = 3
     }
 
+    [Flags]
+    public enum CreationFlags {
+        CREATE_SUSPENDED = 0x00000004,
+        CREATE_NEW_CONSOLE = 0x00000010,
+        CREATE_NEW_PROCESS_GROUP = 0x00000200,
+        CREATE_UNICODE_ENVIRONMENT = 0x00000400,
+        CREATE_SEPARATE_WOW_VDM = 0x00000800,
+        CREATE_DEFAULT_ERROR_MODE = 0x04000000,
+    }
+
+    [Flags]
+    public enum LogonFlags {
+        LOGON_WITH_PROFILE = 0x00000001,
+        LOGON_NETCREDENTIALS_ONLY = 0x00000002
+    }
+
     internal static unsafe class NativeMethods {
         public const int MAX_PATH = 260;
 
@@ -232,5 +248,25 @@ namespace Microsoft.R.Host.Broker {
             IntPtr hToken,
             StringBuilder pszProfilePath,
             ref uint cchProfilePath);
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool CreateProcessWithLogonW(
+           [MarshalAs(UnmanagedType.LPWStr)] string userName,
+           [MarshalAs(UnmanagedType.LPWStr)] string domain,
+           [MarshalAs(UnmanagedType.LPWStr)] string password,
+           LogonFlags logonFlags,
+           [MarshalAs(UnmanagedType.LPWStr)] string applicationName,
+           [MarshalAs(UnmanagedType.LPWStr)] string commandLine,
+           CreationFlags creationFlags,
+           [MarshalAs(UnmanagedType.LPWStr)] string environment,
+           [MarshalAs(UnmanagedType.LPWStr)] string currentDirectory,
+           ref STARTUPINFO startupInfo,
+           out PROCESS_INFORMATION processInformation);
+
+        [DllImport("userenv.dll", SetLastError = true)]
+        public static extern bool CreateEnvironmentBlock(out IntPtr lpEnvironment, IntPtr hToken, bool bInherit);
+
+        [DllImport("userenv.dll", SetLastError = true)]
+        public static extern bool DestroyEnvironmentBlock(IntPtr lpEnvironment);
     }
 }

--- a/src/Host/Broker/Impl/NativeMethods.cs
+++ b/src/Host/Broker/Impl/NativeMethods.cs
@@ -83,22 +83,6 @@ namespace Microsoft.R.Host.Broker {
         LOGON32_PROVIDER_WINNT50 = 3
     }
 
-    [Flags]
-    public enum CreationFlags {
-        CREATE_SUSPENDED = 0x00000004,
-        CREATE_NEW_CONSOLE = 0x00000010,
-        CREATE_NEW_PROCESS_GROUP = 0x00000200,
-        CREATE_UNICODE_ENVIRONMENT = 0x00000400,
-        CREATE_SEPARATE_WOW_VDM = 0x00000800,
-        CREATE_DEFAULT_ERROR_MODE = 0x04000000,
-    }
-
-    [Flags]
-    public enum LogonFlags {
-        LOGON_WITH_PROFILE = 0x00000001,
-        LOGON_NETCREDENTIALS_ONLY = 0x00000002
-    }
-
     internal static unsafe class NativeMethods {
         public const int MAX_PATH = 260;
 
@@ -248,25 +232,5 @@ namespace Microsoft.R.Host.Broker {
             IntPtr hToken,
             StringBuilder pszProfilePath,
             ref uint cchProfilePath);
-
-        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern bool CreateProcessWithLogonW(
-           [MarshalAs(UnmanagedType.LPWStr)] string userName,
-           [MarshalAs(UnmanagedType.LPWStr)] string domain,
-           [MarshalAs(UnmanagedType.LPWStr)] string password,
-           LogonFlags logonFlags,
-           [MarshalAs(UnmanagedType.LPWStr)] string applicationName,
-           [MarshalAs(UnmanagedType.LPWStr)] string commandLine,
-           CreationFlags creationFlags,
-           [MarshalAs(UnmanagedType.LPWStr)] string environment,
-           [MarshalAs(UnmanagedType.LPWStr)] string currentDirectory,
-           ref STARTUPINFO startupInfo,
-           out PROCESS_INFORMATION processInformation);
-
-        [DllImport("userenv.dll", SetLastError = true)]
-        public static extern bool CreateEnvironmentBlock(out IntPtr lpEnvironment, IntPtr hToken, bool bInherit);
-
-        [DllImport("userenv.dll", SetLastError = true)]
-        public static extern bool DestroyEnvironmentBlock(IntPtr lpEnvironment);
     }
 }

--- a/src/Host/Broker/Impl/NativeMethods.cs
+++ b/src/Host/Broker/Impl/NativeMethods.cs
@@ -232,5 +232,8 @@ namespace Microsoft.R.Host.Broker {
             IntPtr hToken,
             StringBuilder pszProfilePath,
             ref uint cchProfilePath);
+
+        [DllImport("kernel32.dll")]
+        public static extern uint GetLastError();
     }
 }

--- a/src/Host/Broker/Impl/Pipes/MessagePipe.cs
+++ b/src/Host/Broker/Impl/Pipes/MessagePipe.cs
@@ -116,7 +116,7 @@ namespace Microsoft.R.Host.Broker.Pipes {
         /// </remarks>
         public IMessagePipeEnd ConnectHost(int pid) {
             if (Interlocked.CompareExchange(ref _hostEnd, new HostEnd(this), null) != null) {
-                throw new InvalidOperationException($"Pipe already has a host end");
+                throw new InvalidOperationException(Resources.Exception_PipeHasHostEnd);
             }
 
             _pid = pid;
@@ -133,7 +133,7 @@ namespace Microsoft.R.Host.Broker.Pipes {
         /// </remarks>
         public IOwnedMessagePipeEnd ConnectClient() {
             if (Interlocked.CompareExchange(ref _clientEnd, new ClientEnd(this), null) != null) {
-                throw new InvalidOperationException($"Pipe already has a client end");
+                throw new InvalidOperationException(Resources.Exception_PipeHasClientEnd);
             }
 
             return _clientEnd;

--- a/src/Host/Broker/Impl/Pipes/ProcessHelpers.cs
+++ b/src/Host/Broker/Impl/Pipes/ProcessHelpers.cs
@@ -7,113 +7,132 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using Microsoft.Win32.SafeHandles;
+using System.Collections.Generic;
+using System.Security;
+using System.Diagnostics;
+using System.Text;
+using System.Collections.Specialized;
 
 namespace Microsoft.R.Host.Broker.Pipes {
     internal static class ProcessHelpers {
-        public static int StartProcessAsUser(IIdentity user, string applicationName, string commandLine, string workingDirectory, out Stream stdin, out Stream stdout) {
-            var winUser = user as WindowsIdentity;
-            if (winUser == null) {
-                throw new ArgumentException($"Provided identity must be a {nameof(WindowsIdentity)}", "user");
-            }
+        public static int StartProcessAsUser(
+            string username,
+            string domain,
+            string password,
+            string applicationName,
+            string commandLineArgs,
+            Dictionary<string,string> environment,
+            string workingDirectory,
+            out Stream stdin, 
+            out Stream stdout) {
 
-            bool impersonate = false;  //WindowsIdentity.GetCurrent().User != winUser.User;
-            using (impersonate ? winUser.Impersonate() : null) {
-                var primaryToken = IntPtr.Zero;
-                if (impersonate) {
-                    IntPtr threadHandle = NativeMethods.GetCurrentThread();
+            IntPtr stdinRead, stdinWrite, stdoutRead, stdoutWrite, tmp = IntPtr.Zero;
+            try {
+                IntPtr currentProcess = NativeMethods.GetCurrentProcess();
 
-                    IntPtr impersonatedToken;
-                    if (!NativeMethods.OpenThreadToken(
-                        threadHandle,
-                        NativeMethods.TOKEN_QUERY | NativeMethods.TOKEN_DUPLICATE | NativeMethods.TOKEN_ASSIGN_PRIMARY,
-                        impersonate,
-                        out impersonatedToken)
-                    ) {
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
-                    }
+                var sa = default(SECURITY_ATTRIBUTES);
+                sa.nLength = Marshal.SizeOf(sa);
+                sa.bInheritHandle = true;
 
-                    if (!NativeMethods.DuplicateTokenEx(
-                        impersonatedToken,
-                        NativeMethods.TOKEN_QUERY | NativeMethods.TOKEN_DUPLICATE | NativeMethods.TOKEN_ASSIGN_PRIMARY,
-                        IntPtr.Zero,
-                        SECURITY_IMPERSONATION_LEVEL.SecurityDelegation,
-                        TOKEN_TYPE.TokenPrimary,
-                        out primaryToken)
-                    ) {
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
-                    }
-                }
-
-                IntPtr stdinRead, stdinWrite, stdoutRead, stdoutWrite, tmp = IntPtr.Zero;
-                try {
-                    IntPtr currentProcess = NativeMethods.GetCurrentProcess();
-
-                    var sa = default(SECURITY_ATTRIBUTES);
-                    sa.nLength = Marshal.SizeOf(sa);
-                    sa.bInheritHandle = true;
-
-                    if (!NativeMethods.CreatePipe(out stdinRead, out tmp, ref sa, 0)) {
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
-                    }
-
-                    if (!NativeMethods.DuplicateHandle(currentProcess, tmp, currentProcess, out stdinWrite, 0, false, NativeMethods.DUPLICATE_SAME_ACCESS)) {
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
-                    }
-
-                    NativeMethods.CloseHandle(tmp);
-                    tmp = IntPtr.Zero;
-
-                    if (!NativeMethods.CreatePipe(out tmp, out stdoutWrite, ref sa, 0)) {
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
-                    }
-
-                    if (!NativeMethods.DuplicateHandle(currentProcess, tmp, currentProcess, out stdoutRead, 0, false, NativeMethods.DUPLICATE_SAME_ACCESS)) {
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
-                    }
-
-                    NativeMethods.CloseHandle(tmp);
-                    tmp = IntPtr.Zero;
-                } finally {
-                    if (tmp != IntPtr.Zero) {
-                        NativeMethods.CloseHandle(tmp);
-                    }
-                }
-
-                //if (!NativeMethods.SetHandleInformation(stdinWrite, HANDLE_FLAGS.INHERIT, 0)) {
-                //    throw new Win32Exception(Marshal.GetLastWin32Error());
-                //}
-
-                //if (!NativeMethods.SetHandleInformation(stdoutRead, HANDLE_FLAGS.INHERIT, 0)) {
-                //    throw new Win32Exception(Marshal.GetLastWin32Error());
-                //}
-
-                IntPtr stderr = NativeMethods.GetStdHandle(NativeMethods.STD_ERROR_HANDLE);
-                if (stderr == (IntPtr)(-1)) {
+                if (!NativeMethods.CreatePipe(out stdinRead, out tmp, ref sa, 0)) {
                     throw new Win32Exception(Marshal.GetLastWin32Error());
                 }
 
-                var si = default(STARTUPINFO);
-                si.cb = Marshal.SizeOf(si);
-                si.dwFlags = NativeMethods.STARTF_USESTDHANDLES;
-                si.hStdInput = stdinRead;
-                si.hStdOutput = stdoutWrite;
-                si.hStdError = stderr;
-
-                PROCESS_INFORMATION pi;
-                if (impersonate) {
-                    if (!NativeMethods.CreateProcessAsUser(primaryToken, applicationName, commandLine, IntPtr.Zero, IntPtr.Zero, true, 0, IntPtr.Zero, workingDirectory, ref si, out pi)) {
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
-                    }
-                } else {
-                    if (!NativeMethods.CreateProcess(applicationName, commandLine, IntPtr.Zero, IntPtr.Zero, true, 0, IntPtr.Zero, workingDirectory, ref si, out pi)) {
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
-                    }
+                if (!NativeMethods.DuplicateHandle(currentProcess, tmp, currentProcess, out stdinWrite, 0, false, NativeMethods.DUPLICATE_SAME_ACCESS)) {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
                 }
 
-                stdin = new FileStream(new SafeFileHandle(stdinWrite, true), FileAccess.Write, 0x1000, false);
-                stdout = new FileStream(new SafeFileHandle(stdoutRead, true), FileAccess.Read, 0x1000, false);
-                return pi.dwProcessId;
+                NativeMethods.CloseHandle(tmp);
+                tmp = IntPtr.Zero;
+
+                if (!NativeMethods.CreatePipe(out tmp, out stdoutWrite, ref sa, 0)) {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                if (!NativeMethods.DuplicateHandle(currentProcess, tmp, currentProcess, out stdoutRead, 0, false, NativeMethods.DUPLICATE_SAME_ACCESS)) {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                NativeMethods.CloseHandle(tmp);
+                tmp = IntPtr.Zero;
+            } finally {
+                if (tmp != IntPtr.Zero) {
+                    NativeMethods.CloseHandle(tmp);
+                }
             }
+
+            //if (!NativeMethods.SetHandleInformation(stdinWrite, HANDLE_FLAGS.INHERIT, 0)) {
+            //    throw new Win32Exception(Marshal.GetLastWin32Error());
+            //}
+
+            //if (!NativeMethods.SetHandleInformation(stdoutRead, HANDLE_FLAGS.INHERIT, 0)) {
+            //    throw new Win32Exception(Marshal.GetLastWin32Error());
+            //}
+
+            IntPtr stderr = NativeMethods.GetStdHandle(NativeMethods.STD_ERROR_HANDLE);
+            if (stderr == (IntPtr)(-1)) {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            var si = default(STARTUPINFO);
+            si.cb = Marshal.SizeOf(si);
+            si.dwFlags = NativeMethods.STARTF_USESTDHANDLES;
+            si.hStdInput = stdinRead;
+            si.hStdOutput = stdoutWrite;
+            si.hStdError = stderr;
+
+            
+
+            string envStr = null;
+            {
+                byte[] envBytes = null;
+
+                using (MemoryStream ms = new MemoryStream())
+                using (StreamWriter w = new StreamWriter(ms)) {
+                    w.Flush();
+                    ms.Position = 0; //Skip any byte order marks to identify the encoding
+                    foreach (string k in environment.Keys) {
+                        w.Write(k.ToCharArray());
+                        w.Write('=');
+                        w.Write(environment[k].ToCharArray());
+                        w.Write((char)0); // environment variable separator
+                    }
+                    w.Write((char)0); // double null
+                    w.Write((char)0);
+                    w.Flush();
+                    ms.Flush();
+                    envBytes = ms.ToArray();
+                }
+
+                char[] envChar = new char[envBytes.Length];
+
+                int i = 0;
+                foreach (byte b in envBytes) {
+                    envChar[i++] = (char)b;
+                }
+                envStr = new string(envChar, 0, envChar.Length);
+            }
+
+            PROCESS_INFORMATION pi;
+            if (!NativeMethods.CreateProcessWithLogonW(
+                username, 
+                domain, 
+                password, 
+                LogonFlags.LOGON_WITH_PROFILE, 
+                applicationName, 
+                commandLineArgs, 
+                CreationFlags.CREATE_DEFAULT_ERROR_MODE | CreationFlags.CREATE_NEW_CONSOLE | CreationFlags.CREATE_UNICODE_ENVIRONMENT,
+                envStr,
+                workingDirectory, 
+                ref si, 
+                out pi)) {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            stdin = new FileStream(new SafeFileHandle(stdinWrite, true), FileAccess.Write, 0x1000, false);
+            stdout = new FileStream(new SafeFileHandle(stdoutRead, true), FileAccess.Read, 0x1000, false);
+            return pi.dwProcessId;
         }
+
     }
 }

--- a/src/Host/Broker/Impl/Pipes/ProcessHelpers.cs
+++ b/src/Host/Broker/Impl/Pipes/ProcessHelpers.cs
@@ -13,7 +13,7 @@ namespace Microsoft.R.Host.Broker.Pipes {
         public static int StartProcessAsUser(IIdentity user, string applicationName, string commandLine, string workingDirectory, out Stream stdin, out Stream stdout) {
             var winUser = user as WindowsIdentity;
             if (winUser == null) {
-                throw new ArgumentException($"Provided identity must be a {nameof(WindowsIdentity)}", "user");
+                throw new ArgumentException(string.Format(Resources.Exception_InvalidIdentityType, nameof(WindowsIdentity)), nameof(user));
             }
 
             bool impersonate = false;  //WindowsIdentity.GetCurrent().User != winUser.User;

--- a/src/Host/Broker/Impl/Pipes/ProcessHelpers.cs
+++ b/src/Host/Broker/Impl/Pipes/ProcessHelpers.cs
@@ -7,132 +7,113 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using Microsoft.Win32.SafeHandles;
-using System.Collections.Generic;
-using System.Security;
-using System.Diagnostics;
-using System.Text;
-using System.Collections.Specialized;
 
 namespace Microsoft.R.Host.Broker.Pipes {
     internal static class ProcessHelpers {
-        public static int StartProcessAsUser(
-            string username,
-            string domain,
-            string password,
-            string applicationName,
-            string commandLineArgs,
-            Dictionary<string,string> environment,
-            string workingDirectory,
-            out Stream stdin, 
-            out Stream stdout) {
-
-            IntPtr stdinRead, stdinWrite, stdoutRead, stdoutWrite, tmp = IntPtr.Zero;
-            try {
-                IntPtr currentProcess = NativeMethods.GetCurrentProcess();
-
-                var sa = default(SECURITY_ATTRIBUTES);
-                sa.nLength = Marshal.SizeOf(sa);
-                sa.bInheritHandle = true;
-
-                if (!NativeMethods.CreatePipe(out stdinRead, out tmp, ref sa, 0)) {
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-                }
-
-                if (!NativeMethods.DuplicateHandle(currentProcess, tmp, currentProcess, out stdinWrite, 0, false, NativeMethods.DUPLICATE_SAME_ACCESS)) {
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-                }
-
-                NativeMethods.CloseHandle(tmp);
-                tmp = IntPtr.Zero;
-
-                if (!NativeMethods.CreatePipe(out tmp, out stdoutWrite, ref sa, 0)) {
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-                }
-
-                if (!NativeMethods.DuplicateHandle(currentProcess, tmp, currentProcess, out stdoutRead, 0, false, NativeMethods.DUPLICATE_SAME_ACCESS)) {
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-                }
-
-                NativeMethods.CloseHandle(tmp);
-                tmp = IntPtr.Zero;
-            } finally {
-                if (tmp != IntPtr.Zero) {
-                    NativeMethods.CloseHandle(tmp);
-                }
+        public static int StartProcessAsUser(IIdentity user, string applicationName, string commandLine, string workingDirectory, out Stream stdin, out Stream stdout) {
+            var winUser = user as WindowsIdentity;
+            if (winUser == null) {
+                throw new ArgumentException($"Provided identity must be a {nameof(WindowsIdentity)}", "user");
             }
 
-            //if (!NativeMethods.SetHandleInformation(stdinWrite, HANDLE_FLAGS.INHERIT, 0)) {
-            //    throw new Win32Exception(Marshal.GetLastWin32Error());
-            //}
+            bool impersonate = false;  //WindowsIdentity.GetCurrent().User != winUser.User;
+            using (impersonate ? winUser.Impersonate() : null) {
+                var primaryToken = IntPtr.Zero;
+                if (impersonate) {
+                    IntPtr threadHandle = NativeMethods.GetCurrentThread();
 
-            //if (!NativeMethods.SetHandleInformation(stdoutRead, HANDLE_FLAGS.INHERIT, 0)) {
-            //    throw new Win32Exception(Marshal.GetLastWin32Error());
-            //}
-
-            IntPtr stderr = NativeMethods.GetStdHandle(NativeMethods.STD_ERROR_HANDLE);
-            if (stderr == (IntPtr)(-1)) {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-
-            var si = default(STARTUPINFO);
-            si.cb = Marshal.SizeOf(si);
-            si.dwFlags = NativeMethods.STARTF_USESTDHANDLES;
-            si.hStdInput = stdinRead;
-            si.hStdOutput = stdoutWrite;
-            si.hStdError = stderr;
-
-            
-
-            string envStr = null;
-            {
-                byte[] envBytes = null;
-
-                using (MemoryStream ms = new MemoryStream())
-                using (StreamWriter w = new StreamWriter(ms)) {
-                    w.Flush();
-                    ms.Position = 0; //Skip any byte order marks to identify the encoding
-                    foreach (string k in environment.Keys) {
-                        w.Write(k.ToCharArray());
-                        w.Write('=');
-                        w.Write(environment[k].ToCharArray());
-                        w.Write((char)0); // environment variable separator
+                    IntPtr impersonatedToken;
+                    if (!NativeMethods.OpenThreadToken(
+                        threadHandle,
+                        NativeMethods.TOKEN_QUERY | NativeMethods.TOKEN_DUPLICATE | NativeMethods.TOKEN_ASSIGN_PRIMARY,
+                        impersonate,
+                        out impersonatedToken)
+                    ) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
                     }
-                    w.Write((char)0); // double null
-                    w.Write((char)0);
-                    w.Flush();
-                    ms.Flush();
-                    envBytes = ms.ToArray();
+
+                    if (!NativeMethods.DuplicateTokenEx(
+                        impersonatedToken,
+                        NativeMethods.TOKEN_QUERY | NativeMethods.TOKEN_DUPLICATE | NativeMethods.TOKEN_ASSIGN_PRIMARY,
+                        IntPtr.Zero,
+                        SECURITY_IMPERSONATION_LEVEL.SecurityDelegation,
+                        TOKEN_TYPE.TokenPrimary,
+                        out primaryToken)
+                    ) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
                 }
 
-                char[] envChar = new char[envBytes.Length];
+                IntPtr stdinRead, stdinWrite, stdoutRead, stdoutWrite, tmp = IntPtr.Zero;
+                try {
+                    IntPtr currentProcess = NativeMethods.GetCurrentProcess();
 
-                int i = 0;
-                foreach (byte b in envBytes) {
-                    envChar[i++] = (char)b;
+                    var sa = default(SECURITY_ATTRIBUTES);
+                    sa.nLength = Marshal.SizeOf(sa);
+                    sa.bInheritHandle = true;
+
+                    if (!NativeMethods.CreatePipe(out stdinRead, out tmp, ref sa, 0)) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                    if (!NativeMethods.DuplicateHandle(currentProcess, tmp, currentProcess, out stdinWrite, 0, false, NativeMethods.DUPLICATE_SAME_ACCESS)) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                    NativeMethods.CloseHandle(tmp);
+                    tmp = IntPtr.Zero;
+
+                    if (!NativeMethods.CreatePipe(out tmp, out stdoutWrite, ref sa, 0)) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                    if (!NativeMethods.DuplicateHandle(currentProcess, tmp, currentProcess, out stdoutRead, 0, false, NativeMethods.DUPLICATE_SAME_ACCESS)) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                    NativeMethods.CloseHandle(tmp);
+                    tmp = IntPtr.Zero;
+                } finally {
+                    if (tmp != IntPtr.Zero) {
+                        NativeMethods.CloseHandle(tmp);
+                    }
                 }
-                envStr = new string(envChar, 0, envChar.Length);
-            }
 
-            PROCESS_INFORMATION pi;
-            if (!NativeMethods.CreateProcessWithLogonW(
-                username, 
-                domain, 
-                password, 
-                LogonFlags.LOGON_WITH_PROFILE, 
-                applicationName, 
-                commandLineArgs, 
-                CreationFlags.CREATE_DEFAULT_ERROR_MODE | CreationFlags.CREATE_NEW_CONSOLE | CreationFlags.CREATE_UNICODE_ENVIRONMENT,
-                envStr,
-                workingDirectory, 
-                ref si, 
-                out pi)) {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
+                //if (!NativeMethods.SetHandleInformation(stdinWrite, HANDLE_FLAGS.INHERIT, 0)) {
+                //    throw new Win32Exception(Marshal.GetLastWin32Error());
+                //}
 
-            stdin = new FileStream(new SafeFileHandle(stdinWrite, true), FileAccess.Write, 0x1000, false);
-            stdout = new FileStream(new SafeFileHandle(stdoutRead, true), FileAccess.Read, 0x1000, false);
-            return pi.dwProcessId;
+                //if (!NativeMethods.SetHandleInformation(stdoutRead, HANDLE_FLAGS.INHERIT, 0)) {
+                //    throw new Win32Exception(Marshal.GetLastWin32Error());
+                //}
+
+                IntPtr stderr = NativeMethods.GetStdHandle(NativeMethods.STD_ERROR_HANDLE);
+                if (stderr == (IntPtr)(-1)) {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                var si = default(STARTUPINFO);
+                si.cb = Marshal.SizeOf(si);
+                si.dwFlags = NativeMethods.STARTF_USESTDHANDLES;
+                si.hStdInput = stdinRead;
+                si.hStdOutput = stdoutWrite;
+                si.hStdError = stderr;
+
+                PROCESS_INFORMATION pi;
+                if (impersonate) {
+                    if (!NativeMethods.CreateProcessAsUser(primaryToken, applicationName, commandLine, IntPtr.Zero, IntPtr.Zero, true, 0, IntPtr.Zero, workingDirectory, ref si, out pi)) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+                } else {
+                    if (!NativeMethods.CreateProcess(applicationName, commandLine, IntPtr.Zero, IntPtr.Zero, true, 0, IntPtr.Zero, workingDirectory, ref si, out pi)) {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+                }
+
+                stdin = new FileStream(new SafeFileHandle(stdinWrite, true), FileAccess.Write, 0x1000, false);
+                stdout = new FileStream(new SafeFileHandle(stdoutRead, true), FileAccess.Read, 0x1000, false);
+                return pi.dwProcessId;
+            }
         }
-
     }
 }

--- a/src/Host/Broker/Impl/Resources.Designer.cs
+++ b/src/Host/Broker/Impl/Resources.Designer.cs
@@ -59,5 +59,302 @@ namespace Microsoft.R.Host.Broker {
                 resourceCulture = value;
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Requested to write server.urls to pipe &apos;{0}&apos;, but it is not a valid pipe handle.
+        /// </summary>
+        internal static string Critical_InvalidPipeHandle {
+            get {
+                return ResourceManager.GetString("Critical_InvalidPipeHandle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Designated parent process {0} not found.
+        /// </summary>
+        internal static string Critical_ParentProcessNotFound {
+            get {
+                return ResourceManager.GetString("Critical_ParentProcessNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ping timed out, terminating.
+        /// </summary>
+        internal static string Critical_PingTimeOut {
+            get {
+                return ResourceManager.GetString("Critical_PingTimeOut", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Requested to write server.urls to pipe &apos;{0}&apos;, but timed out while trying to connect to pipe.
+        /// </summary>
+        internal static string Critical_PipeConnectTimeOut {
+            get {
+                return ResourceManager.GetString("Critical_PipeConnectTimeOut", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Timed out waiting for graceful shutdown.
+        /// </summary>
+        internal static string Critical_TimeOutShutdown {
+            get {
+                return ResourceManager.GetString("Critical_TimeOutShutdown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to retrieve R installation data for interpreter \&quot;{0}\&quot; at \&quot;{1}\&quot;.
+        /// </summary>
+        internal static string Error_FailedRInstallationData {
+            get {
+                return ResourceManager.GetString("Error_FailedRInstallationData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to get user profile directory for user {0} with WIN32 error code 0x{1}.
+        /// </summary>
+        internal static string Error_GetUserProfileDirectory {
+            get {
+                return ResourceManager.GetString("Error_GetUserProfileDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Log on failed for user: {0}.
+        /// </summary>
+        internal static string Error_LogOnFailed {
+            get {
+                return ResourceManager.GetString("Error_LogOnFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Profile creation failed for user {0} with WIN32 error code 0x{1}.
+        /// </summary>
+        internal static string Error_ProfileCreationFailed {
+            get {
+                return ResourceManager.GetString("Error_ProfileCreationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RHost {0} process failed to start.
+        /// </summary>
+        internal static string Error_RHostFailedToStart {
+            get {
+                return ResourceManager.GetString("Error_RHostFailedToStart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to User name parsing failed for user {0} with WIN32 error code 0x{1}.
+        /// </summary>
+        internal static string Error_UserNameParse {
+            get {
+                return ResourceManager.GetString("Error_UserNameParse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provided identity must be a {0}.
+        /// </summary>
+        internal static string Exception_InvalidIdentityType {
+            get {
+                return ResourceManager.GetString("Exception_InvalidIdentityType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pipe already has a client end.
+        /// </summary>
+        internal static string Exception_PipeHasClientEnd {
+            get {
+                return ResourceManager.GetString("Exception_PipeHasClientEnd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pipe already has a host end.
+        /// </summary>
+        internal static string Exception_PipeHasHostEnd {
+            get {
+                return ResourceManager.GetString("Exception_PipeHasHostEnd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Broker name &apos;{0}&apos; assigned.
+        /// </summary>
+        internal static string Info_BrokerName {
+            get {
+                return ResourceManager.GetString("Info_BrokerName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Monitoring parent process {0}.
+        /// </summary>
+        internal static string Info_MonitoringParentProcess {
+            get {
+                return ResourceManager.GetString("Info_MonitoringParentProcess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parent process {0} exited, shutting down.
+        /// </summary>
+        internal static string Info_ParentProcessExited {
+            get {
+                return ResourceManager.GetString("Info_ParentProcessExited", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Profile already exists for user: {0}.
+        /// </summary>
+        internal static string Info_ProfileAlreadyExists {
+            get {
+                return ResourceManager.GetString("Info_ProfileAlreadyExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Profile created for user: {0}.
+        /// </summary>
+        internal static string Info_ProfileCreated {
+            get {
+                return ResourceManager.GetString("Info_ProfileCreated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RHost started for session {0} of user {1}.
+        /// </summary>
+        internal static string Info_StartedRHost {
+            get {
+                return ResourceManager.GetString("Info_StartedRHost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Starting RHost for session {0} of user {1} with command line: {2} {3}.
+        /// </summary>
+        internal static string Info_StartingRHost {
+            get {
+                return ResourceManager.GetString("Info_StartingRHost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto-detecting R ....
+        /// </summary>
+        internal static string Trace_AutoDetectingR {
+            get {
+                return ResourceManager.GetString("Trace_AutoDetectingR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to R {0} detected at \&quot;{1}\&quot;.
+        /// </summary>
+        internal static string Trace_DetectedR {
+            get {
+                return ResourceManager.GetString("Trace_DetectedR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} = {1}.
+        /// </summary>
+        internal static string Trace_EnvironmentVariable {
+            get {
+                return ResourceManager.GetString("Trace_EnvironmentVariable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Creating user environment variables for user {0} with profile directory {1}.
+        /// </summary>
+        internal static string Trace_EnvironmentVariableCreationBegin {
+            get {
+                return ResourceManager.GetString("Trace_EnvironmentVariableCreationBegin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to |{0}|: {1}.
+        /// </summary>
+        internal static string Trace_ErrorDataReceived {
+            get {
+                return ResourceManager.GetString("Trace_ErrorDataReceived", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Log on succeeded for user: {0}.
+        /// </summary>
+        internal static string Trace_LogOnSuccess {
+            get {
+                return ResourceManager.GetString("Trace_LogOnSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Attempting log on for user: {0}.
+        /// </summary>
+        internal static string Trace_LogOnUserBegin {
+            get {
+                return ResourceManager.GetString("Trace_LogOnUserBegin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Writing server.urls to pipe &apos;{0}&apos;:{1}{2}.
+        /// </summary>
+        internal static string Trace_ServerUrlsToPipeBegin {
+            get {
+                return ResourceManager.GetString("Trace_ServerUrlsToPipeBegin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wrote server.urls to pipe &apos;{0}&apos;.
+        /// </summary>
+        internal static string Trace_ServerUrlsToPipeDone {
+            get {
+                return ResourceManager.GetString("Trace_ServerUrlsToPipeDone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Attempting to create profile for user: {0}.
+        /// </summary>
+        internal static string Trace_UserProfileCreation {
+            get {
+                return ResourceManager.GetString("Trace_UserProfileCreation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to User {0} profile directory: {1}.
+        /// </summary>
+        internal static string Trace_UserProfileDirectory {
+            get {
+                return ResourceManager.GetString("Trace_UserProfileDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No R interpreters auto-detected.
+        /// </summary>
+        internal static string Warning_NoRInterpreters {
+            get {
+                return ResourceManager.GetString("Warning_NoRInterpreters", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Host/Broker/Impl/Resources.resx
+++ b/src/Host/Broker/Impl/Resources.resx
@@ -117,4 +117,103 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Critical_InvalidPipeHandle" xml:space="preserve">
+    <value>Requested to write server.urls to pipe '{0}', but it is not a valid pipe handle</value>
+  </data>
+  <data name="Critical_ParentProcessNotFound" xml:space="preserve">
+    <value>Designated parent process {0} not found</value>
+  </data>
+  <data name="Critical_PingTimeOut" xml:space="preserve">
+    <value>Ping timed out, terminating</value>
+  </data>
+  <data name="Critical_PipeConnectTimeOut" xml:space="preserve">
+    <value>Requested to write server.urls to pipe '{0}', but timed out while trying to connect to pipe</value>
+  </data>
+  <data name="Critical_TimeOutShutdown" xml:space="preserve">
+    <value>Timed out waiting for graceful shutdown</value>
+  </data>
+  <data name="Error_FailedRInstallationData" xml:space="preserve">
+    <value>Failed to retrieve R installation data for interpreter \"{0}\" at \"{1}\"</value>
+  </data>
+  <data name="Error_GetUserProfileDirectory" xml:space="preserve">
+    <value>Failed to get user profile directory for user {0} with WIN32 error code 0x{1}</value>
+  </data>
+  <data name="Error_LogOnFailed" xml:space="preserve">
+    <value>Log on failed for user: {0}</value>
+  </data>
+  <data name="Error_ProfileCreationFailed" xml:space="preserve">
+    <value>Profile creation failed for user {0} with WIN32 error code 0x{1}</value>
+  </data>
+  <data name="Error_RHostFailedToStart" xml:space="preserve">
+    <value>RHost {0} process failed to start</value>
+  </data>
+  <data name="Error_UserNameParse" xml:space="preserve">
+    <value>User name parsing failed for user {0} with WIN32 error code 0x{1}</value>
+  </data>
+  <data name="Exception_InvalidIdentityType" xml:space="preserve">
+    <value>Provided identity must be a {0}</value>
+  </data>
+  <data name="Exception_PipeHasClientEnd" xml:space="preserve">
+    <value>Pipe already has a client end</value>
+  </data>
+  <data name="Exception_PipeHasHostEnd" xml:space="preserve">
+    <value>Pipe already has a host end</value>
+  </data>
+  <data name="Info_BrokerName" xml:space="preserve">
+    <value>Broker name '{0}' assigned</value>
+  </data>
+  <data name="Info_MonitoringParentProcess" xml:space="preserve">
+    <value>Monitoring parent process {0}</value>
+  </data>
+  <data name="Info_ParentProcessExited" xml:space="preserve">
+    <value>Parent process {0} exited, shutting down</value>
+  </data>
+  <data name="Info_ProfileAlreadyExists" xml:space="preserve">
+    <value>Profile already exists for user: {0}</value>
+  </data>
+  <data name="Info_ProfileCreated" xml:space="preserve">
+    <value>Profile created for user: {0}</value>
+  </data>
+  <data name="Info_StartedRHost" xml:space="preserve">
+    <value>RHost started for session {0} of user {1}</value>
+  </data>
+  <data name="Info_StartingRHost" xml:space="preserve">
+    <value>Starting RHost for session {0} of user {1} with command line: {2} {3}</value>
+  </data>
+  <data name="Trace_AutoDetectingR" xml:space="preserve">
+    <value>Auto-detecting R ...</value>
+  </data>
+  <data name="Trace_DetectedR" xml:space="preserve">
+    <value>R {0} detected at \"{1}\"</value>
+  </data>
+  <data name="Trace_EnvironmentVariable" xml:space="preserve">
+    <value>{0} = {1}</value>
+  </data>
+  <data name="Trace_EnvironmentVariableCreationBegin" xml:space="preserve">
+    <value>Creating user environment variables for user {0} with profile directory {1}</value>
+  </data>
+  <data name="Trace_ErrorDataReceived" xml:space="preserve">
+    <value>|{0}|: {1}</value>
+  </data>
+  <data name="Trace_LogOnSuccess" xml:space="preserve">
+    <value>Log on succeeded for user: {0}</value>
+  </data>
+  <data name="Trace_LogOnUserBegin" xml:space="preserve">
+    <value>Attempting log on for user: {0}</value>
+  </data>
+  <data name="Trace_ServerUrlsToPipeBegin" xml:space="preserve">
+    <value>Writing server.urls to pipe '{0}':{1}{2}</value>
+  </data>
+  <data name="Trace_ServerUrlsToPipeDone" xml:space="preserve">
+    <value>Wrote server.urls to pipe '{0}'</value>
+  </data>
+  <data name="Trace_UserProfileCreation" xml:space="preserve">
+    <value>Attempting to create profile for user: {0}</value>
+  </data>
+  <data name="Trace_UserProfileDirectory" xml:space="preserve">
+    <value>User {0} profile directory: {1}</value>
+  </data>
+  <data name="Warning_NoRInterpreters" xml:space="preserve">
+    <value>No R interpreters auto-detected</value>
+  </data>
 </root>

--- a/src/Host/Broker/Impl/Security/Claims.cs
+++ b/src/Host/Broker/Impl/Security/Claims.cs
@@ -5,5 +5,6 @@ namespace Microsoft.R.Host.Broker.Security {
     public static class Claims {
         public const string RUser = "87743606-A56D-405F-94B0-93DD482CF41C";
         public const string Password = "4059142A-D01D-49E7-BAAC-AE441DEE0749";
+        public const string RUserProfileDir = "D0EE3FD6-D076-425E-9255-44025124D46F";
     }
 }

--- a/src/Host/Broker/Impl/Security/SecurityManager.cs
+++ b/src/Host/Broker/Impl/Security/SecurityManager.cs
@@ -58,7 +58,7 @@ namespace Microsoft.R.Host.Broker.Security {
             IntPtr token;
             WindowsIdentity winIdentity = null;
             string profilePath = "";
-            if (NativeMethods.LogonUser(user.ToString(), domain.ToString(), context.Password, (int)LogonType.LOGON32_LOGON_INTERACTIVE, (int)LogonProvider.LOGON32_PROVIDER_DEFAULT, out token)) {
+            if (NativeMethods.LogonUser(user.ToString(), domain.ToString(), context.Password, (int)LogonType.LOGON32_LOGON_NETWORK, (int)LogonProvider.LOGON32_PROVIDER_DEFAULT, out token)) {
                 winIdentity = new WindowsIdentity(token);
                 StringBuilder profileDir = new StringBuilder(NativeMethods.MAX_PATH);
                 uint size = (uint)profileDir.Capacity;

--- a/src/Host/Broker/Impl/Security/SecurityManager.cs
+++ b/src/Host/Broker/Impl/Security/SecurityManager.cs
@@ -54,7 +54,7 @@ namespace Microsoft.R.Host.Broker.Security {
 
             uint error = NativeMethods.CredUIParseUserName(context.Username, user, user.Capacity, domain, domain.Capacity);
             if (error != 0) {
-                _logger.LogError(string.Format(Resources.Error_UserNameParse, context.Username, error.ToString("X")));
+                _logger.LogError(Resources.Error_UserNameParse, context.Username, error.ToString("X"));
                 return null;
             }
 
@@ -62,23 +62,23 @@ namespace Microsoft.R.Host.Broker.Security {
             WindowsIdentity winIdentity = null;
             string profilePath = "";
 
-            _logger.LogTrace(string.Format(Resources.Trace_LogOnUserBegin, context.Username));
+            _logger.LogTrace(Resources.Trace_LogOnUserBegin, context.Username);
             if (NativeMethods.LogonUser(user.ToString(), domain.ToString(), context.Password, (int)LogonType.LOGON32_LOGON_NETWORK, (int)LogonProvider.LOGON32_PROVIDER_DEFAULT, out token)) {
-                _logger.LogTrace(string.Format(Resources.Trace_LogOnSuccess, context.Username));
+                _logger.LogTrace(Resources.Trace_LogOnSuccess, context.Username);
                 winIdentity = new WindowsIdentity(token);
                 StringBuilder profileDir = new StringBuilder(NativeMethods.MAX_PATH);
                 uint size = (uint)profileDir.Capacity;
 
-                _logger.LogTrace(string.Format(Resources.Trace_UserProfileCreation, context.Username));
+                _logger.LogTrace(Resources.Trace_UserProfileCreation, context.Username);
                 error = NativeMethods.CreateProfile(winIdentity.User.Value, user.ToString(), profileDir, size);
                 // 0x800700b7 - Profile already exists.
                 if (error != 0 && error != 0x800700b7) {
-                    _logger.LogError(string.Format(Resources.Error_ProfileCreationFailed, context.Username, error.ToString("X")));
+                    _logger.LogError(Resources.Error_ProfileCreationFailed, context.Username, error.ToString("X"));
                     return null;
                 } else if (error == 0x800700b7) {
-                    _logger.LogInformation(string.Format(Resources.Info_ProfileAlreadyExists, context.Username));
+                    _logger.LogInformation(Resources.Info_ProfileAlreadyExists, context.Username);
                 } else {
-                    _logger.LogInformation(string.Format(Resources.Info_ProfileCreated, context.Username));
+                    _logger.LogInformation(Resources.Info_ProfileCreated, context.Username);
                 }
 
                 profileDir = new StringBuilder(NativeMethods.MAX_PATH * 2);
@@ -86,12 +86,12 @@ namespace Microsoft.R.Host.Broker.Security {
 
                 if (NativeMethods.GetUserProfileDirectory(token, profileDir, ref size)) {
                     profilePath = profileDir.ToString();
-                    _logger.LogTrace(string.Format(Resources.Trace_UserProfileDirectory, context.Username, profilePath));
+                    _logger.LogTrace(Resources.Trace_UserProfileDirectory, context.Username, profilePath);
                 } else {
-                    _logger.LogError(string.Format(Resources.Error_GetUserProfileDirectory, context.Username, Marshal.GetLastWin32Error().ToString("X")));
+                    _logger.LogError(Resources.Error_GetUserProfileDirectory, context.Username, Marshal.GetLastWin32Error().ToString("X"));
                 }
             } else {
-                _logger.LogError(string.Format(Resources.Error_LogOnFailed, context.Username, Marshal.GetLastWin32Error().ToString("X")));
+                _logger.LogError(Resources.Error_LogOnFailed, context.Username, Marshal.GetLastWin32Error().ToString("X"));
                 return null;
             }
 

--- a/src/Host/Broker/Impl/Sessions/Session.cs
+++ b/src/Host/Broker/Impl/Sessions/Session.cs
@@ -80,37 +80,26 @@ namespace Microsoft.R.Host.Broker.Sessions {
                 throw new ArgumentException();
             }
 
-            ProcessStartInfo psi = null;
-            bool impersonate = WindowsIdentity.GetCurrent().User != ((WindowsIdentity)User).User;
-            if(impersonate) {
-                using (var impersonationContext = ((WindowsIdentity)User).Impersonate()) {
-                    psi = new ProcessStartInfo(rhostExePath) {
-                        UseShellExecute = false,
-                        CreateNoWindow = false,
-                        Arguments = arguments,
-                        RedirectStandardInput = true,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true
-                    };
+            ProcessStartInfo psi = new ProcessStartInfo(rhostExePath) {
+                UseShellExecute = false,
+                CreateNoWindow = false,
+                Arguments = arguments,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                LoadUserProfile = true
+            };
 
-                    psi.EnvironmentVariables["USERNAME"] = username.ToString();
-                    psi.EnvironmentVariables["HOMEDRIVE"] = profilePath.Substring(0, 2);
-                    psi.EnvironmentVariables["HOMEPATH"] = profilePath.Substring(2);
-                    psi.EnvironmentVariables["USERPROFILE"] = $"{psi.EnvironmentVariables["HOMEDRIVE"]}{psi.EnvironmentVariables["HOMEPATH"]}";
-                    psi.EnvironmentVariables["APPDATA"] = $"{psi.EnvironmentVariables["USERPROFILE"]}\\AppData\\Roaming";
-                    psi.EnvironmentVariables["LOCALAPPDATA"] = $"{psi.EnvironmentVariables["USERPROFILE"]}\\AppData\\Local";
-                    psi.EnvironmentVariables["TEMP"] = $"{psi.EnvironmentVariables["LOCALAPPDATA"]}\\Temp";
-                    psi.EnvironmentVariables["TMP"] = $"{psi.EnvironmentVariables["LOCALAPPDATA"]}\\Temp";
-                }
-            } else {
-                psi = new ProcessStartInfo(rhostExePath) {
-                    UseShellExecute = false,
-                    CreateNoWindow = false,
-                    Arguments = arguments,
-                    RedirectStandardInput = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true
-                };
+            if (WindowsIdentity.GetCurrent().User != ((WindowsIdentity)User).User) {
+                // if broker and rhost are run as different users.
+                psi.EnvironmentVariables["USERNAME"] = username.ToString();
+                psi.EnvironmentVariables["HOMEDRIVE"] = profilePath.Substring(0, 2);
+                psi.EnvironmentVariables["HOMEPATH"] = profilePath.Substring(2);
+                psi.EnvironmentVariables["USERPROFILE"] = $"{psi.EnvironmentVariables["HOMEDRIVE"]}{psi.EnvironmentVariables["HOMEPATH"]}";
+                psi.EnvironmentVariables["APPDATA"] = $"{psi.EnvironmentVariables["USERPROFILE"]}\\AppData\\Roaming";
+                psi.EnvironmentVariables["LOCALAPPDATA"] = $"{psi.EnvironmentVariables["USERPROFILE"]}\\AppData\\Local";
+                psi.EnvironmentVariables["TEMP"] = $"{psi.EnvironmentVariables["LOCALAPPDATA"]}\\Temp";
+                psi.EnvironmentVariables["TMP"] = $"{psi.EnvironmentVariables["LOCALAPPDATA"]}\\Temp";
             }
 
             var shortHome = new StringBuilder(NativeMethods.MAX_PATH);

--- a/src/Host/Broker/Impl/Sessions/Session.cs
+++ b/src/Host/Broker/Impl/Sessions/Session.cs
@@ -61,7 +61,7 @@ namespace Microsoft.R.Host.Broker.Sessions {
             }
         }
 
-        internal Session(SessionManager manager, IIdentity user, string id, Interpreter interpreter, string commandLineArguments, ILogger<Session> sessionLogger) {
+        internal Session(SessionManager manager, IIdentity user, string id, Interpreter interpreter, string commandLineArguments, ILogger sessionLogger) {
             Manager = manager;
             Interpreter = interpreter;
             User = user;
@@ -79,9 +79,8 @@ namespace Microsoft.R.Host.Broker.Sessions {
 
             uint error = NativeMethods.CredUIParseUserName(User.Name, username, username.Capacity, domain, domain.Capacity);
             if (error != 0) {
-                var message = string.Format(Resources.Error_UserNameParse, User.Name, error);
-                _sessionLogger.LogError(message);
-                throw new ArgumentException(message);
+                _sessionLogger.LogError(Resources.Error_UserNameParse, User.Name, error);
+                throw new ArgumentException(string.Format(Resources.Error_UserNameParse, User.Name, error));
             }
 
             ProcessStartInfo psi = new ProcessStartInfo(rhostExePath) {
@@ -96,31 +95,31 @@ namespace Microsoft.R.Host.Broker.Sessions {
 
             var useridentity = User as WindowsIdentity;
             if (useridentity != null && WindowsIdentity.GetCurrent().User != useridentity.User) {
-                _sessionLogger.LogTrace(string.Format(Resources.Trace_EnvironmentVariableCreationBegin, User.Name, profilePath));
+                _sessionLogger.LogTrace(Resources.Trace_EnvironmentVariableCreationBegin, User.Name, profilePath);
                 // if broker and rhost are run as different users.
                 psi.EnvironmentVariables["USERNAME"] = username.ToString();
-                _sessionLogger.LogTrace(string.Format(Resources.Trace_EnvironmentVariable, "USERNAME", psi.EnvironmentVariables["USERNAME"]));
+                _sessionLogger.LogTrace(Resources.Trace_EnvironmentVariable, "USERNAME", psi.EnvironmentVariables["USERNAME"]);
 
                 psi.EnvironmentVariables["HOMEDRIVE"] = profilePath.Substring(0, 2);
-                _sessionLogger.LogTrace(string.Format(Resources.Trace_EnvironmentVariable, "HOMEDRIVE", psi.EnvironmentVariables["HOMEDRIVE"]));
+                _sessionLogger.LogTrace(Resources.Trace_EnvironmentVariable, "HOMEDRIVE", psi.EnvironmentVariables["HOMEDRIVE"]);
 
                 psi.EnvironmentVariables["HOMEPATH"] = profilePath.Substring(2);
-                _sessionLogger.LogTrace(string.Format(Resources.Trace_EnvironmentVariable, "HOMEPATH", psi.EnvironmentVariables["HOMEPATH"]));
+                _sessionLogger.LogTrace(Resources.Trace_EnvironmentVariable, "HOMEPATH", psi.EnvironmentVariables["HOMEPATH"]);
 
                 psi.EnvironmentVariables["USERPROFILE"] = $"{psi.EnvironmentVariables["HOMEDRIVE"]}{psi.EnvironmentVariables["HOMEPATH"]}";
-                _sessionLogger.LogTrace(string.Format(Resources.Trace_EnvironmentVariable, "USERPROFILE", psi.EnvironmentVariables["USERPROFILE"]));
+                _sessionLogger.LogTrace(Resources.Trace_EnvironmentVariable, "USERPROFILE", psi.EnvironmentVariables["USERPROFILE"]);
 
                 psi.EnvironmentVariables["APPDATA"] = $"{psi.EnvironmentVariables["USERPROFILE"]}\\AppData\\Roaming";
-                _sessionLogger.LogTrace(string.Format(Resources.Trace_EnvironmentVariable, "APPDATA", psi.EnvironmentVariables["APPDATA"]));
+                _sessionLogger.LogTrace(Resources.Trace_EnvironmentVariable, "APPDATA", psi.EnvironmentVariables["APPDATA"]);
 
                 psi.EnvironmentVariables["LOCALAPPDATA"] = $"{psi.EnvironmentVariables["USERPROFILE"]}\\AppData\\Local";
-                _sessionLogger.LogTrace(string.Format(Resources.Trace_EnvironmentVariable, "LOCALAPPDATA", psi.EnvironmentVariables["LOCALAPPDATA"]));
+                _sessionLogger.LogTrace(Resources.Trace_EnvironmentVariable, "LOCALAPPDATA", psi.EnvironmentVariables["LOCALAPPDATA"]);
 
                 psi.EnvironmentVariables["TEMP"] = $"{psi.EnvironmentVariables["LOCALAPPDATA"]}\\Temp";
-                _sessionLogger.LogTrace(string.Format(Resources.Trace_EnvironmentVariable, "TEMP", psi.EnvironmentVariables["TEMP"]));
+                _sessionLogger.LogTrace(Resources.Trace_EnvironmentVariable, "TEMP", psi.EnvironmentVariables["TEMP"]);
 
                 psi.EnvironmentVariables["TMP"] = $"{psi.EnvironmentVariables["LOCALAPPDATA"]}\\Temp";
-                _sessionLogger.LogTrace(string.Format(Resources.Trace_EnvironmentVariable, "TMP", psi.EnvironmentVariables["TMP"]));
+                _sessionLogger.LogTrace(Resources.Trace_EnvironmentVariable, "TMP", psi.EnvironmentVariables["TMP"]);
             }
 
             var shortHome = new StringBuilder(NativeMethods.MAX_PATH);
@@ -143,16 +142,16 @@ namespace Microsoft.R.Host.Broker.Sessions {
 
             _process.ErrorDataReceived += (sender, e) => {
                 var process = (Process)sender;
-                outputLogger?.LogTrace(string.Format(Resources.Trace_ErrorDataReceived, process.Id, e.Data));
+                outputLogger?.LogTrace(Resources.Trace_ErrorDataReceived, process.Id, e.Data);
             };
 
             _process.Exited += delegate {
                 _pipe = null;
             };
 
-            _sessionLogger.LogInformation(string.Format(Resources.Info_StartingRHost, Id, User.Name, rhostExePath, arguments));
+            _sessionLogger.LogInformation(Resources.Info_StartingRHost, Id, User.Name, rhostExePath, arguments);
             _process.Start();
-            _sessionLogger.LogInformation(string.Format(Resources.Info_StartedRHost, Id, User.Name));
+            _sessionLogger.LogInformation(Resources.Info_StartedRHost, Id, User.Name);
 
             _process.BeginErrorReadLine();
 

--- a/src/Host/Broker/Impl/Sessions/SessionManager.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionManager.cs
@@ -17,7 +17,8 @@ namespace Microsoft.R.Host.Broker.Sessions {
     public class SessionManager {
         private readonly InterpreterManager _interpManager;
         private readonly LoggingOptions _loggingOptions;
-        private readonly ILogger _hostOutputLogger, _messageLogger, _sessionLogger;
+        private readonly ILogger _hostOutputLogger, _messageLogger;
+        private readonly ILogger<Session> _sessionLogger;
 
         private readonly Dictionary<string, List<Session>> _sessions = new Dictionary<string, List<Session>>();
 
@@ -60,12 +61,11 @@ namespace Microsoft.R.Host.Broker.Sessions {
                     userSessions.Remove(oldSession);
                 }
 
-                session = new Session(this, user, id, interpreter, commandLineArguments);
+                session = new Session(this, user, id, interpreter, commandLineArguments, _sessionLogger);
                 userSessions.Add(session);
             }
 
             session.StartHost(
-                _sessionLogger,
                 password,
                 profilePath,
                 _loggingOptions.LogHostOutput ? _hostOutputLogger : null,

--- a/src/Host/Broker/Impl/Sessions/SessionManager.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionManager.cs
@@ -43,7 +43,7 @@ namespace Microsoft.R.Host.Broker.Sessions {
             }
         }
 
-        public Session CreateSession(IIdentity user, string id, Interpreter interpreter, SecureString password, string commandLineArguments) {
+        public Session CreateSession(IIdentity user, string id, Interpreter interpreter, SecureString password, string profilePath, string commandLineArguments) {
             Session session;
 
             lock (_sessions) {
@@ -65,6 +65,7 @@ namespace Microsoft.R.Host.Broker.Sessions {
 
             session.StartHost(
                 password,
+                profilePath,
                 _loggingOptions.LogHostOutput ? _hostOutputLogger : null,
                 _loggingOptions.LogPackets ? _messageLogger : null);
 

--- a/src/Host/Broker/Impl/Sessions/SessionManager.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionManager.cs
@@ -17,16 +17,17 @@ namespace Microsoft.R.Host.Broker.Sessions {
     public class SessionManager {
         private readonly InterpreterManager _interpManager;
         private readonly LoggingOptions _loggingOptions;
-        private readonly ILogger _hostOutputLogger, _messageLogger;
+        private readonly ILogger _hostOutputLogger, _messageLogger, _sessionLogger;
 
         private readonly Dictionary<string, List<Session>> _sessions = new Dictionary<string, List<Session>>();
 
         [ImportingConstructor]
-        public SessionManager(InterpreterManager interpManager, IOptions<LoggingOptions> loggingOptions, ILogger<Process> hostOutputLogger, ILogger<MessagePipe> messageLogger) {
+        public SessionManager(InterpreterManager interpManager, IOptions<LoggingOptions> loggingOptions, ILogger<Process> hostOutputLogger, ILogger<MessagePipe> messageLogger, ILogger<Session> sessionLogger) {
             _interpManager = interpManager;
             _loggingOptions = loggingOptions.Value;
             _hostOutputLogger = hostOutputLogger;
             _messageLogger = messageLogger;
+            _sessionLogger = sessionLogger;
         }
 
         public IEnumerable<Session> GetSessions(IIdentity user) {
@@ -64,6 +65,7 @@ namespace Microsoft.R.Host.Broker.Sessions {
             }
 
             session.StartHost(
+                _sessionLogger,
                 password,
                 profilePath,
                 _loggingOptions.LogHostOutput ? _hostOutputLogger : null,

--- a/src/Host/Broker/Impl/Sessions/SessionManager.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionManager.cs
@@ -17,8 +17,7 @@ namespace Microsoft.R.Host.Broker.Sessions {
     public class SessionManager {
         private readonly InterpreterManager _interpManager;
         private readonly LoggingOptions _loggingOptions;
-        private readonly ILogger _hostOutputLogger, _messageLogger;
-        private readonly ILogger<Session> _sessionLogger;
+        private readonly ILogger _hostOutputLogger, _messageLogger, _sessionLogger;
 
         private readonly Dictionary<string, List<Session>> _sessions = new Dictionary<string, List<Session>>();
 

--- a/src/Host/Broker/Impl/Sessions/SessionsController.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionsController.cs
@@ -38,11 +38,13 @@ namespace Microsoft.R.Host.Broker.Sessions {
                 }
             }
 
+            string profilePath = User.FindFirst(Claims.RUserProfileDir)?.Value;
+
             var interp = string.IsNullOrEmpty(request.InterpreterId)
                 ? _interpManager.Interpreters.First()
                 : _interpManager.Interpreters.First(ip => ip.Id == request.InterpreterId);
 
-            var session = _sessionManager.CreateSession(User.Identity, id, interp, securePassword, request.CommandLineArguments);
+            var session = _sessionManager.CreateSession(User.Identity, id, interp, securePassword, profilePath, request.CommandLineArguments);
             return Task.FromResult(session.Info);
         }
 

--- a/src/Host/Broker/Impl/Startup/Program.cs
+++ b/src/Host/Broker/Impl/Startup/Program.cs
@@ -48,7 +48,7 @@ namespace Microsoft.R.Host.Broker.Startup {
             _logger = _loggerFactory.CreateLogger<Program>();
 
             if (_startupOptions.Name != null) {
-                _logger.LogInformation(string.Format(Resources.Info_BrokerName, _startupOptions.Name));
+                _logger.LogInformation(Resources.Info_BrokerName, _startupOptions.Name);
             }
 
             CreateWebHost().Run();
@@ -75,10 +75,10 @@ namespace Microsoft.R.Host.Broker.Startup {
                     pipe = new NamedPipeClientStream(".", pipeName, PipeDirection.Out);
                     pipe.Connect(10000);
                 } catch (IOException ex) {
-                    _logger.LogCritical(0, ex, string.Format(Resources.Critical_InvalidPipeHandle, pipeName));
+                    _logger.LogCritical(0, ex, Resources.Critical_InvalidPipeHandle, pipeName);
                     throw;
                 } catch (TimeoutException ex) {
-                    _logger.LogCritical(0, ex, string.Format(Resources.Critical_PipeConnectTimeOut, pipeName));
+                    _logger.LogCritical(0, ex, Resources.Critical_PipeConnectTimeOut, pipeName);
                     throw;
                 }
 
@@ -86,14 +86,14 @@ namespace Microsoft.R.Host.Broker.Startup {
                 applicationLifetime.ApplicationStarted.Register(() => Task.Run(() => {
                     using (pipe) {
                         string serverUriStr = JsonConvert.SerializeObject(serverAddresses.Addresses);
-                        _logger.LogTrace(string.Format(Resources.Trace_ServerUrlsToPipeBegin, pipeName, Environment.NewLine, serverUriStr));
+                        _logger.LogTrace(Resources.Trace_ServerUrlsToPipeBegin, pipeName, Environment.NewLine, serverUriStr);
 
                         var serverUriData = Encoding.UTF8.GetBytes(serverUriStr);
                         pipe.Write(serverUriData, 0, serverUriData.Length);
                         pipe.Flush();
                     }
 
-                    _logger.LogTrace(string.Format(Resources.Trace_ServerUrlsToPipeDone, pipeName));
+                    _logger.LogTrace(Resources.Trace_ServerUrlsToPipeDone, pipeName);
                 }));
             }
 

--- a/src/Host/Broker/Impl/Startup/Program.cs
+++ b/src/Host/Broker/Impl/Startup/Program.cs
@@ -48,7 +48,7 @@ namespace Microsoft.R.Host.Broker.Startup {
             _logger = _loggerFactory.CreateLogger<Program>();
 
             if (_startupOptions.Name != null) {
-                _logger.LogInformation($"Broker name '{_startupOptions.Name}' assigned");
+                _logger.LogInformation(string.Format(Resources.Info_BrokerName, _startupOptions.Name));
             }
 
             CreateWebHost().Run();
@@ -75,10 +75,10 @@ namespace Microsoft.R.Host.Broker.Startup {
                     pipe = new NamedPipeClientStream(".", pipeName, PipeDirection.Out);
                     pipe.Connect(10000);
                 } catch (IOException ex) {
-                    _logger.LogCritical(0, ex, $"Requested to write server.urls to pipe '{pipeName}', but it is not a valid pipe handle.");
+                    _logger.LogCritical(0, ex, string.Format(Resources.Critical_InvalidPipeHandle, pipeName));
                     throw;
                 } catch (TimeoutException ex) {
-                    _logger.LogCritical(0, ex, $"Requested to write server.urls to pipe '{pipeName}', but timed out while trying to connect to pipe.");
+                    _logger.LogCritical(0, ex, string.Format(Resources.Critical_PipeConnectTimeOut, pipeName));
                     throw;
                 }
 
@@ -86,14 +86,14 @@ namespace Microsoft.R.Host.Broker.Startup {
                 applicationLifetime.ApplicationStarted.Register(() => Task.Run(() => {
                     using (pipe) {
                         string serverUriStr = JsonConvert.SerializeObject(serverAddresses.Addresses);
-                        _logger.LogTrace($"Writing server.urls to pipe '{pipeName}':{Environment.NewLine}{serverUriStr}");
+                        _logger.LogTrace(string.Format(Resources.Trace_ServerUrlsToPipeBegin, pipeName, Environment.NewLine, serverUriStr));
 
                         var serverUriData = Encoding.UTF8.GetBytes(serverUriStr);
                         pipe.Write(serverUriData, 0, serverUriData.Length);
                         pipe.Flush();
                     }
 
-                    _logger.LogTrace($"Wrote server.urls to pipe '{pipeName}'.");
+                    _logger.LogTrace(string.Format(Resources.Trace_ServerUrlsToPipeDone, pipeName));
                 }));
             }
 
@@ -107,7 +107,7 @@ namespace Microsoft.R.Host.Broker.Startup {
                 // Give cooperative cancellation 10 seconds to shut the process down gracefully,
                 // but if it didn't work, just terminate it.
                 await Task.Delay(10000);
-                _logger.LogCritical("Timed out waiting for graceful shutdown");
+                _logger.LogCritical(Resources.Critical_TimeOutShutdown);
                 Environment.Exit(1);
             });
         }


### PR DESCRIPTION
Fixes a bug where the rhost process does not receive the user environment variables (%USERPROFILE%, %USERNAME%, etc) when it is started with a different user identity than the broker process. #2234