### PR TITLE
Session management and reconnection (RTVS)

### DIFF
--- a/src/Host/Broker/Impl/Microsoft.R.Host.Broker.csproj
+++ b/src/Host/Broker/Impl/Microsoft.R.Host.Broker.csproj
@@ -87,7 +87,8 @@
     <Compile Include="Logging\FileLoggerProvider.cs" />
     <Compile Include="Logging\LoggingOptions.cs" />
     <Compile Include="NativeMethods.cs" />
-    <Compile Include="Pipes\IOwnedMessagePipeEnd.cs" />
+    <Compile Include="Pipes\HostDisconnectedException.cs" />
+    <Compile Include="Pipes\MessageParser.cs" />
     <Compile Include="Pipes\ProcessHelpers.cs" />
     <Compile Include="Pipes\WebSocketPipeAction.cs" />
     <Compile Include="RemoteUri\RemoteUriHelper.cs" />
@@ -105,6 +106,8 @@
     <Compile Include="Security\HttpBasicAuth\IBasicEvents.cs" />
     <Compile Include="Security\SecurityManager.cs" />
     <Compile Include="Security\Policies.cs" />
+    <Compile Include="Sessions\SessionStateChangedEventArgs.cs" />
+    <Compile Include="Sessions\SessionState.cs" />
     <Compile Include="Startup\StartupOptions.cs" />
     <Compile Include="Startup\Program.cs" />
     <Compile Include="Sessions\Session.cs" />

--- a/src/Host/Broker/Impl/Pipes/HostDisconnectedException.cs
+++ b/src/Host/Broker/Impl/Pipes/HostDisconnectedException.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.R.Host.Broker.Pipes {
+    public class HostDisconnectedException : Exception {
+        public HostDisconnectedException()
+            : this("Host end of the message pipe was disconnected") {
+        }
+
+        public HostDisconnectedException(string message)
+            : base(message) {
+        }
+    }
+}

