### PR TITLE
Update inactive session icon so it doesn't look cut off.

### DIFF
--- a/src/R/Wpf/Impl/CommonResources.xaml
+++ b/src/R/Wpf/Impl/CommonResources.xaml
@@ -165,7 +165,7 @@
         <DrawingBrush.Drawing>
             <DrawingGroup>
                 <DrawingGroup.Children>
-                    <GeometryDrawing Brush="#FFF6F6F6" Geometry="{StaticResource GeometryCircle18}" />
+                    <GeometryDrawing Brush="#FFA6A6A6" Geometry="{StaticResource GeometryCircle18}" />
                     <GeometryDrawing Brush="#FF000000" Geometry="{StaticResource GeometryLocal}" />
                     <GeometryDrawing Brush="#FFF6F6F6" Geometry="{StaticResource GeometryR}" />
                 </DrawingGroup.Children>
@@ -201,7 +201,7 @@
         <DrawingBrush.Drawing>
             <DrawingGroup>
                 <DrawingGroup.Children>
-                    <GeometryDrawing Brush="#FFF6F6F6" Geometry="{StaticResource GeometryCircle18}" />
+                    <GeometryDrawing Brush="#FFA6A6A6" Geometry="{StaticResource GeometryCircle18}" />
                     <GeometryDrawing Brush="#FF000000" Geometry="{StaticResource GeometryCloud}" />
                     <GeometryDrawing Brush="#FFF6F6F6" Geometry="{StaticResource GeometryR}" />
                 </DrawingGroup.Children>


### PR DESCRIPTION
Fixes #2414 

Here's what it looks like in all 3 themes:
![image](https://cloud.githubusercontent.com/assets/1696845/19163780/328cbb96-8bb2-11e6-9893-56509c55e2bd.png)
