### PR TITLE
Several bug fixes

### DIFF
--- a/src/Host/Client/Impl/Definitions/IRSessionReconnectTransaction.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionReconnectTransaction.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.R.Host.Client {
+    public interface IRSessionReconnectTransaction : IDisposable {
+        Task ReconnectAsync();
+    }
+}

--- a/src/Host/Client/Impl/Host/BrokerClient.cs
+++ b/src/Host/Client/Impl/Host/BrokerClient.cs
@@ -113,12 +113,15 @@ namespace Microsoft.R.Host.Client.Host {
         public virtual async Task<RHost> ConnectAsync(string name, IRCallbacks callbacks, string rCommandLineArguments = null, int timeout = 3000, CancellationToken cancellationToken = new CancellationToken()) {
             DisposableBag.ThrowIfDisposed();
             await TaskUtilities.SwitchToBackgroundThread();
-
-            await CreateBrokerSessionAsync(name, rCommandLineArguments, cancellationToken);
-            var webSocket = await ConnectToBrokerAsync(name, cancellationToken);
-            var host = CreateRHost(name, callbacks, webSocket);
-            await GetHostInformationAsync(cancellationToken);
-            return host;
+            try {
+                await CreateBrokerSessionAsync(name, rCommandLineArguments, cancellationToken);
+                var webSocket = await ConnectToBrokerAsync(name, cancellationToken);
+                var host = CreateRHost(name, callbacks, webSocket);
+                await GetHostInformationAsync(cancellationToken);
+                return host;
+            } catch (HttpRequestException ex) {
+                throw new RHostDisconnectedException(Resources.Error_HostNotResponsing.FormatInvariant(ex.Message), ex);
+            }
         }
 
         private async Task CreateBrokerSessionAsync(string name, string rCommandLineArguments, CancellationToken cancellationToken) {

--- a/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
+++ b/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
@@ -65,6 +65,7 @@
     <Compile Include="DataInspection\RSessionExtensions.cs" />
     <Compile Include="Definitions\IRBlobInfo.cs" />
     <Compile Include="Definitions\IRSessionProviderCallback.cs" />
+    <Compile Include="Definitions\IRSessionReconnectTransaction.cs" />
     <Compile Include="Definitions\IRSessionSwitchBrokerTransaction.cs" />
     <Compile Include="Host\RHost.BlobWriteRequest.cs" />
     <Compile Include="Host\RHost.BlobReadRequest.cs" />

--- a/src/Host/Client/Impl/Resources.Designer.cs
+++ b/src/Host/Client/Impl/Resources.Designer.cs
@@ -191,7 +191,7 @@ namespace Microsoft.R.Host.Client {
         /// <summary>
         ///   Looks up a localized string similar to Interactive Window is disconnected from R Session.
         ///Try connecting to a remote machine in the Workspaces window or
-        ///click Reset to restart local R interpreter..
+        ///click Reset to restart current R interpreter..
         /// </summary>
         internal static string RHostDisconnected {
             get {
@@ -209,13 +209,44 @@ namespace Microsoft.R.Host.Client {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Couldn&apos;t connect session to 
-        ///&apos;{0}&apos; : {1} 
-        ///because of the following error: {2}.
+        ///   Looks up a localized string similar to Reconnection to the &apos;{0}&apos;: {1}
+        ///has been canceled.
         /// </summary>
-        internal static string RSessionProvider_RestartingSessionFailed {
+        internal static string RSessionProvider_ReconnectingWorkspaceCanceled {
             get {
-                return ResourceManager.GetString("RSessionProvider_RestartingSessionFailed", resourceCulture);
+                return ResourceManager.GetString("RSessionProvider_ReconnectingWorkspaceCanceled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reconnection to the &apos;{0}&apos;: {1}
+        ///has failed because of the following error: {2}.
+        /// </summary>
+        internal static string RSessionProvider_ReconnectingWorkspaceFailed {
+            get {
+                return ResourceManager.GetString("RSessionProvider_ReconnectingWorkspaceFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to R Session restart has been canceled for &apos;{0}&apos;: {1}
+        ///Please restart it manually or select another connection in Workspaces window..
+        /// </summary>
+        internal static string RSessionProvider_RestartingSessionAfterSwitchingCanceled {
+            get {
+                return ResourceManager.GetString("RSessionProvider_RestartingSessionAfterSwitchingCanceled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Couldn&apos;t restart R Session &apos;{0}&apos;: {1} 
+        ///because of the following error: {2}
+        ///Connection switched back to &apos;{3}&apos;: {4}
+        ///Please restart R Session manually or select another connection in Workspaces window..
+        /// </summary>
+        internal static string RSessionProvider_RestartingSessionAfterSwitchingFailed {
+            get {
+                return ResourceManager.GetString("RSessionProvider_RestartingSessionAfterSwitchingFailed", resourceCulture);
             }
         }
         
@@ -238,17 +269,9 @@ namespace Microsoft.R.Host.Client {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Starting R Session has been canceled, please restart it manually..
-        /// </summary>
-        internal static string RSessionProvider_StartingSessionAfterSwitchingCanceled {
-            get {
-                return ResourceManager.GetString("RSessionProvider_StartingSessionAfterSwitchingCanceled", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Starting R Session has failed, please restart it manually. Restoring connection to the
-        ///&apos;{0}&apos;: {1}.
+        ///   Looks up a localized string similar to Couldn&apos;t start R Session &apos;{0}&apos;: {1} 
+        ///because of the following error: {2}
+        ///Please restart R Session manually or select another connection in Workspaces window..
         /// </summary>
         internal static string RSessionProvider_StartingSessionAfterSwitchingFailed {
             get {
@@ -275,8 +298,8 @@ namespace Microsoft.R.Host.Client {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Connection to the new R Workspace has been canceled, restoring connection to the
-        ///&apos;{0}&apos;: {1}.
+        ///   Looks up a localized string similar to Connection to the &apos;{0}&apos;: {1}
+        ///has been canceled.
         /// </summary>
         internal static string RSessionProvider_SwitchingWorkspaceCanceled {
             get {
@@ -285,8 +308,8 @@ namespace Microsoft.R.Host.Client {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Connecting to the new R Workspace failed, restoring connection to 
-        ///&apos;{0}&apos; : {1}.
+        ///   Looks up a localized string similar to Couldn&apos;t connect session to the &apos;{0}&apos;: {1} 
+        ///because of the following error: {2}.
         /// </summary>
         internal static string RSessionProvider_SwitchingWorkspaceFailed {
             get {

--- a/src/Host/Client/Impl/Resources.resx
+++ b/src/Host/Client/Impl/Resources.resx
@@ -125,7 +125,7 @@ use another connection or install local R.</value>
   <data name="RHostDisconnected" xml:space="preserve">
     <value>Interactive Window is disconnected from R Session.
 Try connecting to a remote machine in the Workspaces window or
-click Reset to restart local R interpreter.</value>
+click Reset to restart current R interpreter.</value>
   </data>
   <data name="RSessionProvider_StartSwitchingWorkspaceFormat" xml:space="preserve">
     <value>Start switching to the '{0}': {1}</value>
@@ -140,24 +140,35 @@ click Reset to restart local R interpreter.</value>
     <value>Restarting sessions ({0})...</value>
   </data>
   <data name="RSessionProvider_SwitchingWorkspaceFailed" xml:space="preserve">
-    <value>Connecting to the new R Workspace failed, restoring connection to 
-'{0}' : {1}</value>
+    <value>Couldn't connect session to the '{0}': {1} 
+because of the following error: {2}</value>
   </data>
   <data name="RSessionProvider_SwitchingWorkspaceCanceled" xml:space="preserve">
-    <value>Connection to the new R Workspace has been canceled, restoring connection to the
-'{0}': {1}</value>
+    <value>Connection to the '{0}': {1}
+has been canceled</value>
   </data>
   <data name="RSessionProvider_StartingSessionAfterSwitchingFailed" xml:space="preserve">
-    <value>Starting R Session has failed, please restart it manually. Restoring connection to the
-'{0}': {1}</value>
+    <value>Couldn't start R Session '{0}': {1} 
+because of the following error: {2}
+Please restart R Session manually or select another connection in Workspaces window.</value>
   </data>
-  <data name="RSessionProvider_StartingSessionAfterSwitchingCanceled" xml:space="preserve">
-    <value>Starting R Session has been canceled, please restart it manually.</value>
+  <data name="RSessionProvider_RestartingSessionAfterSwitchingFailed" xml:space="preserve">
+    <value>Couldn't restart R Session '{0}': {1} 
+because of the following error: {2}
+Connection switched back to '{3}': {4}
+Please restart R Session manually or select another connection in Workspaces window.</value>
   </data>
-  <data name="RSessionProvider_RestartingSessionFailed" xml:space="preserve">
-    <value>Couldn't connect session to 
-'{0}' : {1} 
-because of the following error: {2}</value>
+  <data name="RSessionProvider_RestartingSessionAfterSwitchingCanceled" xml:space="preserve">
+    <value>R Session restart has been canceled for '{0}': {1}
+Please restart it manually or select another connection in Workspaces window.</value>
+  </data>
+  <data name="RSessionProvider_ReconnectingWorkspaceFailed" xml:space="preserve">
+    <value>Reconnection to the '{0}': {1}
+has failed because of the following error: {2}</value>
+  </data>
+  <data name="RSessionProvider_ReconnectingWorkspaceCanceled" xml:space="preserve">
+    <value>Reconnection to the '{0}': {1}
+has been canceled</value>
   </data>
   <data name="Bits32" xml:space="preserve">
     <value>32 bit</value>

--- a/src/Host/Client/Impl/Session/RSessionProvider.cs
+++ b/src/Host/Client/Impl/Session/RSessionProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.R.Host.Client.Session {
         private readonly ConcurrentDictionary<Guid, RSession> _sessions = new ConcurrentDictionary<Guid, RSession>();
         private readonly DisposeToken _disposeToken = DisposeToken.Create<RSessionProvider>();
         private readonly BinaryAsyncLock _brokerSwitchLock = new BinaryAsyncLock();
+        private readonly BinaryAsyncLock _brokerDisconnectedLock = new BinaryAsyncLock();
         private readonly AsyncCountdownEvent _connectCde = new AsyncCountdownEvent(0);
 
         private readonly BrokerClientProxy _brokerProxy;
@@ -100,6 +101,7 @@ namespace Microsoft.R.Host.Client.Session {
 
         private void RSessionOnConnected(object sender, RConnectedEventArgs e) {
             OnBrokerConnected();
+            _brokerDisconnectedLock.ResetAsync().DoNotWait();
         }
 
         private void RSessionOnDisconnected(object sender, EventArgs e) {
@@ -107,10 +109,13 @@ namespace Microsoft.R.Host.Client.Session {
         }
 
         private async Task RSessionOnDisconnectedAsync() {
+            var token = await _brokerDisconnectedLock.WaitAsync();
             try {
-                // We don't want to show that connection is broken just because one of the sessions has been disconnected. Ping broker.
-                await _brokerProxy.PingAsync();
+                // We don't want to show that connection is broken just because one of the sessions has been disconnected. Need to test connection
+                await TestBrokerConnectionWithRHost(_brokerProxy, default(CancellationToken));
+                token.Reset();
             } catch (RHostDisconnectedException) {
+                token.Set();
                 OnBrokerDisconnected();
             }
         }
@@ -138,17 +143,21 @@ namespace Microsoft.R.Host.Client.Session {
             }
 
             try {
-                var callbacks = new NullRCallbacks();
-                var rhost = await brokerClient.ConnectAsync(nameof(TestBrokerConnectionAsync), callbacks, cancellationToken: cancellationToken);
-                try {
-                    var rhostRunTask = rhost.Run(cancellationToken);
-                    callbacks.SetReadConsoleInput("q()\n");
-                    await rhostRunTask;
-                } finally {
-                    rhost.Dispose();
-                }
+                await TestBrokerConnectionWithRHost(brokerClient, cancellationToken);
             } finally {
                 brokerClient.Dispose();
+            }
+        }
+
+        private static async Task TestBrokerConnectionWithRHost(IBrokerClient brokerClient, CancellationToken cancellationToken) {
+            var callbacks = new NullRCallbacks();
+            var rhost = await brokerClient.ConnectAsync(nameof(TestBrokerConnectionAsync), callbacks, cancellationToken: cancellationToken);
+            try {
+                var rhostRunTask = rhost.Run(cancellationToken);
+                callbacks.SetReadConsoleInput("q()\n");
+                await rhostRunTask;
+            } finally {
+                rhost.Dispose();
             }
         }
 
@@ -162,10 +171,90 @@ namespace Microsoft.R.Host.Client.Session {
 
             if (brokerClient.Name.EqualsOrdinal(_brokerProxy.Name) &&
                 brokerClient.Uri.AbsoluteUri.PathEquals(_brokerProxy.Uri.AbsoluteUri)) {
-                // Switching to the broker that is currently running is always successful
-                return true;
+
+                brokerClient.Dispose();
+                // Switching to the broker that is currently running and connected is always successful
+                if (IsConnected) {
+                    return true;
+                }
+
+                return await TryReconnectAsync(cancellationToken);
             }
 
+            // Connector switching shouldn't be concurrent
+            IBinaryAsyncLockToken lockToken;
+            try {
+                lockToken = await _brokerSwitchLock.WaitAsync(cancellationToken);
+                await _connectCde.WaitAsync(cancellationToken);
+            } catch (OperationCanceledException) {
+                brokerClient.Dispose();
+                return false;
+            }
+
+            // First switch broker proxy so that all new sessions are created for the new broker
+            var oldBroker = _brokerProxy.Set(brokerClient);
+            try {
+                BrokerChanging?.Invoke(this, EventArgs.Empty);
+                await SwitchBrokerAsync(cancellationToken, oldBroker);
+                oldBroker.Dispose();
+                PrintBrokerInformation();
+            } catch(Exception) {
+                _brokerProxy.Set(oldBroker);
+                brokerClient.Dispose();
+                BrokerChangeFailed?.Invoke(this, EventArgs.Empty);
+                return false;
+            } finally {
+                lockToken.Reset();
+            }
+
+            OnBrokerConnected();
+            BrokerChanged?.Invoke(this, new EventArgs());
+            return true;
+        }
+
+        private async Task SwitchBrokerAsync(CancellationToken cancellationToken, IBrokerClient oldBroker) {
+            var switchingFromNull = oldBroker is NullBrokerClient;
+            if (!switchingFromNull) {
+                _callback.WriteConsole(Resources.RSessionProvider_StartSwitchingWorkspaceFormat.FormatInvariant(_brokerProxy.Name, GetUriString(_brokerProxy)));
+            }
+
+            var sessions = _sessions.Values.ToList();
+            if (sessions.Any()) {
+                await SwitchSessionsAsync(sessions, oldBroker, cancellationToken);
+            } else {
+                // Ping isn't enough here - need a "full" test with RHost
+                await TestBrokerConnectionWithRHost(_brokerProxy, cancellationToken);
+            }
+
+            if (!switchingFromNull) {
+                _callback.WriteConsole(Resources.RSessionProvider_SwitchingRWorkspaceCompleted);
+            }
+        }
+
+        private async Task SwitchSessionsAsync(IEnumerable<RSession> sessions, IBrokerClient oldBroker, CancellationToken cancellationToken) {
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            // All sessions should participate in switch. If any of it didn't start, cancel the rest.
+            var startTransactionTasks = sessions.Select(s => s.StartSwitchingBrokerAsync(cts.Token)).ToList();
+
+            try {
+                await Task.WhenAll(startTransactionTasks);
+                var transactions = startTransactionTasks.Select(t => t.Result).ToList();
+
+                _callback.WriteConsole(Resources.RSessionProvider_StartConnectingToWorkspaceFormat.FormatInvariant(transactions.Count));
+                await Task.WhenAll(transactions.Select(t => ConnectToNewBrokerAsync(t, cts)));
+
+                _callback.WriteConsole(Resources.RSessionProvider_RestartingSessionsFormat.FormatInvariant(transactions.Count));
+                OnBrokerDisconnected();
+                await Task.WhenAll(transactions.Select(t => CompleteSwitchingBrokerAsync(t, oldBroker, cts)));
+            } finally {
+                foreach (var task in startTransactionTasks.Where(t => t.Status == TaskStatus.RanToCompletion)) {
+                    task.Result.Dispose();
+                }
+            }
+        }
+
+        private async Task<bool> TryReconnectAsync(CancellationToken cancellationToken) {
             // Connector switching shouldn't be concurrent
             IBinaryAsyncLockToken lockToken;
             try {
@@ -176,65 +265,54 @@ namespace Microsoft.R.Host.Client.Session {
             }
 
             try {
-                // First switch connector so that all new sessions are created for the new broker
-                var oldBroker = _brokerProxy.Set(brokerClient);
-                BrokerChanging?.Invoke(this, EventArgs.Empty);
-                var switchingFromNull = oldBroker is NullBrokerClient;
-                if (!switchingFromNull) {
-                    _callback.WriteConsole(Resources.RSessionProvider_StartSwitchingWorkspaceFormat.FormatInvariant(_brokerProxy.Name, GetUriString(_brokerProxy)));
-                }
-
-                var sessions = _sessions.Values.ToList();
-                if (sessions.Any()) {
-                    var sessionsSwitched = await TrySwitchSessionsAsync(sessions, oldBroker, cancellationToken);
-                    if (!sessionsSwitched) {
-                        BrokerChangeFailed?.Invoke(this, EventArgs.Empty);
-                        return false;
-                    }
-                }
-
-                if (!switchingFromNull) {
-                    _callback.WriteConsole(Resources.RSessionProvider_SwitchingRWorkspaceCompleted);
-                }
-                PrintBrokerInformation();
+                await ReconnectAsync(cancellationToken);
+            } catch (Exception) {
+                return false;
             } finally {
                 lockToken.Reset();
             }
 
             OnBrokerConnected();
-            BrokerChanged?.Invoke(this, new EventArgs());
             return true;
         }
 
-        private async Task<bool> TrySwitchSessionsAsync(List<RSession> sessions, IBrokerClient oldBroker, CancellationToken cancellationToken) {
-            // All sessions should participate in switch. If any of it didn't start, cancel the rest.
-            var startTransactionTasks = sessions.Select(s => s.StartSwitchingBrokerAsync(cancellationToken)).ToList();
-            try {
-                await Task.WhenAll(startTransactionTasks);
-            } catch (OperationCanceledException) {
-                foreach (var task in startTransactionTasks.Where(t => t.Status == TaskStatus.RanToCompletion)) {
-                    task.Result.Dispose();
-                }
-                var newBroker = _brokerProxy.Set(oldBroker);
-                newBroker.Dispose();
-                return false;
-            }
+        private async Task ReconnectAsync(CancellationToken cancellationToken) {
+            var sessions = _sessions.Values.ToList();
+            if (sessions.Any()) {
+                var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                // All sessions should participate in reconnect. If any of it didn't start, cancel the rest.
+                var startTransactionTasks = sessions.Select(s => s.StartReconnectingAsync(cts.Token)).ToList();
 
-            // Try switching
-            var transactions = startTransactionTasks.Select(t => t.Result).ToList();
-            try {
-                await ConnectSessionsToNewBrokerAsync(transactions, oldBroker);
-                OnBrokerDisconnected();
-                await CompleteSwitchingBrokerAsync(transactions, oldBroker);
-            } catch (Exception) {
-                return false;
-            } finally {
-                foreach (var transaction in transactions) {
-                    transaction.Dispose();
-                }
-            }
+                try {
+                    await Task.WhenAll(startTransactionTasks);
+                    var transactions = startTransactionTasks.Select(t => t.Result).ToList();
 
-            return true;
+                    await Task.WhenAll(transactions.Select(s => ReconnectSessionAsync(s, cts)));
+                } finally {
+                    foreach (var task in startTransactionTasks.Where(t => t.Status == TaskStatus.RanToCompletion)) {
+                        task.Result.Dispose();
+                    }
+                }
+            } else {
+                await TestBrokerConnectionWithRHost(_brokerProxy, cancellationToken);
+            }
+        }
+
+        private async Task ReconnectSessionAsync(IRSessionReconnectTransaction transaction, CancellationTokenSource cts) {
+            try {
+                await transaction.ReconnectAsync();
+            } catch (OperationCanceledException ex) when (!(ex is RHostDisconnectedException)) {
+                // Swallow cancellation if it is a result of another session failure
+                if (!cts.IsCancellationRequested) {
+                    _callback.WriteConsole(Resources.RSessionProvider_SwitchingWorkspaceCanceled.FormatInvariant(_brokerProxy.Name, GetUriString(_brokerProxy)));
+                    cts.Cancel();
+                    throw;
+                }
+            } catch (Exception ex) {
+                _callback.WriteConsole(Resources.RSessionProvider_SwitchingWorkspaceFailed.FormatInvariant(_brokerProxy.Name, GetUriString(_brokerProxy), ex.Message));
+                cts.Cancel();
+                throw;
+            }
         }
 
         public void PrintBrokerInformation() {
@@ -257,44 +335,40 @@ namespace Microsoft.R.Host.Client.Session {
             }
         }
 
-        private async Task ConnectToNewBrokerAsync(IRSessionSwitchBrokerTransaction transaction) {
+        private async Task ConnectToNewBrokerAsync(IRSessionSwitchBrokerTransaction transaction, CancellationTokenSource cts) {
             try {
                 await transaction.ConnectToNewBrokerAsync();
-            } catch (RHostDisconnectedException ex) {
-                _callback.WriteConsole(Resources.RSessionProvider_RestartingSessionFailed.FormatInvariant(_brokerProxy.Name, _brokerProxy.Uri, ex.Message));
-                throw;
-            }
-        }
-
-        private async Task ConnectSessionsToNewBrokerAsync(List<IRSessionSwitchBrokerTransaction> transactions, IBrokerClient oldBroker) {
-            try {
-                _callback.WriteConsole(Resources.RSessionProvider_StartConnectingToWorkspaceFormat.FormatInvariant(transactions.Count));
-                await Task.WhenAll(transactions.Select(ConnectToNewBrokerAsync));
-            } catch(Exception ex) {
-                if (ex is OperationCanceledException && !(ex is RHostDisconnectedException)) {
-                    _callback.WriteConsole(Resources.RSessionProvider_SwitchingWorkspaceCanceled.FormatInvariant(oldBroker.Name, GetUriString(oldBroker)));
-                } else {
-                    _callback.WriteConsole(Resources.RSessionProvider_SwitchingWorkspaceFailed.FormatInvariant(oldBroker.Name, GetUriString(oldBroker)));
-                }
-                
-                var newBroker = _brokerProxy.Set(oldBroker);
-                newBroker.Dispose();
-                throw;
-            }
-        }
-
-        private async Task CompleteSwitchingBrokerAsync(List<IRSessionSwitchBrokerTransaction> transactions, IBrokerClient oldBroker) {
-            try {
-                _callback.WriteConsole(Resources.RSessionProvider_RestartingSessionsFormat.FormatInvariant(transactions.Count));
-                await Task.WhenAll(transactions.Select(t => t.CompleteSwitchingBrokerAsync()));
             } catch (OperationCanceledException ex) when (!(ex is RHostDisconnectedException)) {
-                _callback.WriteConsole(Resources.RSessionProvider_StartingSessionAfterSwitchingCanceled);
-                oldBroker.Dispose();
+                // Swallow cancellation if it is a result of another session failure
+                if (!cts.IsCancellationRequested) {
+                    _callback.WriteConsole(Resources.RSessionProvider_SwitchingWorkspaceCanceled.FormatInvariant(_brokerProxy.Name, GetUriString(_brokerProxy)));
+                    cts.Cancel();
+                    throw;
+                }
+            } catch (Exception ex) {
+                _callback.WriteConsole(Resources.RSessionProvider_SwitchingWorkspaceFailed.FormatInvariant(_brokerProxy.Name, GetUriString(_brokerProxy), ex.Message));
+                cts.Cancel();
                 throw;
-            } catch (Exception) {
-                _callback.WriteConsole(Resources.RSessionProvider_StartingSessionAfterSwitchingFailed.FormatInvariant(oldBroker.Name, GetUriString(oldBroker)));
-                var newBroker = _brokerProxy.Set(oldBroker);
-                newBroker.Dispose();
+            }
+        }
+
+        private async Task CompleteSwitchingBrokerAsync(IRSessionSwitchBrokerTransaction transaction, IBrokerClient oldBroker, CancellationTokenSource cts) {
+            try {
+                await transaction.CompleteSwitchingBrokerAsync();
+            } catch (OperationCanceledException ex) when (!(ex is RHostDisconnectedException)) {
+                // Swallow cancellation if it is a result of another session failure
+                if (!cts.IsCancellationRequested) {
+                    _callback.WriteConsole(Resources.RSessionProvider_RestartingSessionAfterSwitchingCanceled.FormatInvariant(_brokerProxy.Name, GetUriString(_brokerProxy)));
+                    cts.Cancel();
+                }
+            } catch (Exception ex) {
+                var switchingFromNull = oldBroker is NullBrokerClient;
+                var message = switchingFromNull
+                    ? Resources.RSessionProvider_StartingSessionAfterSwitchingFailed
+                    : Resources.RSessionProvider_RestartingSessionAfterSwitchingFailed.FormatInvariant(_brokerProxy.Name, GetUriString(_brokerProxy), ex.Message, oldBroker.Name, GetUriString(oldBroker));
+
+                _callback.WriteConsole(message);
+                cts.Cancel();
                 throw;
             }
         }

--- a/src/Host/Client/Test/Session/RSessionProviderTest.cs
+++ b/src/Host/Client/Test/Session/RSessionProviderTest.cs
@@ -166,6 +166,18 @@ namespace Microsoft.R.Host.Client.Test.Session {
             }
         }
 
+        [Test]
+        public async Task SwitchToTheSameBroker_NoSessions() {
+            using (var sessionProvider = new RSessionProvider()) {
+                var switch1Task = sessionProvider.TrySwitchBrokerAsync(nameof(RSessionProviderTest) + nameof(SwitchToTheSameBroker));
+                var switch2Task = sessionProvider.TrySwitchBrokerAsync(nameof(RSessionProviderTest) + nameof(SwitchToTheSameBroker));
+                await Task.WhenAll(switch1Task, switch2Task);
+
+                switch1Task.Status.Should().Be(TaskStatus.RanToCompletion);
+                switch2Task.Status.Should().Be(TaskStatus.RanToCompletion);
+            }
+        }
+
         [InlineData(0)]
         [InlineData(10)]
         [InlineData(50)]

--- a/src/R/Components/Impl/ConnectionManager/Commands/ReconnectCommand.cs
+++ b/src/R/Components/Impl/ConnectionManager/Commands/ReconnectCommand.cs
@@ -2,25 +2,31 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.Common.Core;
+using Microsoft.Common.Core.Shell;
 using Microsoft.R.Components.Controller;
 using Microsoft.R.Components.InteractiveWorkflow;
 
 namespace Microsoft.R.Components.ConnectionManager.Commands {
     public class ReconnectCommand : IAsyncCommand {
-        private readonly IConnectionManager _connectionsManager;
+        private readonly IConnectionManager _connectionManager;
+        private readonly ICoreShell _shell;
 
         public ReconnectCommand(IRInteractiveWorkflow workflow) {
-            _connectionsManager = workflow.Connections;
+            _connectionManager = workflow.Connections;
+            _shell = workflow.Shell;
         }
 
-        public CommandStatus Status => _connectionsManager.IsConnected 
+        public CommandStatus Status => _connectionManager.IsConnected 
             ? CommandStatus.Supported
             : CommandStatus.SupportedAndEnabled;
 
         public async Task<CommandResult> InvokeAsync() {
-            var connection = _connectionsManager.ActiveConnection;
-            if (connection != null) {
-                await _connectionsManager.ConnectAsync(connection);
+            var connection = _connectionManager.ActiveConnection;
+            if (connection != null && !_connectionManager.IsConnected) {
+                using (_shell.ShowProgressBar(Resources.ConnectionManager_ReconnectionToProgressBarMessage.FormatInvariant(connection.Name))) {
+                    await _connectionManager.ReconnectAsync();
+                }
             }
             return CommandResult.Executed;
         }

--- a/src/R/Components/Impl/ConnectionManager/IConnectionManager.cs
+++ b/src/R/Components/Impl/ConnectionManager/IConnectionManager.cs
@@ -26,6 +26,7 @@ namespace Microsoft.R.Components.ConnectionManager {
         bool TryRemove(Uri id);
 
         Task ConnectAsync(IConnectionInfo connection, CancellationToken cancellationToken = default(CancellationToken));
+        Task ReconnectAsync(CancellationToken cancellationToken = default(CancellationToken));
         Task TestConnectionAsync(IConnectionInfo connection, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
@@ -112,6 +112,13 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
             return _sessionProvider.TestBrokerConnectionAsync(connection.Name, connection.Path, cancellationToken);
         }
 
+        public async Task ReconnectAsync(CancellationToken cancellationToken = default(CancellationToken)) {
+            var connection = ActiveConnection;
+            if (connection != null && !_sessionProvider.IsConnected) {
+                await _sessionProvider.TrySwitchBrokerAsync(connection.Name, connection.Path, cancellationToken);
+            }
+        }
+
         public async Task ConnectAsync(IConnectionInfo connection, CancellationToken cancellationToken = default(CancellationToken)) {
             if (ActiveConnection == null || !ActiveConnection.Path.PathEquals(connection.Path) || string.IsNullOrEmpty(_sessionProvider.Broker.Name)) {
                 await TrySwitchBrokerAsync(connection, cancellationToken);

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionManagerViewModel.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionManagerViewModel.cs
@@ -214,12 +214,19 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.ViewModel {
 
         public async Task ConnectAsync(IConnectionViewModel connection) {
             _shell.AssertIsOnMainThread();
-            var progressBarMessage = _connectionManager.ActiveConnection != null
-                ? Resources.ConnectionManager_SwitchConnectionProgressBarMessage.FormatInvariant(_connectionManager.ActiveConnection.Name, connection.Name)
-                : Resources.ConnectionManager_ConnectionToProgressBarMessage.FormatInvariant(connection.Name);
-            using (var progressBarSession = _shell.ShowProgressBar(progressBarMessage)) {
-                await _connectionManager.ConnectAsync(connection, progressBarSession.UserCancellationToken);
+            if (_connectionManager.ActiveConnection != null && !IsConnected) {
+                using (_shell.ShowProgressBar(Resources.ConnectionManager_ReconnectionToProgressBarMessage.FormatInvariant(connection.Name))) {
+                    await _connectionManager.ReconnectAsync();
+                }
+            } else {
+                var progressBarMessage = _connectionManager.ActiveConnection != null
+                    ? Resources.ConnectionManager_SwitchConnectionProgressBarMessage.FormatInvariant(_connectionManager.ActiveConnection.Name, connection.Name)
+                    : Resources.ConnectionManager_ConnectionToProgressBarMessage.FormatInvariant(connection.Name);
+                using (var progressBarSession = _shell.ShowProgressBar(progressBarMessage)) {
+                    await _connectionManager.ConnectAsync(connection, progressBarSession.UserCancellationToken);
+                }
             }
+
             UpdateConnections();
         }
 

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWindowVisualComponent.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWindowVisualComponent.cs
@@ -32,36 +32,34 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             Container = container;
 
             _sessionProvider = sessionProvider;
-            sessionProvider.BrokerChanged += OnBrokerChanged;
+            sessionProvider.BrokerStateChanged += OnBrokerChanged;
 
             var textView = interactiveWindow.TextView;
             Controller = ServiceManagerBase.GetService<ICommandTarget>(textView);
             Control = textView.VisualElement;
             interactiveWindow.Properties.AddProperty(typeof(IInteractiveWindowVisualComponent), this);
 
-            UpdateWindowTitle();
+            UpdateWindowTitle(_sessionProvider.IsConnected);
         }
 
         public void Dispose() {
             InteractiveWindow.Properties.RemoveProperty(typeof (IInteractiveWindowVisualComponent));
-            _sessionProvider.BrokerChanged -= OnBrokerChanged;
+            _sessionProvider.BrokerStateChanged -= OnBrokerChanged;
         }
 
-        private void OnBrokerChanged(object sender, EventArgs e) {
-            UpdateWindowTitle();
+        private void OnBrokerChanged(object sender, BrokerStateChangedEventArgs e) {
+            UpdateWindowTitle(e.IsConnected);
         }
 
-        private void UpdateWindowTitle() {
-            var broker = _sessionProvider.Broker;
-            string title;
-            if (broker != null) {
-                title = broker.IsRemote
+        private void UpdateWindowTitle(bool isConnected) {
+            if (isConnected) {
+                var broker = _sessionProvider.Broker;
+                Container.CaptionText = broker.IsRemote
                     ? Invariant($"{Resources.ReplWindowName} - {broker.Name} ({broker.Uri.ToString().TrimTrailingSlash()})")
                     : Invariant($"{Resources.ReplWindowName} - {broker.Name}");
             } else {
-                title = Resources.Disconnected;
+                Container.CaptionText = Resources.Disconnected;
             }
-            Container.CaptionText = title;
         }
     }
 }

--- a/src/R/Components/Impl/Resources.Designer.cs
+++ b/src/R/Components/Impl/Resources.Designer.cs
@@ -288,6 +288,15 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reconnecting to &quot;{0}&quot;.
+        /// </summary>
+        public static string ConnectionManager_ReconnectionToProgressBarMessage {
+            get {
+                return ResourceManager.GetString("ConnectionManager_ReconnectionToProgressBarMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remote.
         /// </summary>
         public static string ConnectionManager_RemoteConnections {

--- a/src/R/Components/Impl/Resources.resx
+++ b/src/R/Components/Impl/Resources.resx
@@ -498,6 +498,9 @@ Port: {2}
   <data name="ConnectionManager_ConnectionToProgressBarMessage" xml:space="preserve">
     <value>Connecting to "{0}"</value>
   </data>
+  <data name="ConnectionManager_ReconnectionToProgressBarMessage" xml:space="preserve">
+    <value>Reconnecting to "{0}"</value>
+  </data>
   <data name="ConnectionManager_None" xml:space="preserve">
     <value>none specified</value>
   </data>


### PR DESCRIPTION
- Fix #2372: Don't restore connection when new connection failed
- Fix #2362: Failed connection should have different message when there is no fallback
- Fix #2354: Connection progress doesn't dismiss when it can't connect
- Fix #2352: Various remote status don't agree as to where I'm connected
- Fix #2351: Reconnect button doesn't work (neither in CM nor in status bar)