--- a/src/Host/Broker/Impl/Pipes/IMessagePipeEnd.cs
+++ b/src/Host/Broker/Impl/Pipes/IMessagePipeEnd.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Broker.Pipes {
-    public interface IMessagePipeEnd {
+    public interface IMessagePipeEnd : IDisposable {
         Task<byte[]> ReadAsync(CancellationToken cancellationToken);
         void Write(byte[] message);
     }

--- a/src/Host/Broker/Impl/Pipes/MessageParser.cs
+++ b/src/Host/Broker/Impl/Pipes/MessageParser.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.R.Host.Broker.Pipes {
+    public static class MessageParser {
+        public static ulong GetId(byte[] message) =>
+            BitConverter.ToUInt64(message, 0);
+
+        public static ulong GetRequestId(byte[] message) =>
+            BitConverter.ToUInt64(message, 8);
+
+        public static bool IsNamed(byte[] message, byte[] name) {
+            int i = 16;
+
+            if (i + name.Length >= message.Length) {
+                return false;
+            }
+
+            foreach (var ch in name) {
+                if (message[i++] != ch) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Host/Broker/Impl/Pipes/WebSocketPipeAction.cs
+++ b/src/Host/Broker/Impl/Pipes/WebSocketPipeAction.cs
@@ -12,28 +12,42 @@ using Microsoft.R.Host.Broker.Sessions;
 
 namespace Microsoft.R.Host.Broker.Pipes {
     public class WebSocketPipeAction : IActionResult {
-        private readonly Session _session;
+        private readonly string _id;
+        private readonly IMessagePipeEnd _pipe;
 
-        public WebSocketPipeAction(Session session) {
-            _session = session;
+        public WebSocketPipeAction(string id, IMessagePipeEnd pipe) {
+            _id = id;
+            _pipe = pipe;
         }
 
         public async Task ExecuteResultAsync(ActionContext actionContext) {
-            var context = actionContext.HttpContext;
-            var httpResponse = context.Features.Get<IHttpResponseFeature>();
+            using (_pipe) {
+                var context = actionContext.HttpContext;
+                var httpResponse = context.Features.Get<IHttpResponseFeature>();
 
-            if (!context.WebSockets.IsWebSocketRequest) {
-                httpResponse.ReasonPhrase = "Websocket connection expected";
-                httpResponse.StatusCode = 401;
-                return;
-            }
+                if (!context.WebSockets.IsWebSocketRequest) {
+                    httpResponse.ReasonPhrase = "Websocket connection expected";
+                    httpResponse.StatusCode = 401;
+                    return;
+                }
 
-            var socket = await context.WebSockets.AcceptWebSocketAsync("Microsoft.R.Host");
+                using (var socket = await context.WebSockets.AcceptWebSocketAsync("Microsoft.R.Host")) {
+                    Task wsToPipe, pipeToWs, completed;
 
-            using (var pipe = _session.ConnectClient()) {
-                Task wsToPipe = WebSocketToPipeWorker(socket, pipe, context.RequestAborted);
-                Task pipeToWs = PipeToWebSocketWorker(socket, pipe, context.RequestAborted);
-                await Task.WhenAll(wsToPipe, pipeToWs);
+                    var cts = CancellationTokenSource.CreateLinkedTokenSource(context.RequestAborted);
+                    wsToPipe = WebSocketToPipeWorker(socket, _pipe, cts.Token);
+                    pipeToWs = PipeToWebSocketWorker(socket, _pipe, cts.Token);
+                    completed = await Task.WhenAny(wsToPipe, pipeToWs);
+
+                    if (completed == pipeToWs) {
+                        // If the pipe end is exhausted, tell the client that there's no more messages to follow,
+                        // so that it can gracefully disconnect from its end. 
+                        await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", context.RequestAborted);
+                    } else {
+                        // If the client disconnected, then just cancel any outstanding reads from the pipe.
+                        cts.Cancel();
+                    }
+                }
             }
         }
 
@@ -63,7 +77,13 @@ namespace Microsoft.R.Host.Broker.Pipes {
             while (true) {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var message = await pipe.ReadAsync(cancellationToken);
+                byte[] message;
+                try {
+                    message = await pipe.ReadAsync(cancellationToken);
+                } catch (HostDisconnectedException) {
+                    break;
+                }
+
                 await socket.SendAsync(new ArraySegment<byte>(message, 0, message.Length), WebSocketMessageType.Binary, true, cancellationToken);
             }
         }

--- a/src/Host/Broker/Impl/Sessions/SessionManager.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
@@ -23,12 +24,24 @@ namespace Microsoft.R.Host.Broker.Sessions {
         private readonly Dictionary<string, List<Session>> _sessions = new Dictionary<string, List<Session>>();
 
         [ImportingConstructor]
-        public SessionManager(InterpreterManager interpManager, IOptions<LoggingOptions> loggingOptions, ILogger<Process> hostOutputLogger, ILogger<MessagePipe> messageLogger, ILogger<Session> sessionLogger) {
+        public SessionManager(
+            InterpreterManager interpManager,
+            IOptions<LoggingOptions> loggingOptions,
+            ILogger<Session> sessionLogger,
+            ILogger<MessagePipe> messageLogger,
+            ILogger<Process> hostOutputLogger
+        ) {
             _interpManager = interpManager;
             _loggingOptions = loggingOptions.Value;
-            _hostOutputLogger = hostOutputLogger;
-            _messageLogger = messageLogger;
             _sessionLogger = sessionLogger;
+
+            if (_loggingOptions.LogPackets) {
+                _messageLogger = messageLogger;
+            }
+
+            if (_loggingOptions.LogHostOutput) {
+                _hostOutputLogger = hostOutputLogger;
+            }
         }
 
         public IEnumerable<Session> GetSessions(IIdentity user) {
@@ -45,9 +58,7 @@ namespace Microsoft.R.Host.Broker.Sessions {
             }
         }
 
-        public Session CreateSession(IIdentity user, string id, Interpreter interpreter, SecureString password, string profilePath, string commandLineArguments) {
-            Session session;
-
+        private List<Session> GetOrCreateSessionList(IIdentity user) {
             lock (_sessions) {
                 List<Session> userSessions;
                 _sessions.TryGetValue(user.Name, out userSessions);
@@ -55,13 +66,28 @@ namespace Microsoft.R.Host.Broker.Sessions {
                     _sessions[user.Name] = userSessions = new List<Session>();
                 }
 
+                return userSessions;
+            }
+        }
+
+        public Session CreateSession(IIdentity user, string id, Interpreter interpreter, SecureString password, string profilePath, string commandLineArguments) {
+            Session session;
+
+            lock (_sessions) {
+                var userSessions = GetOrCreateSessionList(user);
+
                 var oldSession = userSessions.FirstOrDefault(s => s.Id == id);
                 if (oldSession != null) {
-                    oldSession.KillHost();
-                    userSessions.Remove(oldSession);
+                    try {
+                        oldSession.KillHost();
+                    } catch (Exception) { }
+
+                    oldSession.State = SessionState.Terminated;
                 }
 
-                session = new Session(this, user, id, interpreter, commandLineArguments, _sessionLogger);
+                session = new Session(this, user, id, interpreter, commandLineArguments, _sessionLogger, _messageLogger);
+                session.StateChanged += Session_StateChanged;
+
                 userSessions.Add(session);
             }
 
@@ -69,10 +95,19 @@ namespace Microsoft.R.Host.Broker.Sessions {
                 password,
                 profilePath,
                 _loggingOptions.LogHostOutput ? _hostOutputLogger : null,
-                _loggingOptions.LogPackets ? _messageLogger : null,
                 _loggingOptions.LogPackets || _loggingOptions.LogHostOutput ? LogVerbosity.Traffic : LogVerbosity.Minimal);
 
             return session;
+        }
+
+        private void Session_StateChanged(object sender, SessionStateChangedEventArgs e) {
+            var session = (Session)sender;
+            if (e.NewState == SessionState.Terminated) {
+                lock (_sessions) {
+                    var userSessions = GetOrCreateSessionList(session.User);
+                    userSessions.Remove(session);
+                }
+            }
         }
     }
 }

--- a/src/Host/Broker/Impl/Sessions/SessionState.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionState.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-
-namespace Microsoft.R.Host.Broker.Pipes {
-    public interface IOwnedMessagePipeEnd : IMessagePipeEnd, IDisposable {
+namespace Microsoft.R.Host.Broker.Sessions {
+    public enum SessionState {
+        Running,
+        Dormant,
+        Terminated
     }
 }

--- a/src/Host/Broker/Impl/Sessions/SessionStateChangedEventArgs.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionStateChangedEventArgs.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.R.Host.Broker.Sessions {
+    public class SessionStateChangedEventArgs : EventArgs {
+        public SessionState OldState { get; }
+        public SessionState NewState { get; }
+
+        public SessionStateChangedEventArgs(SessionState oldState, SessionState newState) {
+            OldState = oldState;
+            NewState = newState;
+        }
+    }
+}

--- a/src/Host/Client/Impl/BrokerServices/ICredentialsProvider.cs
+++ b/src/Host/Client/Impl/BrokerServices/ICredentialsProvider.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.R.Host.Client.BrokerServices {
+    public interface ICredentialsProvider {
+        void UpdateCredentials();
+
+        void OnCredentialsValidated(bool isValid);
+    }
+}

--- a/src/Host/Client/Impl/BrokerServices/ISessionsWebService.cs
+++ b/src/Host/Client/Impl/BrokerServices/ISessionsWebService.cs
@@ -10,5 +10,6 @@ namespace Microsoft.R.Host.Client.BrokerServices {
     public interface ISessionsWebService {
         Task<IEnumerable<SessionInfo>> GetAsync(CancellationToken cancellationToken = default(CancellationToken));
         Task<SessionInfo> PutAsync(string id, SessionCreateRequest request, CancellationToken cancellationToken = default(CancellationToken));
+        Task DeleteAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Host/Client/Impl/BrokerServices/SessionsWebService.cs
+++ b/src/Host/Client/Impl/BrokerServices/SessionsWebService.cs
@@ -10,8 +10,8 @@ using Microsoft.R.Host.Protocol;
 
 namespace Microsoft.R.Host.Client.BrokerServices {
     public class SessionsWebService : WebService, ISessionsWebService {
-        public SessionsWebService(HttpClient httpClient)
-            : base(httpClient) {
+        public SessionsWebService(HttpClient httpClient, ICredentialsProvider credentialsProvider)
+            : base(httpClient, credentialsProvider) {
         }
 
         private static readonly Uri getUri = new Uri("/sessions", UriKind.Relative);
@@ -19,9 +19,12 @@ namespace Microsoft.R.Host.Client.BrokerServices {
         public Task<IEnumerable<SessionInfo>> GetAsync(CancellationToken cancellationToken = default(CancellationToken)) =>
             HttpGetAsync<IEnumerable<SessionInfo>>(getUri, cancellationToken);
 
-        private static readonly UriTemplate putUri = new UriTemplate("/sessions/{name}");
+        private static readonly UriTemplate sessionUri = new UriTemplate("/sessions/{name}");
 
         public Task<SessionInfo> PutAsync(string id, SessionCreateRequest request, CancellationToken cancellationToken = default(CancellationToken)) =>
-            HttpPutAsync<SessionCreateRequest, SessionInfo>(putUri, request, cancellationToken, id);
+            HttpPutAsync<SessionCreateRequest, SessionInfo>(sessionUri, request, cancellationToken, id);
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default(CancellationToken)) =>
+            HttpDeleteAsync(sessionUri, cancellationToken, id);
     }
 }

--- a/src/Host/Client/Impl/BrokerServices/WebService.cs
+++ b/src/Host/Client/Impl/BrokerServices/WebService.cs
@@ -15,37 +15,70 @@ using Newtonsoft.Json;
 
 namespace Microsoft.R.Host.Client.BrokerServices {
     public class WebService {
+        private readonly ICredentialsProvider _credentialsProvider;
+
         protected HttpClient HttpClient { get; }
 
-        public WebService(HttpClient httpClient) {
+        public WebService(HttpClient httpClient, ICredentialsProvider credentialsProvider) {
             HttpClient = httpClient;
+            _credentialsProvider = credentialsProvider;
         }
 
         private static HttpResponseMessage EnsureSuccessStatusCode(HttpResponseMessage response) {
-            if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden) {
-                throw new UnauthorizedAccessException();
-            }
+            try {
+                if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden) {
+                    throw new UnauthorizedAccessException();
+                }
 
-            IEnumerable<string> values;
-            if(response.Headers.TryGetValues(CustomHttpHeaders.RTVSApiError, out values)) {
-                var s = values.FirstOrDefault();
-                if (s != null) {
-                    BrokerApiError apiError;
-                    if (Enum.TryParse(s, out apiError)) {
-                        response.Headers.TryGetValues(CustomHttpHeaders.RTVSBrokerException, out values);
-                        throw new BrokerApiErrorException(apiError, values?.FirstOrDefault());
-                    } else {
-                        throw new ProtocolViolationException("Unknown broker API error");
+                IEnumerable<string> values;
+                if (response.Headers.TryGetValues(CustomHttpHeaders.RTVSApiError, out values)) {
+                    var s = values.FirstOrDefault();
+                    if (s != null) {
+                        BrokerApiError apiError;
+                        if (Enum.TryParse(s, out apiError)) {
+                            response.Headers.TryGetValues(CustomHttpHeaders.RTVSBrokerException, out values);
+                            throw new BrokerApiErrorException(apiError, values?.FirstOrDefault());
+                        } else {
+                            throw new ProtocolViolationException("Unknown broker API error");
+                        }
+                    }
+                }
+
+                return response.EnsureSuccessStatusCode();
+            } catch {
+                response.Dispose();
+                throw;
+            }
+        }
+
+        private async Task<T> RepeatUntilAuthenticatedAsync<T>(Func<Task<T>> action) {
+            while (true) {
+                bool? isValidCredentials = null;
+                try {
+                    _credentialsProvider.UpdateCredentials();
+                    isValidCredentials = true;
+                    return await action();
+                } catch (UnauthorizedAccessException) {
+                    isValidCredentials = false;
+                    continue;
+                } finally {
+                    if (isValidCredentials != null) {
+                        _credentialsProvider.OnCredentialsValidated(isValidCredentials.Value);
                     }
                 }
             }
-
-            return response.EnsureSuccessStatusCode();
         }
 
+        private Task RepeatUntilAuthenticatedAsync(Func<Task> action) =>
+            RepeatUntilAuthenticatedAsync(async () => {
+                await action();
+                return false;
+            });
+
         public async Task<TResponse> HttpGetAsync<TResponse>(Uri uri, CancellationToken cancellationToken = default(CancellationToken)) {
-            var resonse = await HttpClient.GetAsync(uri, cancellationToken);
-            return JsonConvert.DeserializeObject<TResponse>(await resonse.Content.ReadAsStringAsync());
+            using (var response = await RepeatUntilAuthenticatedAsync(async () => EnsureSuccessStatusCode(await HttpClient.GetAsync(uri, cancellationToken)))) {
+                return JsonConvert.DeserializeObject<TResponse>(await response.Content.ReadAsStringAsync());
+            }
         }
 
         public Task<TResponse> HttpGetAsync<TResponse>(UriTemplate uriTemplate, CancellationToken cancellationToken = default(CancellationToken), params object[] args) =>
@@ -53,8 +86,11 @@ namespace Microsoft.R.Host.Client.BrokerServices {
 
         public async Task HttpPutAsync<TRequest>(Uri uri, TRequest request) {
             var requestBody = JsonConvert.SerializeObject(request);
-            var content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-            EnsureSuccessStatusCode(await HttpClient.PutAsync(uri, content));
+
+            await RepeatUntilAuthenticatedAsync(async () => {
+                var content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+                EnsureSuccessStatusCode(await HttpClient.PutAsync(uri, content)).Dispose();
+            });
         }
 
         public Task HttpPutAsync<TRequest>(UriTemplate uriTemplate, TRequest request, params object[] args) =>
@@ -62,24 +98,36 @@ namespace Microsoft.R.Host.Client.BrokerServices {
 
         public async Task<TResponse> HttpPutAsync<TRequest, TResponse>(Uri uri, TRequest request, CancellationToken cancellationToken = default(CancellationToken)) {
             var requestBody = JsonConvert.SerializeObject(request);
-            var content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-            var response = EnsureSuccessStatusCode(await HttpClient.PutAsync(uri, content, cancellationToken));
-            var responseBody = await response.Content.ReadAsStringAsync();
-            try {
-                return JsonConvert.DeserializeObject<TResponse>(responseBody);
-            } catch(JsonSerializationException ex) {
-                throw new ProtocolViolationException(ex.Message);
-            }
-        }
 
-        public async Task<Stream> HttpPostAsync(Uri uri, Stream request) {
-            var content = new StreamContent(request);
-            var response = (await HttpClient.PostAsync(uri, content)).EnsureSuccessStatusCode();
-            return await response.Content.ReadAsStreamAsync();
+            using (var response = await RepeatUntilAuthenticatedAsync(async () => {
+                var content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+                return EnsureSuccessStatusCode(await HttpClient.PutAsync(uri, content, cancellationToken));
+            })) {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                try {
+                    return JsonConvert.DeserializeObject<TResponse>(responseBody);
+                } catch (JsonSerializationException ex) {
+                    throw new ProtocolViolationException(ex.Message);
+                }
+            }
         }
 
         public Task<TResponse> HttpPutAsync<TRequest, TResponse>(UriTemplate uriTemplate, TRequest request, CancellationToken cancellationToken = default(CancellationToken), params object[] args) =>
             HttpPutAsync<TRequest, TResponse>(MakeUri(uriTemplate, args), request, cancellationToken);
+
+        public async Task<Stream> HttpPostAsync(Uri uri, Stream request) {
+            var content = new StreamContent(request);
+
+            using (var response = await RepeatUntilAuthenticatedAsync(async () => EnsureSuccessStatusCode(await HttpClient.PostAsync(uri, content)))) {
+                return await response.Content.ReadAsStreamAsync();
+            }
+        }
+
+        public Task HttpDeleteAsync(Uri uri, CancellationToken cancellationToken = default(CancellationToken)) =>
+            RepeatUntilAuthenticatedAsync(async () => EnsureSuccessStatusCode(await HttpClient.DeleteAsync(uri, cancellationToken)).Dispose());
+        
+        public Task HttpDeleteAsync(UriTemplate uriTemplate, CancellationToken cancellationToken = default(CancellationToken), params object[] args) =>
+            HttpDeleteAsync(MakeUri(uriTemplate, args), cancellationToken);
 
         private Uri MakeUri(UriTemplate uriTemplate, params object[] args) =>
             uriTemplate.BindByPosition(HttpClient.BaseAddress, args.Select(x => x.ToString()).ToArray());

--- a/src/Host/Client/Impl/Definitions/IMessageTransport.cs
+++ b/src/Host/Client/Impl/Definitions/IMessageTransport.cs
@@ -8,7 +8,8 @@ using Microsoft.R.Host.Protocol;
 
 namespace Microsoft.R.Host.Client {
     public interface IMessageTransport {
-        Task SendAsync(Message message, CancellationToken ct = default(CancellationToken));
-        Task<Message> ReceiveAsync(CancellationToken ct = default(CancellationToken));
+        Task CloseAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task SendAsync(Message message, CancellationToken cancellationToken = default(CancellationToken));
+        Task<Message> ReceiveAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Host/Client/Impl/Definitions/IRCallbacks.cs
+++ b/src/Host/Client/Impl/Definitions/IRCallbacks.cs
@@ -12,6 +12,8 @@ namespace Microsoft.R.Host.Client {
         Task Connected(string rVersion);
         Task Disconnected();
 
+        Task Shutdown(bool rDataSaved);
+
         /// <summary>
         /// Called as a result of R calling R API 'YesNoCancel' callback
         /// </summary>

--- a/src/Host/Client/Impl/Host/BrokerClientProxy.cs
+++ b/src/Host/Client/Impl/Host/BrokerClientProxy.cs
@@ -39,6 +39,9 @@ namespace Microsoft.R.Host.Client.Host {
             }
         }
 
+        public Task TerminateSessionAsync(string name, CancellationToken cancellationToken = new CancellationToken()) =>
+            _broker.TerminateSessionAsync(name, cancellationToken);
+
         public string HandleUrl(string url, CancellationToken ct) => _broker.HandleUrl(url, ct);
     }
 }

--- a/src/Host/Client/Impl/Host/IBrokerClient.cs
+++ b/src/Host/Client/Impl/Host/IBrokerClient.cs
@@ -15,6 +15,7 @@ namespace Microsoft.R.Host.Client.Host {
 
         Task PingAsync();
         Task<RHost> ConnectAsync(string name, IRCallbacks callbacks, string rCommandLineArguments = null, int timeout = 3000, CancellationToken cancellationToken = default(CancellationToken));
+        Task TerminateSessionAsync(string name, CancellationToken cancellationToken = default(CancellationToken));
         string HandleUrl(string url, CancellationToken ct);
     }
 }

--- a/src/Host/Client/Impl/Host/NullBrokerClient.cs
+++ b/src/Host/Client/Impl/Host/NullBrokerClient.cs
@@ -21,6 +21,8 @@ namespace Microsoft.R.Host.Client.Host {
 
         public Task<RHost> ConnectAsync(string name, IRCallbacks callbacks, string rCommandLineArguments = null, int timeout = 3000, CancellationToken cancellationToken = new CancellationToken()) => Result;
 
+        public Task TerminateSessionAsync(string name, CancellationToken cancellationToken = new CancellationToken()) => Result;
+
         public void Dispose() { }
 
         public string HandleUrl(string url, CancellationToken ct) => url;

--- a/src/Host/Client/Impl/Host/NullRCallbacks.cs
+++ b/src/Host/Client/Impl/Host/NullRCallbacks.cs
@@ -21,6 +21,7 @@ namespace Microsoft.R.Host.Client.Host {
 
         public Task Connected(string rVersion) => Task.CompletedTask;
         public Task Disconnected() => Task.CompletedTask;
+        public Task Shutdown(bool savedRData) => Task.CompletedTask;
         public Task<YesNoCancel> YesNoCancel(IReadOnlyList<IRContext> contexts, string s, CancellationToken ct) => Task.FromResult(Cancel);
         public Task<MessageButtons> ShowDialog(IReadOnlyList<IRContext> contexts, string s, MessageButtons buttons, CancellationToken ct) => Task.FromResult(MessageButtons.Cancel);
         public Task WriteConsoleEx(string buf, OutputType otype, CancellationToken ct) => Task.CompletedTask;

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -55,7 +55,7 @@ namespace Microsoft.R.Host.Client {
         }
 
         public void Dispose() {
-            _cts.Cancel();
+            DisconnectAsync().DoNotWait();
         }
 
         public void FlushLog() {
@@ -80,7 +80,10 @@ namespace Microsoft.R.Host.Client {
                 throw new OperationCanceledException(new OperationCanceledException().Message, ex);
             }
 
-            _log.Response(message.ToString(), _rLoopDepth);
+            if (message != null) {
+                _log.Response(message.ToString(), _rLoopDepth);
+            }
+
             return message;
         }
 
@@ -355,7 +358,7 @@ namespace Microsoft.R.Host.Client {
                 _cancelAllCts.Cancel();
 
                 try {
-                    await NotifyAsync("!/", CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken).Token, null);
+                    await NotifyAsync("!//", CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken).Token);
                 } catch (OperationCanceledException) {
                     return;
                 } catch (MessageTransportException) {
@@ -368,9 +371,12 @@ namespace Microsoft.R.Host.Client {
             }
         }
 
+        public Task RequestShutdownAsync(bool saveRData) =>
+            NotifyAsync("!Shutdown", _cts.Token, saveRData);
+
         public async Task DisconnectAsync() {
             if (_runTask == null) {
-                throw new InvalidOperationException("Not connected to host.");
+                return;
             }
 
             await TaskUtilities.SwitchToBackgroundThread();
@@ -384,7 +390,7 @@ namespace Microsoft.R.Host.Client {
             try {
                 // Don't use _cts, since it's already cancelled. We want to try to send this message in
                 // any case, and we'll catch MessageTransportException if no-one is on the other end anymore.
-                await NotifyAsync("!End", new CancellationToken());
+                await _transport.CloseAsync();
             } catch (OperationCanceledException) {
             } catch (MessageTransportException) {
             }
@@ -405,7 +411,9 @@ namespace Microsoft.R.Host.Client {
                 _log.EnterRLoop(_rLoopDepth++);
                 while (!ct.IsCancellationRequested) {
                     var message = await ReceiveMessageAsync(ct);
-                    if (message.IsResponse) {
+                    if (message == null) {
+                        return null;
+                    } else if (message.IsResponse) {
                         Request request;
                         if (!_requests.TryRemove(message.RequestId, out request)) {
                             throw ProtocolError($"Mismatched response - no request with such ID:", message);
@@ -420,7 +428,9 @@ namespace Microsoft.R.Host.Client {
                     try {
                         switch (message.Name) {
                             case "!End":
-                                return null;
+                                message.ExpectArguments(1);
+                                await _callbacks.Shutdown(message.GetBoolean(0, "rdataSaved"));
+                                break;
 
                             case "!CanceledAll":
                                 CancelAll();
@@ -566,7 +576,7 @@ namespace Microsoft.R.Host.Client {
 
             try {
                 var message = await ReceiveMessageAsync(ct);
-                if (!message.IsNotification || message.Name != "!Microsoft.R.Host") {
+                if (message == null || !message.IsNotification || message.Name != "!Microsoft.R.Host") {
                     throw ProtocolError($"Microsoft.R.Host handshake expected:", message);
                 }
 
@@ -583,6 +593,9 @@ namespace Microsoft.R.Host.Client {
                     throw ProtocolError($"Unexpected host response message:", message);
                 }
             } finally {
+                // Signal cancellation to any callbacks that haven't returned yet.
+                _cts.Cancel();
+
                 await _callbacks.Disconnected();
             }
         }

--- a/src/Host/Client/Impl/Host/RHostDisconnectedException.cs
+++ b/src/Host/Client/Impl/Host/RHostDisconnectedException.cs
@@ -40,6 +40,8 @@ namespace Microsoft.R.Host.Client.Host {
                         return Resources.Error_UnableToStartHostException.FormatInvariant(ex.Message);
                     }
                     return Resources.Error_UnknownError;
+                case BrokerApiError.PipeAlreadyConnected:
+                    return "This session already has an active client connection";
             }
 
             Debug.Fail("No localized resources for broker API error" + ex.ApiError.ToString());

--- a/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
+++ b/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
@@ -46,6 +46,7 @@
     <Compile Include="BrokerServices\BrokerApiErrorException.cs" />
     <Compile Include="Blobs\RBlobStream.cs" />
     <Compile Include="BrokerServices\IRemoteUriWebService.cs" />
+    <Compile Include="BrokerServices\ICredentialsProvider.cs" />
     <Compile Include="BrokerServices\ISessionsWebService.cs" />
     <Compile Include="BrokerServices\RemoteUriWebService.cs" />
     <Compile Include="BrokerServices\WebServer.cs" />

--- a/src/Host/Client/Impl/Program.cs
+++ b/src/Host/Client/Impl/Program.cs
@@ -47,6 +47,10 @@ namespace Microsoft.R.Host.Client {
             return Task.CompletedTask;
         }
 
+        public Task Shutdown(bool savedRData) {
+            return Task.CompletedTask;
+        }
+
         public async Task<string> ReadConsole(IReadOnlyList<IRContext> contexts, string prompt, int len, bool addToHistory, CancellationToken ct) {
             return (await ReadLineAsync(prompt, ct)) + "\n";
         }

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -288,45 +288,26 @@ namespace Microsoft.R.Host.Client.Session {
 
             ResetInitializationTcs();
 
-            Task<IRSessionInteraction> requestTask;
+            // Try graceful shutdown with q() first.
             try {
-                requestTask = BeginInteractionAsync(false);
-                await Task.WhenAny(requestTask, Task.Delay(200)).Unwrap();
-            } catch (RHostDisconnectedException) {
-                // BeginInteractionAsync will fail with RHostDisconnectedException if RHost isn't running. Nothing to stop.
-                return;
-            }
+                await Task.WhenAny(_hostRunTask, this.QuitAsync(), Task.Delay(500)).Unwrap();
+            } catch (Exception) { }
 
             if (_hostRunTask.IsCompleted) {
-                requestTask
-                    .ContinueWith(t => t.Result.Dispose(), TaskContinuationOptions.OnlyOnRanToCompletion)
-                    .DoNotWait();
                 return;
             }
 
-            if (requestTask.Status == TaskStatus.RanToCompletion) {
-                using (var inter = await requestTask) {
-                    // Try graceful shutdown with q() first.
-                    try {
-                        await Task.WhenAny(_hostRunTask, inter.QuitAsync(), Task.Delay(500)).Unwrap();
-                    } catch (Exception) { }
+            // If it didn't work, tell the broker to forcibly terminate the host process. 
+            try {
+                await BrokerClient.TerminateSessionAsync(_startupInfo.Name);
+            } catch (Exception) { }
 
-                    if (_hostRunTask.IsCompleted) {
-                        return;
-                    }
-
-                    // If that doesn't work, then try sending the disconnect packet to the host -
-                    // it will call R_Suicide, which is not graceful, but at least it's cooperative.
-                    await Task.WhenAny(_host.DisconnectAsync(), Task.Delay(500)).Unwrap();
-
-                    if (_hostRunTask.IsCompleted) {
-                        return;
-                    }
-                }
+            if (_hostRunTask.IsCompleted) {
+                return;
             }
 
-            // If nothing worked, then just kill the host process.
-            _host?.Dispose();
+            // If nothing worked, then just disconnect.
+            await _host?.DisconnectAsync();
             await _hostRunTask;
         }
 
@@ -398,8 +379,17 @@ namespace Microsoft.R.Host.Client.Session {
             }
         }
 
+        private const int rtvsPackageVersion = 1;
+
         private static async Task LoadRtvsPackage(IRSessionEvaluation eval, string libPath) {
-            await eval.ExecuteAsync(Invariant($"base::loadNamespace('rtvs', lib.loc = {libPath.ToRStringLiteral()})"));
+            await eval.ExecuteAsync(Invariant($@"
+if (!base::isNamespaceLoaded('rtvs')) {{
+    base::loadNamespace('rtvs', lib.loc = {libPath.ToRStringLiteral()})
+}}
+if (rtvs:::version != {rtvsPackageVersion}) {{
+    warning('This R session was created using an incompatible version of RTVS, and may misbehave or crash when used with this version. Click ""Reset"" to replace it with a new clean session.');
+}}
+"));
         }
 
         public void FlushLog() {
@@ -426,6 +416,10 @@ namespace Microsoft.R.Host.Client.Session {
 
             ClearPendingRequests(exception);
             lockToken.Reset();
+        }
+
+        Task IRCallbacks.Shutdown(bool rDataSaved) {
+            return Task.CompletedTask;
         }
 
         private void ClearPendingRequests(OperationCanceledException exception) {
@@ -484,7 +478,7 @@ namespace Microsoft.R.Host.Client.Session {
             evaluationCts.Cancel();
             await evaluationTask;
 
-            AfterRequest?.Invoke(this, new RAfterRequestEventArgs(contexts, prompt, consoleInput, addToHistory, _currentRequestSource.IsVisible));
+            AfterRequest?.Invoke(this, new RAfterRequestEventArgs(contexts, prompt, consoleInput, addToHistory, currentRequest?.IsVisible ?? false));
 
             return consoleInput;
         }

--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -14,6 +14,9 @@ namespace Microsoft.R.Host.Client.Session {
             return evaluation.ExecuteAsync($"options(width=as.integer({width}))\n");
         }
 
+        public static Task QuitAsync(this IRExpressionEvaluator eval) =>
+            eval.ExecuteAsync("q()", REvaluationKind.Normal);
+
         public static async Task<string> GetRUserDirectoryAsync(this IRExpressionEvaluator evaluation) {
             var result = await evaluation.EvaluateAsync<string>("Sys.getenv('R_USER')", REvaluationKind.Normal);
             return result.Replace('/', '\\');

--- a/src/Host/Client/Impl/Session/RSessionInteractionCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionInteractionCommands.cs
@@ -6,8 +6,5 @@ using Microsoft.R.Host.Client;
 
 namespace Microsoft.R.Host.Client.Session {
     public static class RSessionInteractionCommands {
-        public static Task QuitAsync(this IRSessionInteraction interaction) {
-            return interaction.RespondAsync("q()\n");
-        }
     }
 }

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
+version <- 1
+
 call_embedded <- function(name, ...) {
   .Call(paste0('Microsoft.R.Host::Call.', name, collapse = ''), ..., PACKAGE = '(embedding)')
 }

--- a/src/Host/Protocol/Impl/BrokerApiError.cs
+++ b/src/Host/Protocol/Impl/BrokerApiError.cs
@@ -5,6 +5,8 @@ namespace Microsoft.R.Host.Protocol {
     public enum BrokerApiError {
         NoRInterpreters = 1,
         InterpreterNotFound,
-        UnableToStartRHost
+        UnableToStartRHost,
+        UnableToTerminateRHost,
+        PipeAlreadyConnected,
     }
 }

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
@@ -209,7 +209,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
         private void SessionOnAfterRequest(object sender, RAfterRequestEventArgs e) {
             if (_evaluatorRequest.Count == 0 && e.AddToHistory && e.IsVisible) {
                 _coreShell.DispatchOnUIThread(() => {
-                    if (CurrentWindow == null) {
+                    if (CurrentWindow == null || CurrentWindow.IsResetting) {
                         return;
                     }
 


### PR DESCRIPTION
When connecting to a host, query broker for any existing session with the same ID, and use it when available.

Add basic version checking for rtvs package when (re)connecting, to ensure that a compatible package version is used.

Fix REPL Reset not hard-killing the host process if q() doesn't worl.

Fix session not properly recorded as terminated when host process goes down.

Fix cancellation handling when recording requests without responses to replay during a future reconnect.

Fix websocket tunnel lifetime issues:
- close tunnel when host process goes down;
- use cooperative closure, so that the client is immediately aware of it;
- properly close the tunnel from VS end in all termination scenarios.

Refactor HTTP credentials handling to make it reusable for different endpoints.