### PR TITLE
Extracted `WhenAllCancelOnFailure`

### DIFF
--- a/src/Common/Core/Test/Tasks/TaskUtilitiesTest.cs
+++ b/src/Common/Core/Test/Tasks/TaskUtilitiesTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.UnitTests.Core.FluentAssertions;
@@ -19,6 +20,89 @@ namespace Microsoft.Common.Core.Test.Tasks {
 
             Func<Task<int>> f = async () => await task;
             await f.ShouldThrowAsync<CustomOperationCanceledException>();
+        }
+
+        [Test]
+        public async Task WhenAllCancelOnFailure_Array() {
+            Func<CancellationToken, Task> function1 = async ct => {
+                await Task.Delay(100, ct);
+                throw new InvalidOperationException("1");
+            };
+
+            Func<CancellationToken, Task> function2 = async ct => {
+                await Task.Delay(50, ct);
+                throw new InvalidOperationException("2");
+            };
+
+            Func<Task> f = () => TaskUtilities.WhenAllCancelOnFailure(function1, function2);
+            (await f.ShouldThrowAsync<InvalidOperationException>()).WithMessage("2");
+        }
+
+        [Test]
+        public async Task WhenAllCancelOnFailure_NoCancellation() {
+            Func<CancellationToken, Task> function1 = async ct => {
+                await Task.Delay(100, ct);
+                throw new InvalidOperationException("1");
+            };
+
+            Func<CancellationToken, Task> function2 = async ct => {
+                await Task.Delay(50, ct);
+                throw new InvalidOperationException("2");
+            };
+
+            Func<Task> f = () => TaskUtilities.WhenAllCancelOnFailure(new [] { function1, function2 }, CancellationToken.None);
+            (await f.ShouldThrowAsync<InvalidOperationException>()).WithMessage("2");
+        }
+
+        [Test]
+        public async Task WhenAllCancelOnFailure_FailureThenCancellation() {
+            Func<CancellationToken, Task> function1 = async ct => {
+                await Task.Delay(150, ct);
+                throw new InvalidOperationException("1");
+            };
+
+            Func<CancellationToken, Task> function2 = async ct => {
+                await Task.Delay(50, ct);
+                throw new InvalidOperationException("2");
+            };
+
+            var cts = new CancellationTokenSource(100);
+            Func<Task> f = () => TaskUtilities.WhenAllCancelOnFailure(new [] { function1, function2 }, cts.Token);
+            (await f.ShouldThrowAsync<InvalidOperationException>()).WithMessage("2");
+        }
+
+        [Test]
+        public async Task WhenAllCancelOnFailure_CancellationThenFailure() {
+            Func<CancellationToken, Task> function1 = async ct => {
+                await Task.Delay(150, ct);
+                throw new InvalidOperationException("1");
+            };
+
+            Func<CancellationToken, Task> function2 = async ct => {
+                await Task.Delay(100, ct);
+                throw new InvalidOperationException("2");
+            };
+
+            var cts = new CancellationTokenSource(50);
+            Func<Task> f = () => TaskUtilities.WhenAllCancelOnFailure(new [] { function1, function2 }, cts.Token);
+            await f.ShouldThrowAsync<OperationCanceledException>();
+        }
+
+        [Test]
+        public async Task WhenAllCancelOnFailure_FailureOnCancellation() {
+            Func<CancellationToken, Task> function1 = async ct => {
+                await Task.Delay(100, ct);
+                throw new InvalidOperationException("1");
+            };
+
+            Func<CancellationToken, Task> function2 = async ct => {
+                await Task.Delay(50, ct);
+                throw new OperationCanceledException("2");
+            };
+
+            var cts = new CancellationTokenSource(100);
+            Func<Task> f = () => TaskUtilities.WhenAllCancelOnFailure(new [] { function1, function2 }, cts.Token);
+            (await f.ShouldThrowAsync<OperationCanceledException>()).WithMessage("2");
         }
 
         private class CustomOperationCanceledException : OperationCanceledException { }

--- a/src/Host/Client/Impl/Definitions/IRSessionReconnectTransaction.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionReconnectTransaction.cs
@@ -2,10 +2,20 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Client {
     public interface IRSessionReconnectTransaction : IDisposable {
-        Task ReconnectAsync();
+        /// <summary>
+        /// First step of the transaction. Acquires lock that prevents switch, reconnect 
+        /// and other types of initialization from being called concurrently.
+        /// </summary>
+        Task AcquireLockAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Second step of the transaction. Performs actual reconnection.
+        /// </summary>
+        Task ReconnectAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Host/Client/Impl/Definitions/IRSessionSwitchBrokerTransaction.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionSwitchBrokerTransaction.cs
@@ -2,22 +2,29 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Client {
     public interface IRSessionSwitchBrokerTransaction : IDisposable {
         /// <summary>
-        /// First step of the transaction. Creates connection to the broker based on the RSession parameters. 
+        /// First step of the transaction. Acquires lock that prevents switch, reconnect 
+        /// and other types of initialization from being called concurrently.
+        /// </summary>
+        Task AcquireLockAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Second step of the transaction. Creates connection to the broker based on the RSession parameters. 
         /// At the end of stage, old connection still exists and all pending interactions/evaluations are alive.
         /// Canceling transaction during or at the end of this stage allows to fallback to the old broker and avoid restarting session
         /// </summary>
-        Task ConnectToNewBrokerAsync();
+        Task ConnectToNewBrokerAsync(CancellationToken cancellationToken);
 
         /// <summary>
-        /// Second step of the transaction. Assumes that connection to the new broker has been established.
+        /// Third step of the transaction. Assumes that connection to the new broker has been established.
         /// During this stage, all existing interactions/evaluations are canceled and session is restarted using new connection.
         /// Canceling transaction during this stage will leave session in a broken stage, so manual restart is required (restarted session will be connected to the new broker).
         /// </summary>
-        Task CompleteSwitchingBrokerAsync();
+        Task CompleteSwitchingBrokerAsync(CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
This pattern is used in `RSessionProvider` several times - when any individual session fails on any step of switch or reconnection transaction, there is no reason for other sessions to continue, so we cancel them.