### PR TITLE
Plot window clear on session connect, context menu via keyboard

### DIFF
--- a/src/Package/Impl/DataInspect/VariableView.xaml.cs
+++ b/src/Package/Impl/DataInspect/VariableView.xaml.cs
@@ -174,12 +174,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                     return;
                 case Key.System:
                     if (e.SystemKey == Key.F10 && (Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift) {
-                        var focus = Keyboard.FocusedElement as FrameworkElement;
-                        if (focus != null) {
-                            var pt = focus.PointToScreen(new Point(1, 1));
-                            _shell.ShowContextMenu(
-                                new CommandID(RGuidList.RCmdSetGuid, (int)RContextMenuId.VariableExplorer), (int)pt.X, (int)pt.Y, this);
-                        }
+                        ShowContextMenu();
                     }
                     break;
                 case Key.C:
@@ -196,6 +191,15 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             base.OnPreviewKeyDown(e);
         }
 
+        private void ShowContextMenu() {
+            var focus = Keyboard.FocusedElement as FrameworkElement;
+            if (focus != null) {
+                var pt = focus.PointToScreen(new Point(1, 1));
+                _shell.ShowContextMenu(
+                    new CommandID(RGuidList.RCmdSetGuid, (int)RContextMenuId.VariableExplorer), (int)pt.X, (int)pt.Y, this);
+            }
+        }
+
         protected override void OnPreviewKeyUp(KeyEventArgs e) {
             // Prevent Enter from being passed to WPF control
             // when user hits it in the context menu
@@ -206,6 +210,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                 return;
             } else if (e.Key == Key.Delete || e.Key == Key.Back) {
                 DeleteCurrentVariableAsync().DoNotWait();
+            } else if (e.Key == Key.Apps) {
+                ShowContextMenu();
             }
             base.OnPreviewKeyUp(e);
         }

--- a/src/R/Components/Impl/Microsoft.R.Components.csproj
+++ b/src/R/Components/Impl/Microsoft.R.Components.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Plots\Implementation\View\DesignTime\DesignTimeRPlotHistoryEntryViewModel.cs" />
     <Compile Include="Plots\Implementation\View\DesignTime\DesignTimeRPlotHistoryViewModel.cs" />
     <Compile Include="Plots\Implementation\View\DragSurface.cs" />
+    <Compile Include="Plots\Implementation\View\PointEventArgs.cs" />
     <Compile Include="Plots\IRPlot.cs" />
     <Compile Include="Plots\IRPlotDevice.cs" />
     <Compile Include="Plots\RPlotEventArgs.cs" />

--- a/src/R/Components/Impl/Plots/Implementation/RPlotDeviceVisualComponent.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotDeviceVisualComponent.cs
@@ -6,14 +6,12 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Input;
 using Microsoft.Common.Core.Disposables;
 using Microsoft.Common.Core.Shell;
 using Microsoft.R.Components.Controller;
 using Microsoft.R.Components.Plots.Implementation.View;
 using Microsoft.R.Components.Plots.Implementation.ViewModel;
 using Microsoft.R.Components.Plots.ViewModel;
-using Microsoft.R.Components.Settings;
 using Microsoft.R.Components.View;
 using Microsoft.R.Host.Client;
 
@@ -153,8 +151,8 @@ namespace Microsoft.R.Components.Plots.Implementation {
             _disposableBag.TryDispose();
         }
 
-        private void Control_ContextMenuRequested(object sender, System.Windows.Input.MouseButtonEventArgs e) {
-            Container.ShowContextMenu(RPlotCommandIds.PlotDeviceContextMenu, GetPosition(e, (FrameworkElement)sender));
+        private void Control_ContextMenuRequested(object sender, PointEventArgs e) {
+            Container.ShowContextMenu(RPlotCommandIds.PlotDeviceContextMenu, e.Point);
         }
 
         private void ViewModel_PlotChanged(object sender, EventArgs e) {
@@ -191,20 +189,6 @@ namespace Microsoft.R.Components.Plots.Implementation {
 
         private void UpdateStatus() {
             Container.StatusText = _viewModel.LocatorMode ? Resources.Plots_StatusLocatorActive : string.Empty;
-        }
-
-        private static Point GetPosition(InputEventArgs e, FrameworkElement fe) {
-            var mouseEventArgs = e as MouseEventArgs;
-            if (mouseEventArgs != null) {
-                return mouseEventArgs.GetPosition(fe);
-            }
-
-            var touchEventArgs = e as TouchEventArgs;
-            if (touchEventArgs != null) {
-                return touchEventArgs.GetTouchPoint(fe).Position;
-            }
-
-            return new Point(0, 0);
         }
     }
 }

--- a/src/R/Components/Impl/Plots/Implementation/RPlotHistoryVisualComponent.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotHistoryVisualComponent.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Windows;
-using System.Windows.Input;
 using Microsoft.Common.Core.Disposables;
 using Microsoft.Common.Core.Shell;
 using Microsoft.R.Components.Controller;
@@ -91,22 +90,8 @@ namespace Microsoft.R.Components.Plots.Implementation {
             }
         }
 
