### PR TITLE
Fix drag drop of plot windows

### DIFF
--- a/src/R/Components/Impl/Plots/Implementation/View/DragSurface.cs
+++ b/src/R/Components/Impl/Plots/Implementation/View/DragSurface.cs
@@ -7,15 +7,25 @@ using System.Windows.Input;
 
 namespace Microsoft.R.Components.Plots.Implementation.View {
     internal class DragSurface {
-        private Point _lastMousedownPosition;
+        private Point? _lastMousedownPosition;
 
         public void MouseDown(MouseEventArgs e) {
             _lastMousedownPosition = e.GetPosition(null);
         }
 
+        public void MouseMove(MouseEventArgs e) {
+            if (e.MouseDevice.LeftButton == MouseButtonState.Released) {
+                _lastMousedownPosition = null;
+            }
+        }
+
+        public void MouseLeave(MouseEventArgs e) {
+            _lastMousedownPosition = null;
+        }
+
         public bool IsMouseMoveStartingDrag(MouseEventArgs e) {
-            if (e.MouseDevice.LeftButton == MouseButtonState.Pressed) {
-                var distance = e.GetPosition(null) - _lastMousedownPosition;
+            if (e.MouseDevice.LeftButton == MouseButtonState.Pressed && _lastMousedownPosition.HasValue) {
+                var distance = e.GetPosition(null) - _lastMousedownPosition.Value;
                 if (Math.Abs(distance.X) > SystemParameters.MinimumHorizontalDragDistance ||
                     Math.Abs(distance.Y) > SystemParameters.MinimumVerticalDragDistance) {
                     return true;

--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotDeviceControl.xaml
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotDeviceControl.xaml
@@ -35,6 +35,7 @@
                Source="{Binding Path=PlotImage}"
                Visibility="{Binding Path=PlotImage, Converter={x:Static rwpf:Converters.NullIsCollapsed}}"
                MouseMove="Image_MouseMove"
+               MouseLeave="Image_MouseLeave"
                PreviewMouseDown="Image_PreviewMouseDown"
                MouseLeftButtonUp="Image_MouseLeftButtonUp">
             <Image.ToolTip>

--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotDeviceControl.xaml.cs
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotDeviceControl.xaml.cs
@@ -128,7 +128,13 @@ namespace Microsoft.R.Components.Plots.Implementation.View {
                 var data = PlotClipboardData.Serialize(new PlotClipboardData(Model.Device.DeviceId, Model.Device.ActivePlot.PlotId, false));
                 var obj = new DataObject(PlotClipboardData.Format, data);
                 DragDrop.DoDragDrop(this, obj, DragDropEffects.Copy | DragDropEffects.Move);
+            } else {
+                _dragSurface.MouseMove(e);
             }
+        }
+
+        private void Image_MouseLeave(object sender, MouseEventArgs e) {
+            _dragSurface.MouseLeave(e);
         }
 
         private void Image_PreviewMouseDown(object sender, MouseButtonEventArgs e) {

--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml
@@ -43,6 +43,7 @@
                   SelectionMode="Single"
                   BorderThickness="0"
                   MouseMove="HistoryListView_MouseMove"
+                  MouseLeave="HistoryListView_MouseLeave"
                   PreviewMouseDown="HistoryListView_PreviewMouseDown"
                   MouseRightButtonUp="HistoryListView_MouseRightButtonUp">
             <ListView.GroupStyle>

--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml.cs
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml.cs
@@ -40,12 +40,20 @@ namespace Microsoft.R.Components.Plots.Implementation.View {
         }
 
         private void HistoryListView_MouseMove(object sender, MouseEventArgs e) {
-            if (_dragSurface.IsMouseMoveStartingDrag(e) && HistoryListView.SelectedItems.Count == 1) {
-                var entry = (IRPlotHistoryEntryViewModel)HistoryListView.SelectedItems[0];
-                var data = PlotClipboardData.Serialize(new PlotClipboardData(entry.Plot.ParentDevice.DeviceId, entry.Plot.PlotId, false));
-                var obj = new DataObject(PlotClipboardData.Format, data);
-                DragDrop.DoDragDrop(HistoryListView, obj, DragDropEffects.Copy | DragDropEffects.Move);
+            if (_dragSurface.IsMouseMoveStartingDrag(e)) {
+                if (HistoryListView.SelectedItems.Count == 1) {
+                    var entry = (IRPlotHistoryEntryViewModel)HistoryListView.SelectedItems[0];
+                    var data = PlotClipboardData.Serialize(new PlotClipboardData(entry.Plot.ParentDevice.DeviceId, entry.Plot.PlotId, false));
+                    var obj = new DataObject(PlotClipboardData.Format, data);
+                    DragDrop.DoDragDrop(HistoryListView, obj, DragDropEffects.Copy | DragDropEffects.Move);
+                }
+            } else {
+                _dragSurface.MouseMove(e);
             }
+        }
+
+        private void HistoryListView_MouseLeave(object sender, MouseEventArgs e) {
+            _dragSurface.MouseLeave(e);
         }
 
         private void HistoryListView_PreviewMouseDown(object sender, MouseButtonEventArgs e) {


### PR DESCRIPTION
It was being too aggressive, starting drag & drop operations when it shouldn't.  The most problematic of which is when it was starting a drag & drop of plot while VS was in toolwindow drag & drop mode.

Fixes https://github.com/Microsoft/RTVS/issues/2374
