### PR TITLE
Fix 2349

### DIFF
--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotDeviceControl.xaml.cs
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotDeviceControl.xaml.cs
@@ -81,7 +81,7 @@ namespace Microsoft.R.Components.Plots.Implementation.View {
             if (e.Data.GetDataPresent(PlotClipboardData.Format)) {
                 var source = PlotClipboardData.Parse((string)e.Data.GetData(PlotClipboardData.Format));
                 if (source != null) {
-                    var targetDeviceId = Model?.Device.DeviceId;
+                    var targetDeviceId = Model?.Device?.DeviceId;
                     if (targetDeviceId != source.DeviceId) {
                         bool isMove = (e.KeyStates & DragDropKeyStates.ShiftKey) != 0;
                         e.Effects = isMove ? DragDropEffects.Move : DragDropEffects.Copy;


### PR DESCRIPTION
Fixes #2349 Plots: Null reference exception when dropping (drag/drop) on unassigned device 

When a plot window doesn't have a graphics device, it creates one as necessary before issuing a copy plot command.  That was all set up to work, but a late change during code review broke the drag move handler code, which prevents that part of the feature from working.