-        private void Control_ContextMenuRequested(object sender, MouseButtonEventArgs e) {
-            Container.ShowContextMenu(RPlotCommandIds.PlotHistoryContextMenu, GetPosition(e, (FrameworkElement)sender));
-        }
-
-        private static Point GetPosition(InputEventArgs e, FrameworkElement fe) {
-            var mouseEventArgs = e as MouseEventArgs;
-            if (mouseEventArgs != null) {
-                return mouseEventArgs.GetPosition(fe);
-            }
-
-            var touchEventArgs = e as TouchEventArgs;
-            if (touchEventArgs != null) {
-                return touchEventArgs.GetTouchPoint(fe).Position;
-            }
-
-            return new Point(0, 0);
+        private void Control_ContextMenuRequested(object sender, PointEventArgs e) {
+            Container.ShowContextMenu(RPlotCommandIds.PlotHistoryContextMenu, e.Point);
         }
 
         public void DecreaseThumbnailSize() {

--- a/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
@@ -37,10 +37,10 @@ namespace Microsoft.R.Components.Plots.Implementation {
             _fileSystem = fileSystem;
 
             _disposableBag = DisposableBag.Create<RPlotManager>()
-                .Add(() => interactiveWorkflow.RSession.Disconnected += RSession_Disconnected)
+                .Add(() => interactiveWorkflow.RSession.Connected -= RSession_Connected)
                 .Add(() => interactiveWorkflow.RSession.Mutated -= RSession_Mutated);
 
-            interactiveWorkflow.RSession.Disconnected += RSession_Disconnected;
+            interactiveWorkflow.RSession.Connected += RSession_Connected;
             interactiveWorkflow.RSession.Mutated += RSession_Mutated;
         }
 
@@ -488,11 +488,11 @@ namespace Microsoft.R.Components.Plots.Implementation {
             device.DeviceNum = num ?? 0;
         }
 
-        private void RSession_Disconnected(object sender, EventArgs e) {
-            RSessionDisconnectedAsync().DoNotWait();
+        private void RSession_Connected(object sender, RConnectedEventArgs e) {
+            RSessionConnectedAsync().DoNotWait();
         }
 
-        private async Task RSessionDisconnectedAsync() {
+        private async Task RSessionConnectedAsync() {
             await InteractiveWorkflow.Shell.SwitchToMainThreadAsync();
 
             RemoveAllDevices();

--- a/src/R/Components/Impl/Plots/Implementation/View/PointEventArgs.cs
+++ b/src/R/Components/Impl/Plots/Implementation/View/PointEventArgs.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Windows;
+
+namespace Microsoft.R.Components.Plots.Implementation.View {
+    public class PointEventArgs : EventArgs {
+        public Point Point { get; }
+
+        public PointEventArgs(Point point) {
+            Point = point;
+        }
+    }
+}

--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotDeviceControl.xaml.cs
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotDeviceControl.xaml.cs
@@ -27,7 +27,7 @@ namespace Microsoft.R.Components.Plots.Implementation.View {
 
         public IRPlotDeviceViewModel Model => DataContext as IRPlotDeviceViewModel;
 
-        public event EventHandler<MouseButtonEventArgs> ContextMenuRequested;
+        public event EventHandler<PointEventArgs> ContextMenuRequested;
 
         public RPlotDeviceControl() {
             InitializeComponent();
@@ -142,8 +142,8 @@ namespace Microsoft.R.Components.Plots.Implementation.View {
         }
 
         private void UserControl_MouseRightButtonUp(object sender, MouseButtonEventArgs e) {
-            // TODO: also support keyboard (Shift+F10 or context menu key)
-            ContextMenuRequested?.Invoke(sender, e);
+            var point = e.GetPosition(this);
+            ContextMenuRequested?.Invoke(this, new PointEventArgs(point));
         }
     }
 }

--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml.cs
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml.cs
@@ -17,7 +17,11 @@ namespace Microsoft.R.Components.Plots.Implementation.View {
         private IRPlotHistoryViewModel ViewModel => (IRPlotHistoryViewModel)DataContext;
         private DragSurface _dragSurface = new DragSurface();
 
-        public event EventHandler<MouseButtonEventArgs> ContextMenuRequested;
+        /// <summary>
+        /// Show context menu at the specified point, which is relative
+        /// to the visual component control (ie. this control).
+        /// </summary>
+        public event EventHandler<PointEventArgs> ContextMenuRequested;
 
 
         public RPlotHistoryControl() {
@@ -33,6 +37,11 @@ namespace Microsoft.R.Components.Plots.Implementation.View {
             if (e.Key == Key.Enter) {
                 var entry = (IRPlotHistoryEntryViewModel)(((ListViewItem)sender).Content);
                 ActivatePlot(entry);
+            } else if (e.Key == Key.Apps || (e.SystemKey == Key.F10 && (Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift)) {
+                ListViewItem item = (ListViewItem)sender;
+                var point = item.TranslatePoint(new Point(1, 1), this);
+                ContextMenuRequested?.Invoke(this, new PointEventArgs(point));
+                e.Handled = true;
             }
         }
 
@@ -62,8 +71,8 @@ namespace Microsoft.R.Components.Plots.Implementation.View {
         }
 
         private void HistoryListView_MouseRightButtonUp(object sender, MouseButtonEventArgs e) {
-            // TODO: also support keyboard (Shift+F10 or context menu key)
-            ContextMenuRequested?.Invoke(sender, e);
+            var point = e.GetPosition(this);
+            ContextMenuRequested?.Invoke(this, new PointEventArgs(point));
         }
 
         private static ListViewItem GetSourceListViewItem(DependencyObject obj) {


### PR DESCRIPTION
Partial fix for #2410 (makes keyboard context menu work plot history window, but not plot device window)
Fixes #2403 
Also makes the context menu key work in variable explorer (used to be just shift-f10).