### PR TITLE
#2425, #2427 (autosaving and restoring session state)

### DIFF
--- a/src/Host/Broker/Impl/Microsoft.R.Host.Broker.csproj
+++ b/src/Host/Broker/Impl/Microsoft.R.Host.Broker.csproj
@@ -87,7 +87,7 @@
     <Compile Include="Logging\FileLoggerProvider.cs" />
     <Compile Include="Logging\LoggingOptions.cs" />
     <Compile Include="NativeMethods.cs" />
-    <Compile Include="Pipes\HostDisconnectedException.cs" />
+    <Compile Include="Pipes\PipeDisconnectedException.cs" />
     <Compile Include="Pipes\MessageParser.cs" />
     <Compile Include="Pipes\ProcessHelpers.cs" />
     <Compile Include="Pipes\WebSocketPipeAction.cs" />

--- a/src/Host/Broker/Impl/Microsoft.R.Host.Broker.csproj
+++ b/src/Host/Broker/Impl/Microsoft.R.Host.Broker.csproj
@@ -108,7 +108,6 @@
     <Compile Include="Security\SecurityManager.cs" />
     <Compile Include="Security\Policies.cs" />
     <Compile Include="Security\TlsConfiguration.cs" />
-    <Compile Include="Sessions\SessionState.cs" />
     <Compile Include="Sessions\SessionStateChangedEventArgs.cs" />
     <Compile Include="Startup\StartupOptions.cs" />
     <Compile Include="Startup\Program.cs" />

--- a/src/Host/Broker/Impl/Pipes/PipeDisconnectedException.cs
+++ b/src/Host/Broker/Impl/Pipes/PipeDisconnectedException.cs
@@ -4,12 +4,12 @@
 using System;
 
 namespace Microsoft.R.Host.Broker.Pipes {
-    public class HostDisconnectedException : Exception {
-        public HostDisconnectedException()
+    public class PipeDisconnectedException : Exception {
+        public PipeDisconnectedException()
             : this("Host end of the message pipe was disconnected") {
         }
 
-        public HostDisconnectedException(string message)
+        public PipeDisconnectedException(string message)
             : base(message) {
         }
     }

--- a/src/Host/Broker/Impl/Pipes/WebSocketPipeAction.cs
+++ b/src/Host/Broker/Impl/Pipes/WebSocketPipeAction.cs
@@ -80,7 +80,7 @@ namespace Microsoft.R.Host.Broker.Pipes {
                 byte[] message;
                 try {
                     message = await pipe.ReadAsync(cancellationToken);
-                } catch (HostDisconnectedException) {
+                } catch (PipeDisconnectedException) {
                     break;
                 }
 

--- a/src/Host/Broker/Impl/Sessions/SessionManager.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionManager.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.R.Host.Broker.Interpreters;
 using Microsoft.R.Host.Broker.Logging;
 using Microsoft.R.Host.Broker.Pipes;
+using Microsoft.R.Host.Protocol;
 
 namespace Microsoft.R.Host.Broker.Sessions {
     public class SessionManager {

--- a/src/Host/Broker/Impl/Sessions/SessionStateChangedEventArgs.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionStateChangedEventArgs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using Microsoft.R.Host.Protocol;
 
 namespace Microsoft.R.Host.Broker.Sessions {
     public class SessionStateChangedEventArgs : EventArgs {

--- a/src/Host/Client/Impl/Extensions/RStringExtensions.cs
+++ b/src/Host/Client/Impl/Extensions/RStringExtensions.cs
@@ -20,6 +20,9 @@ namespace Microsoft.R.Host.Client {
             return quote + s.Replace("\\", "\\\\").Replace("" + quote, "\\" + quote) + quote;
         }
 
+        public static string ToRBooleanLiteral(this bool b) =>
+            b ? "TRUE" : "FALSE";
+
         public static string FromRStringLiteral(this string s) {
             if (s.Length < 2) {
                 throw new FormatException("Not a quoted R string literal");

--- a/src/Host/Client/Impl/Host/BrokerClient.cs
+++ b/src/Host/Client/Impl/Host/BrokerClient.cs
@@ -97,7 +97,7 @@ namespace Microsoft.R.Host.Client.Host {
             await TaskUtilities.SwitchToBackgroundThread();
 
             try {
-                bool sessionExists = await IsSessionRunningAsync(name, cancellationToken);
+                bool sessionExists = false; //await IsSessionRunningAsync(name, cancellationToken);
 
                 WebSocket webSocket;
                 while (true) {

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -288,27 +288,33 @@ namespace Microsoft.R.Host.Client.Session {
 
             ResetInitializationTcs();
 
-            // Try graceful shutdown with q() first.
-            try {
-                await Task.WhenAny(_hostRunTask, this.QuitAsync(), Task.Delay(500)).Unwrap();
-            } catch (Exception) { }
+            await StopHostAsync(BrokerClient, _startupInfo.Name, _host, _hostRunTask);
+        }
 
-            if (_hostRunTask.IsCompleted) {
-                return;
+        private static async Task StopHostAsync(IBrokerClient brokerClient, string hostName, RHost host, Task hostRunTask) {
+            if (host != null) {
+                // Try graceful shutdown with q() first.
+                try {
+                    await Task.WhenAny(hostRunTask, host.QuitAsync(), Task.Delay(500)).Unwrap();
+                } catch (Exception) { }
+
+                if (hostRunTask.IsCompleted) {
+                    return;
+                }
             }
 
             // If it didn't work, tell the broker to forcibly terminate the host process. 
             try {
-                await BrokerClient.TerminateSessionAsync(_startupInfo.Name);
+                await brokerClient.TerminateSessionAsync(hostName);
             } catch (Exception) { }
 
-            if (_hostRunTask.IsCompleted) {
+            if (hostRunTask.IsCompleted) {
                 return;
             }
 
             // If nothing worked, then just disconnect.
-            await _host?.DisconnectAsync();
-            await _hostRunTask;
+            await host?.DisconnectAsync();
+            await hostRunTask;
         }
 
         public IDisposable DisableMutatedOnReadConsole() {
@@ -375,6 +381,15 @@ namespace Microsoft.R.Host.Client.Session {
                     await evaluation.OverrideFunctionAsync("setwd", "base");
                     await evaluation.SetFunctionRedirectionAsync();
                     await evaluation.OptionsSetWidthAsync(startupInfo.TerminalWidth);
+
+                    try {
+                        // Only enable autosave for this session after querying the user about any existing file.
+                        // This way, if they happen to disconnect while still querying, we don't save the new empty
+                        // session and overwrite the old file.
+                        bool deleteExisting = await evaluation.QueryReloadAutosaveAsync();
+                        await evaluation.EnableAutosaveAsync(deleteExisting);
+                    } catch (REvaluationException) {
+                    }
                 }
             }
         }
@@ -706,6 +721,8 @@ if (rtvs:::version != {rtvsPackageVersion}) {{
                     return;
                 }
 
+                var brokerClient = _session.BrokerClient;
+                var startupInfo = _session._startupInfo;
                 var host = _session._host;
                 var hostRunTask = _session._hostRunTask;
 
@@ -721,8 +738,10 @@ if (rtvs:::version != {rtvsPackageVersion}) {{
                 // Start new RHost
                 await _session.StartHostAsyncBackground(_hostToSwitch, _lockToken, cancellationToken);
 
-                // Don't send stop notification to broker - just dispose host and wait for old hostRunTask to exit;
+                // Shut down the old host, gracefully if possible, and wait for old hostRunTask to exit;
+                await StopHostAsync(brokerClient, startupInfo.Name, host, hostRunTask);
                 host?.Dispose();
+
                 if (hostRunTask != null) {
                     await hostRunTask;
                 }

--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -215,10 +215,15 @@ grDevices::deviceIsInteractive('ide')
             return evaluation.ExecuteAsync(script);
         }
 
-
         public static Task SetFunctionRedirectionAsync(this IRExpressionEvaluator evaluation) {
             var script = "rtvs:::redirect_functions()";
             return evaluation.ExecuteAsync(script);
         }
+
+        public static Task<bool> QueryReloadAutosaveAsync(this IRExpressionEvaluator evaluation) =>
+            evaluation.EvaluateAsync<bool>($"rtvs:::query_reload_autosave()", REvaluationKind.Reentrant);
+
+        public static Task EnableAutosaveAsync(this IRExpressionEvaluator evaluation, bool deleteExisting) =>
+            evaluation.ExecuteAsync($"rtvs:::enable_autosave({deleteExisting.ToRBooleanLiteral()})");
     }
 }

--- a/src/Host/Client/Impl/rtvs/R/breakpoints.R
+++ b/src/Host/Client/Impl/rtvs/R/breakpoints.R
@@ -9,80 +9,80 @@ breakpoints <- new.env(parent = emptyenv())
 
 # Used to check whether a breakpoint is still valid at this location.
 is_breakpoint <- function(filename, line_number) {
-  if (locals$breakpoints_enabled) {
-    line_numbers <- breakpoints[[filename]];
-    return(line_number %in% line_numbers);
-  } else {
-  	return(FALSE);
-  }
+    if (locals$breakpoints_enabled) {
+        line_numbers <- breakpoints[[filename]];
+        return(line_number %in% line_numbers);
+    } else {
+        return(FALSE);
+    }
 }
 
 # Adds a new breakpoint to the list of active breakpoints. If reapply=TRUE, will
 # automatically reapply the new list.
 add_breakpoint <- function(filename, line_number, reapply = TRUE) {
-  breakpoints[[filename]] <- c(breakpoints[[filename]], line_number);
-  if (reapply) {
-    reapply_breakpoints();
-  }
+    breakpoints[[filename]] <- c(breakpoints[[filename]], line_number);
+    if (reapply) {
+        reapply_breakpoints();
+    }
 }
 
 # Removes the breakpoint from the list.
 remove_breakpoint <- function(filename, line_number) {
-  bps <- setdiff(breakpoints[[filename]], line_number);
-  if (length(bps) == 0) {
-    rm(list = filename, envir = breakpoints);
-  } else {
-    breakpoints[[filename]] <- bps;
-  }
+    bps <- setdiff(breakpoints[[filename]], line_number);
+    if (length(bps) == 0) {
+        rm(list = filename, envir = breakpoints);
+    } else {
+        breakpoints[[filename]] <- bps;
+    }
 
-  # TODO: implement reverse reapply: walk all environments looking for injected breakpoints,
-  # and remove those that are no longer in the list using attr('rtvs::original_expr').
+    # TODO: implement reverse reapply: walk all environments looking for injected breakpoints,
+    # and remove those that are no longer in the list using attr('rtvs::original_expr').
 }
 
 # Walks environments, starting from .GlobalEnv up, and injects active breakpoints
 # into all functions in those environments.
 reapply_breakpoints <- function() {
-  if (!locals$breakpoints_enabled) {
-    return();
-  }
-
-  (function(env, visited = NULL) {
-    if (!identical(env, emptyenv()) && !any(sapply(visited, function(x) identical(x, env)))) {
-      visited <- c(visited, env);
-
-      for (name in names(env)) {
-        x <- tryCatch({
-          env[[name]]
-        }, error = function(e) {
-          NULL
-        });
-
-        if (!missing(x)) {
-          if (is.function(x)) {
-            bp_body <- inject_breakpoints(body(x));
-            if (!is.null(bp_body)) {
-              tryCatch({
-                body(env[[name]]) <- bp_body;
-              }, error = function(e) {
-              });
-            }
-            # TODO: also walk parent.env of the function, in case it was defined
-            # elsewhere and then copied here?
-          } else if (is.environment(x)) {
-            # TODO: also walk nested environments?
-            #  Recall(x, visited);
-          }
-        }
-      }
-
-      Recall(parent.env(env), visited);
+    if (!locals$breakpoints_enabled) {
+        return();
     }
-  })(.GlobalEnv);
 
-  # TODO: also walk environment chains for all loaded namespaces.
+    (function(env, visited = NULL) {
+        if (!identical(env, emptyenv()) && !any(sapply(visited, function(x) identical(x, env)))) {
+            visited <- c(visited, env);
 
-  # TODO: this is expensive already. If a deeper walk is performed, this might
-  # have to be rewritten in native code to get acceptable perf.
+            for (name in names(env)) {
+                x <- tryCatch({
+                    env[[name]]
+                }, error = function(e) {
+                    NULL
+                });
+
+                if (!missing(x)) {
+                    if (is.function(x)) {
+                        bp_body <- inject_breakpoints(body(x));
+                        if (!is.null(bp_body)) {
+                            tryCatch({
+                                body(env[[name]]) <- bp_body;
+                            }, error = function(e) {
+                            });
+                        }
+                        # TODO: also walk parent.env of the function, in case it was defined
+                        # elsewhere and then copied here?
+                    } else if (is.environment(x)) {
+                        # TODO: also walk nested environments?
+                        #  Recall(x, visited);
+                    }
+                }
+            }
+
+            Recall(parent.env(env), visited);
+        }
+    })(.GlobalEnv);
+
+    # TODO: also walk environment chains for all loaded namespaces.
+
+    # TODO: this is expensive already. If a deeper walk is performed, this might
+    # have to be rewritten in native code to get acceptable perf.
 }
 
 # Given an expression or a language object, and a line number, return the steps that
@@ -90,189 +90,189 @@ reapply_breakpoints <- function() {
 # at that line number, or NULL if there is no such instruction. The returned value
 # is an integer vector that can be directly used as an index for [[ ]].
 steps_for_line_num <- function(expr, line, have_srcrefs = FALSE) {
-  is_brace <- function(expr)
-  typeof(expr) == 'symbol' && identical(as.character(expr), '{')
+    is_brace <- function(expr)
+    typeof(expr) == 'symbol' && identical(as.character(expr), '{')
 
-  if (typeof(expr) == 'language' || typeof(expr) == 'expression') {
-    srcrefs <- attr(expr, 'srcref')
-    for (i in seq_along(expr)) {
-      srcref <- srcrefs[[i]]
+    if (typeof(expr) == 'language' || typeof(expr) == 'expression') {
+        srcrefs <- attr(expr, 'srcref')
+        for (i in seq_along(expr)) {
+            srcref <- srcrefs[[i]]
 
-      # Check for non-matching range. 
-      if (!is.null(srcref) && (srcref[1] > line || line > srcref[3])) {
-        next
-      }
+            # Check for non-matching range. 
+            if (!is.null(srcref) && (srcref[1] > line || line > srcref[3])) {
+                next
+            }
 
-      # We're in range.  See if there's a finer division, and add it as a substep if so.
-      finer <- steps_for_line_num(expr[[i]], line, have_srcrefs || !is.null(srcrefs))
-      if (!is.null(finer)) {
-        return(c(i, finer))
-      }
+            # We're in range.  See if there's a finer division, and add it as a substep if so.
+            finer <- steps_for_line_num(expr[[i]], line, have_srcrefs || !is.null(srcrefs))
+            if (!is.null(finer)) {
+                return(c(i, finer))
+            }
 
-      # If there was no subdivision, then this is the exact instruction, but only if there was an srcref,
-      # and this is not a breakpoint. However, if this is an opening curly brace for a block, and parent
-      # had an srcref, then match the parent (which will be the whole block).
-      if (!is.null(srcref) && !isTRUE(attr(expr[[i]], 'rtvs::is_breakpoint')) && (!have_srcrefs || !is_brace(expr[[i]]))) {
-        return(i)
-      }
+            # If there was no subdivision, then this is the exact instruction, but only if there was an srcref,
+            # and this is not a breakpoint. However, if this is an opening curly brace for a block, and parent
+            # had an srcref, then match the parent (which will be the whole block).
+            if (!is.null(srcref) && !isTRUE(attr(expr[[i]], 'rtvs::is_breakpoint')) && (!have_srcrefs || !is_brace(expr[[i]]))) {
+                return(i)
+            }
+        }
     }
-  }
 
-  NULL
+    NULL
 }
 
 # Given an expression or language object, return that object with all active
 # breakpoints injected into it, or NULL if no breakpoints were injected.
 inject_breakpoints <- function(expr) {
-  if (length(breakpoints) == 0 || length(expr) == 0) {
-    return(NULL);
-  }
+    if (length(breakpoints) == 0 || length(expr) == 0) {
+        return(NULL);
+    }
 
-  filename <- utils::getSrcFilename(expr);
-  if (is.null(filename) || !is.character(filename) || length(filename) != 1 || is.na(filename) || identical(filename, '')) {
-    return(NULL);
-  }
+    filename <- utils::getSrcFilename(expr);
+    if (is.null(filename) || !is.character(filename) || length(filename) != 1 || is.na(filename) || identical(filename, '')) {
+        return(NULL);
+    }
 
-  line_numbers <- breakpoints[[filename]];
-  if (is.null(line_numbers)) {
-    return(NULL);
-  }
+    line_numbers <- breakpoints[[filename]];
+    if (is.null(line_numbers)) {
+        return(NULL);
+    }
 
-  original_expr <- expr;
-  changed <- FALSE;
+    original_expr <- expr;
+    changed <- FALSE;
 
-  for (line_num in sort(line_numbers)) {
-    step <- steps_for_line_num(expr, line_num);
-    if (length(step) > 0) {
-      new_expr <- expr;
-      target_expr <- expr[[step]];
+    for (line_num in sort(line_numbers)) {
+        step <- steps_for_line_num(expr, line_num);
+        if (length(step) > 0) {
+            new_expr <- expr;
+            target_expr <- expr[[step]];
 
-      # If there's already an injected breakpoint there, nothing to do for this line.
-      if (isTRUE(attr(target_expr, 'rtvs::at_breakpoint')) || !is.null(attr(target_expr, 'rtvs::original_expr'))) {
-        next;
-      }
+            # If there's already an injected breakpoint there, nothing to do for this line.
+            if (isTRUE(attr(target_expr, 'rtvs::at_breakpoint')) || !is.null(attr(target_expr, 'rtvs::original_expr'))) {
+                next;
+            }
 
-      # Attributes cannot be set on NULL, so wrap it in (), and set attributes on the resulting call object.
-      if (identical(target_expr, NULL)) {
-        target_expr <- quote((NULL));
-      }
+            # Attributes cannot be set on NULL, so wrap it in (), and set attributes on the resulting call object.
+            if (identical(target_expr, NULL)) {
+                target_expr <- quote((NULL));
+            }
 
-      new_expr[[step]] <- substitute({
-        .doTrace(if (rtvs:::is_breakpoint(FILENAME, LINE_NUMBER)) browser());
-        EXPR
-      }, list(
+            new_expr[[step]] <- substitute({
+                .doTrace(if (rtvs:::is_breakpoint(FILENAME, LINE_NUMBER)) browser());
+                EXPR
+            }, list(
         FILENAME = filename,
         LINE_NUMBER = line_num,
         EXPR = target_expr
       ));
 
-      attr(new_expr[[step]], 'rtvs::original_expr') <- target_expr;
-      attr(new_expr[[step]][[2]], 'rtvs::is_breakpoint') <- TRUE;
-      attr(new_expr[[step]][[3]], 'rtvs::at_breakpoint') <- TRUE;
+            attr(new_expr[[step]], 'rtvs::original_expr') <- target_expr;
+            attr(new_expr[[step]][[2]], 'rtvs::is_breakpoint') <- TRUE;
+            attr(new_expr[[step]][[3]], 'rtvs::at_breakpoint') <- TRUE;
 
-      expr <- new_expr;
-      changed <- TRUE;
-    }
-  }
-
-  if (!changed) {
-      return(NULL);
-  }
-
-  # Recursively copy srcrefs from the original expression to the new one with injected breakpoints,
-  # synthesizing them for injected breakpoint expressions from original expressions that they replace
-  expr <- (function(before, after) {
-    if (is.symbol(before) || is.symbol(after)) {
-      return(after);
+            expr <- new_expr;
+            changed <- TRUE;
+        }
     }
 
-    before_srcref <- attr(before, 'srcref');
-    attr(after, 'srcref') <- before_srcref;
-
-    for (i in 1:length(after)) {
-      if (is.null(attr(before[[i]], 'rtvs::original_expr')) && !is.null(attr(after[[i]], 'rtvs::original_expr'))) {
-        # If it has the original_expr attribute that wasn't there before, it's an breakpoint expression that 
-        # was freshly injected, replacing the original expression at the point where the breakpoint was set.
-        # It looks like this:
-        #
-        # {.doTrace(...); <original expression>}
-        #
-        # Copy srcrefs from the original, replicating them such that they apply to the entirety of
-        # the replacement expression, so that the same line is considered current for all of it.
-        attr(after[[i]], 'srcref') <- rep(list(before_srcref[[i]]), length(after[[i]]));
-
-        # Auto-step over '{' and '.doTrace', so that stepping skips to the original expression.
-        attr(attr(after, 'srcref')[[i]], 'Microsoft.R.Host::auto_step_over') <- TRUE;
-        attr(attr(after[[i]], 'srcref')[[2]], 'Microsoft.R.Host::auto_step_over') <- TRUE;
-
-        # Recurse into the original expression, in case it has more breakpoints inside.
-        after[[i]][[3]] <- Recall(before[[i]], after[[i]][[3]]);
-      } else if (is.language(after[[i]])) {
-        # Otherwise, if this is not a literal, keep recursing down in case injected breakpoints
-        # are in the subexpressions of this expression.
-        after[[i]] <- Recall(before[[i]], after[[i]]);
-      }
+    if (!changed) {
+        return(NULL);
     }
 
-    after
-  })(original_expr, expr);
+    # Recursively copy srcrefs from the original expression to the new one with injected breakpoints,
+    # synthesizing them for injected breakpoint expressions from original expressions that they replace
+    expr <- (function(before, after) {
+        if (is.symbol(before) || is.symbol(after)) {
+            return(after);
+        }
 
-  expr
+        before_srcref <- attr(before, 'srcref');
+        attr(after, 'srcref') <- before_srcref;
+
+        for (i in 1:length(after)) {
+            if (is.null(attr(before[[i]], 'rtvs::original_expr')) && !is.null(attr(after[[i]], 'rtvs::original_expr'))) {
+                # If it has the original_expr attribute that wasn't there before, it's an breakpoint expression that 
+                # was freshly injected, replacing the original expression at the point where the breakpoint was set.
+                # It looks like this:
+                #
+                # {.doTrace(...); <original expression>}
+                #
+                # Copy srcrefs from the original, replicating them such that they apply to the entirety of
+                # the replacement expression, so that the same line is considered current for all of it.
+                attr(after[[i]], 'srcref') <- rep(list(before_srcref[[i]]), length(after[[i]]));
+
+                # Auto-step over '{' and '.doTrace', so that stepping skips to the original expression.
+                attr(attr(after, 'srcref')[[i]], 'Microsoft.R.Host::auto_step_over') <- TRUE;
+                attr(attr(after[[i]], 'srcref')[[2]], 'Microsoft.R.Host::auto_step_over') <- TRUE;
+
+                # Recurse into the original expression, in case it has more breakpoints inside.
+                after[[i]][[3]] <- Recall(before[[i]], after[[i]][[3]]);
+            } else if (is.language(after[[i]])) {
+                # Otherwise, if this is not a literal, keep recursing down in case injected breakpoints
+                # are in the subexpressions of this expression.
+                after[[i]] <- Recall(before[[i]], after[[i]]);
+            }
+        }
+
+        after
+    })(original_expr, expr);
+
+    expr
 }
 
 # Enables or disables instrumentation that makes breakpoints work.
 enable_breakpoints <- function(enable) {
-  if (locals$breakpoints_enabled != enable) {
-    locals$breakpoints_enabled <- enable;
-    if (enable) {
-      call_embedded('set_instrumentation_callback', inject_breakpoints);
-      reapply_breakpoints();
-    } else {
-      call_embedded('set_instrumentation_callback', NULL);
+    if (locals$breakpoints_enabled != enable) {
+        locals$breakpoints_enabled <- enable;
+        if (enable) {
+            call_embedded('set_instrumentation_callback', inject_breakpoints);
+            reapply_breakpoints();
+        } else {
+            call_embedded('set_instrumentation_callback', NULL);
+        }
     }
-  }
 }
 
 # Like parse, but returns a single `{` call object wrapping the content of the file, rather than
 # an expression object containing separate calls. Consequently, when the returned object is eval'd,
 # it is possible to use debug stepping commands to execute expressions sequentially.
 debug_parse <- function(filename, encoding = getOption('encoding')) {
-  conn <- file(filename, "r", encoding = encoding);
-  tryCatch({
-    text <- readLines(conn, warn = FALSE)
-    if (!length(text)) {
-        text <- ""
+    conn <- file(filename, "r", encoding = encoding);
+    tryCatch({
+        text <- readLines(conn, warn = FALSE)
+        if (!length(text)) {
+            text <- ""
+        }
+    }, finally = close(conn));
+
+    srcfile <- srcfilecopy(filename, text, file.mtime(filename), isFile = TRUE)
+
+    exprs <- parse(text = text, srcfile = srcfile);
+    if (length(exprs) == 0) {
+        return(quote({ }));
     }
-  }, finally = close(conn));
 
-  srcfile <- srcfilecopy(filename, text, file.mtime(filename), isFile = TRUE)
+    # Create a `{` call wrapping all expressions in the file.
+    result <- quote({ });
+    for (i in 1:length(exprs)) {
+        result[[i + 1]] <- exprs[[i]];
+    }
 
-  exprs <- parse(text = text, srcfile = srcfile);
-  if (length(exprs) == 0) {
-    return(quote({}));
-  }
+    # Copy top-level source info.
+    attr(result, 'srcfile') <- attr(exprs, 'srcfile');
 
-  # Create a `{` call wrapping all expressions in the file.
-  result <- quote({});
-  for (i in 1:length(exprs)) {
-    result[[i + 1]] <- exprs[[i]];
-  }
+    # Since the result has indices shifted by 1 due to the addition of `{` at the beginning,
+    # per-line source info needs to be adjusted accordingly before copying.
+    old_srcref <- attr(exprs, 'srcref');
+    new_srcref <- list(attr(exprs, 'srcref')[[1]]);
+    for (i in 1:length(exprs)) {
+        new_srcref[[i + 1]] <- old_srcref[[i]];
+    }
+    attr(result, 'srcref') <- new_srcref;
 
-  # Copy top-level source info.
-  attr(result, 'srcfile') <- attr(exprs, 'srcfile');
-
-  # Since the result has indices shifted by 1 due to the addition of `{` at the beginning,
-  # per-line source info needs to be adjusted accordingly before copying.
-  old_srcref <- attr(exprs, 'srcref');
-  new_srcref <- list(attr(exprs, 'srcref')[[1]]);
-  for (i in 1:length(exprs)) {
-    new_srcref[[i + 1]] <- old_srcref[[i]];
-  }
-  attr(result, 'srcref') <- new_srcref;
-
-  result
+    result
 }
 
 debug_source <- function(file, encoding = getOption('encoding')) {
-  safe_eval(debug_parse(file, encoding), parent.frame(1))
+    safe_eval(debug_parse(file, encoding), parent.frame(1))
 }

--- a/src/Host/Client/Impl/rtvs/R/eval.R
+++ b/src/Host/Client/Impl/rtvs/R/eval.R
@@ -19,83 +19,82 @@
 # be invoked with `obj` as an argument, and the produced value will be stored in `res$repr`.
 # If function raises an exception, it is silently ignored, and `res$repr` will not be set.
 describe_object <- function(obj, res, fields, repr = NULL) {
-  if (missing(res)) {
-    res <- as.environment(list());
-  }   
+    if (missing(res)) {
+        res <- as.environment(list());
+    }
 
-  field <-
-    if (missing(fields)) {
-      function(x) TRUE;
+    field <- if (missing(fields)) {
+        function(x) TRUE;
     } else {
-      function(x) x %in% fields
+        function(x) x %in% fields
     }
-  
-  if (!is.null(repr)) {
-  	  res$repr <- NA_if_error(repr(obj))
-  }
 
-  if (field('type')) {
-    res$type <- force_toString(NA_if_error(typeof(obj)));
-  }
-
-  if (field('classes')) {
-    classes <- NA_if_error(class(obj));
-    res$classes <- lapply(classes, function(cls) {
-      if (!is.character(cls) || length(cls) != 1 || is.na(cls)) NA else cls
-    });
-  }
-
-  if (field('length')) {
-    res$length <- NA_if_error(force_number(length(obj)));
-  }
-  
-  if (field('slot_count')) {
-    res$slot_count <- NA_if_error(force_number(length(slotNames(class(obj)))));
-  }
-  
-  if (field('attr_count')) {
-    res$attr_count <- NA_if_error(force_number(length(attributes(obj))));
-  }
-  
-  if (field('name_count')) {
-    res$name_count <- NA_if_error(force_number(length(names(obj))));
-  }
-  
-  if (field('dim')) {
-    dim <- NA_if_error(dim(obj));
-    if (is.integer(dim) && !anyNA(dim)) {
-      res$dim <- as.list(dim);
+    if (!is.null(repr)) {
+        res$repr <- NA_if_error(repr(obj))
     }
-  }
-  
-  if (field('to_df')) {
-    can_coerce_to_df <- function(obj){
-      df_test <- function(objclass){
-        res <- getS3method('as.data.frame', objclass, optional = TRUE);
-        !is.null(res);
-      }
-      any(sapply(class(obj), df_test));
-    }
-    res$to_df <- NULL_if_error(can_coerce_to_df(obj));
-  }
-    
-  has_parent_env <- FALSE;
-  if (is.environment(obj)) {
-    has_parent_env <- !identical(parent.env(obj), emptyenv());
-    if (field('env_name')) {
-      res$env_name <- NA_if_error(environmentName(obj));
-    }
-  }
 
-  if (field('flags')) {
-    res$flags <- list(
-      if (is.atomic(obj)) "atomic" else NA,
-      if (is.recursive(obj)) "recursive" else NA,
-      if (has_parent_env) "has_parent_env" else NA
-    );
-  }
-  
-  res
+    if (field('type')) {
+        res$type <- force_toString(NA_if_error(typeof(obj)));
+    }
+
+    if (field('classes')) {
+        classes <- NA_if_error(class(obj));
+        res$classes <- lapply(classes, function(cls) {
+            if (!is.character(cls) || length(cls) != 1 || is.na(cls)) NA else cls
+        });
+    }
+
+    if (field('length')) {
+        res$length <- NA_if_error(force_number(length(obj)));
+    }
+
+    if (field('slot_count')) {
+        res$slot_count <- NA_if_error(force_number(length(slotNames(class(obj)))));
+    }
+
+    if (field('attr_count')) {
+        res$attr_count <- NA_if_error(force_number(length(attributes(obj))));
+    }
+
+    if (field('name_count')) {
+        res$name_count <- NA_if_error(force_number(length(names(obj))));
+    }
+
+    if (field('dim')) {
+        dim <- NA_if_error(dim(obj));
+        if (is.integer(dim) && !anyNA(dim)) {
+            res$dim <- as.list(dim);
+        }
+    }
+
+    if (field('to_df')) {
+        can_coerce_to_df <- function(obj) {
+            df_test <- function(objclass) {
+                res <- getS3method('as.data.frame', objclass, optional = TRUE);
+                !is.null(res);
+            }
+            any(sapply(class(obj), df_test));
+        }
+        res$to_df <- NULL_if_error(can_coerce_to_df(obj));
+    }
+
+    has_parent_env <- FALSE;
+    if (is.environment(obj)) {
+        has_parent_env <- !identical(parent.env(obj), emptyenv());
+        if (field('env_name')) {
+            res$env_name <- NA_if_error(environmentName(obj));
+        }
+    }
+
+    if (field('flags')) {
+        res$flags <- list(
+            if (is.atomic(obj)) "atomic" else NA,
+            if (is.recursive(obj)) "recursive" else NA,
+            if (has_parent_env) "has_parent_env" else NA
+        );
+    }
+
+    res
 }
 
 # Evaluates string `expr` in environment `env`, and produces a new environment describing the result.
@@ -114,46 +113,45 @@ describe_object <- function(obj, res, fields, repr = NULL) {
 # be invoked with `obj` as an argument, and the produced value will be stored in `res$repr`.
 # If function raises an exception, it is silently ignored, and `res$repr` will not be set.
 eval_and_describe <- function(expr, env, kind, fields, obj, repr = NULL) {
-  res <- new.env();
-  
-  field <-
-    if (missing(fields)) {
-      function(x) TRUE;
+    res <- new.env();
+
+    field <- if (missing(fields)) {
+        function(x) TRUE;
     } else {
-      function(x) x %in% fields
+        function(x) x %in% fields
     }
 
-  if (field('expression')) {
-    res$expression <- expr;
-  }
-  
-  if (field('kind')) {
-    if (!missing(kind)) { 
-      res$kind <- kind;
+    if (field('expression')) {
+        res$expression <- expr;
     }
-  }
 
-  err <- NULL;
-  tryCatch({
-    if (is.character(expr)) {
-      expr <- parse(text = expr);
+    if (field('kind')) {
+        if (!missing(kind)) {
+            res$kind <- kind;
+        }
     }
-    if (missing(obj)) {
-      obj <- safe_eval(expr, env);
+
+    err <- NULL;
+    tryCatch({
+        if (is.character(expr)) {
+            expr <- parse(text = expr);
+        }
+        if (missing(obj)) {
+            obj <- safe_eval(expr, env);
+        } else {
+            force(obj);
+        }
+    }, error = function(e) {
+        err <<- e;
+    });
+
+    if (is.null(err)) {
+        describe_object(obj, res, fields, repr);
     } else {
-      force(obj);
+        res$error <- force_toString(NA_if_error(conditionMessage(err)));
     }
-  }, error = function(e) {
-    err <<- e;
-  });
 
-  if (is.null(err)) {
-    describe_object(obj, res, fields, repr);
-  } else {
-    res$error <- force_toString(NA_if_error(conditionMessage(err)));
-  }
-
-  res
+    res
 }
 
 # Retrieves and describes children of object `obj`, as if `describe_object` was called on every child.
@@ -165,190 +163,188 @@ eval_and_describe <- function(expr, env, kind, fields, obj, repr = NULL) {
 #
 # `fields` and `repr` are passed to `describe_object` as is.
 describe_children <- function(obj, env, fields, count = NULL, repr = NULL) {
-  if (!missing(env)) {
-    expr <- obj;
-    obj <- safe_eval(parse(text = obj), env);
-  } else {
-    expr <- 'obj';
-  }
-
-  # Preallocate to avoid growing the list on every new child.
-  children <- vector("list", if (is.null(count)) 1000 else count);
-  last_child <- 0;
-
-  process_env <- function() {
-    names <- ls(obj, all.names = TRUE);
-    
-    if (!is.null(count)) {
-      names <- head(names, count);
-      count <<- count - length(names);
+    if (!missing(env)) {
+        expr <- obj;
+        obj <- safe_eval(parse(text = obj), env);
+    } else {
+        expr <- 'obj';
     }
-    
-    for (name in names) {
-      name <- force_toString(name);
-      # If a binding has an empty name, or it wasn't a string, it cannot be accessed, so ignore it.
-      if (name == '') {
-        next;
-      }
 
-      name_sym <- symbol_token(name);
+    # Preallocate to avoid growing the list on every new child.
+    children <- vector("list", if (is.null(count)) 1000 else count);
+    last_child <- 0;
 
-      # Check if it's a promise, and retrieve the promise expression if it is.
-      code <- tryCatch({
-        unevaluated_promise(name, obj)
-      }, error = function(e) {
-        NULL
-      });
+    process_env <- function() {
+        names <- ls(obj, all.names = TRUE);
 
-      item_expr <-
-        if (expr == 'base::environment()') {
-          name_sym
-        } else {
-          paste0(expr, '$', name_sym, collapse = '')
-        };
-
-      if (!is.null(code)) {
-        # It's a promise - we don't want to force it as it could affect the debugged code.
-        value <- list(promise = deparse_str(code), expression = item_expr);
-      } else if (bindingIsActive(name, obj)) {
-        # It's an active binding - we don't want to read it to avoid inadvertently changing program state.
-        eval_res <- 
-          if('computed_value' %in% fields){
-            eval_and_describe(item_expr, environment(), '$', fields, get(name, envir = obj), repr);
-          } else {
-            NULL
-          }
-
-        value <- list(active_binding = TRUE, expression = item_expr, computed_value = eval_res);
-      } else {
-        # It's just a regular binding, so get the actual value, but check for missing() first.
-
-        is_missing <- tryCatch({
-          value <- obj[[name]];
-          missing(value)
-        }, error = function(e) {
-            FALSE
-        });
-        if (is_missing) {
-            next;
+        if (!is.null(count)) {
+            names <- head(names, count);
+            count <<- count - length(names);
         }
 
-        value <- eval_and_describe(item_expr, environment(), '$', fields, get(name, envir = obj), repr);
-      }
-      
-      child <- list(value);
-      names(child) <- name_sym;
-      last_child <<- last_child + 1;
-      children[[last_child]] <<- child;
-    }
-  }
-  
-  if (is.environment(obj)) {
-    process_env();
-  }
-
-  process_slots <- function() {
-    is_S4 <- isS4(obj);
-    names <- NA_if_error(slotNames(class(obj)));
-  
-    if (!is.null(count)) {
-      names <- head(names, count);
-      count <<- count - length(names);
-    }
-  
-    for (name in names) {
-      name <- force_toString(name);
-      # If a binding has an empty name, or it wasn't a string, it cannot be accessed, so ignore it.
-      if (name == '') {
-        next;
-      }
-
-      name_sym <- symbol_token(name);
-      
-      # For S4 objects, slots can be accessed with '@'. For other objects, we have to
-      # use slot(). Still, always use '@' as accessor name to show to the user.
-      accessor <- paste0('@', name_sym, collapse = '');
-      if (is_S4) {
-        slot_expr <- paste0(expr, accessor, collapse = '')
-      } else {
-        slot_expr <- paste0('methods::slot((', expr, '), ', deparse_str(name), ')', collapse = '')
-      }
-      
-      value <- eval_and_describe(slot_expr, environment(), '@', fields, slot(obj, name), repr);
-      
-      child <- list(value);
-      names(child) <- accessor;
-      last_child <<- last_child + 1;
-      children[[last_child]] <<- child;
-    }
-  }
-  
-  # Not just S4 objects have slots, so run this on everything - slotNames() will always
-  # do the right thing.
-  process_slots();
-
-  process_items <- function() {  
-    n <- length(obj);
-
-    names <- names(obj);
-    if (!is.character(names)) {
-      names <- NULL;
-    }
-
-    # For list and language, we always want to show their children, even if there's only one.
-    # For vectors, we don't want to show the child if that's the only item in the vector, to
-    # avoid presenting an infinitely recursive model (a vector of size 1 has the only child,
-    # which is another vector of size 1 etc). However, we do want to show the only child if
-    # it is named, so that the name is exposed.
-    if (n != 1 || !is.atomic(obj) || (length(names) >= 1 && !(is.null(names[[1]]) || is.na(names[[1]]) || names[[1]] == ''))) {
-      if (!is.null(count)) {
-        n <- min(n, count);
-        count <<- count - n;
-      }
-  
-      if (n >= 1) {
-        for (i in 1:n) {
-          # Start with the assumption that this is an unnamed item, accessed by position.
-          accessor <- paste0('[[', as.double(i), ']]', collapse = '');
-          kind <- '[[';
-
-          # If it has a name, it is a named item - but only if that name is unique, or
-          # if this item corresponds to the first mention of that name - i.e. if we have
-          # c(1,2,3), and names() is c('x','y','x'), then c[[1]] is named 'x', but c[[3]]
-          # is effectively unnamed, because there's no way to address it by name.
-          name <- tryCatch({
-              names[[i]]
-          }, error = function(e) {
-              NULL
-          });
-          name <- force_toString(name);
-          if (name != '' && match(name, names, -1) == i) {
-            kind <- '$';
-            # Named items can be accessed with '$' in lists, but other types require brackets.
-            if (is.list(obj)) {
-              accessor <- paste0('$', symbol_token(name), collapse = '');
-            } else {
-              accessor <- paste0('[[', deparse_str(name), ']]', collapse = '');
+        for (name in names) {
+            name <- force_toString(name);
+            # If a binding has an empty name, or it wasn't a string, it cannot be accessed, so ignore it.
+            if (name == '') {
+                next;
             }
-          }
-      
-          value <- eval_and_describe(paste0(expr, accessor, collapse = ''), environment(), kind, fields, obj[[i]], repr);
-      
-          child <- list(value);
-          names(child) <- accessor;
-          last_child <<- last_child + 1;
-          children[[last_child]] <<- child;
+
+            name_sym <- symbol_token(name);
+
+            # Check if it's a promise, and retrieve the promise expression if it is.
+            code <- tryCatch({
+                unevaluated_promise(name, obj)
+            }, error = function(e) {
+                NULL
+            });
+
+            item_expr <- if (expr == 'base::environment()') {
+                name_sym
+            } else {
+                paste0(expr, '$', name_sym, collapse = '')
+            };
+
+            if (!is.null(code)) {
+                # It's a promise - we don't want to force it as it could affect the debugged code.
+                value <- list(promise = deparse_str(code), expression = item_expr);
+            } else if (bindingIsActive(name, obj)) {
+                # It's an active binding - we don't want to read it to avoid inadvertently changing program state.
+                eval_res <- if ('computed_value' %in% fields) {
+                    eval_and_describe(item_expr, environment(), '$', fields, get(name, envir = obj), repr);
+                } else {
+                    NULL
+                }
+
+                value <- list(active_binding = TRUE, expression = item_expr, computed_value = eval_res);
+            } else {
+                # It's just a regular binding, so get the actual value, but check for missing() first.
+
+                is_missing <- tryCatch({
+                    value <- obj[[name]];
+                    missing(value)
+                }, error = function(e) {
+                    FALSE
+                });
+                if (is_missing) {
+                    next;
+                }
+
+                value <- eval_and_describe(item_expr, environment(), '$', fields, get(name, envir = obj), repr);
+            }
+
+            child <- list(value);
+            names(child) <- name_sym;
+            last_child <<- last_child + 1;
+            children[[last_child]] <<- child;
         }
-      }
     }
-  }
-  
-  # If it is an atomic vector, a list or a language object, it might have children,
-  # some of which are possibly named.
-  if (is.atomic(obj) || is.list(obj) || (is.language(obj) && !is.symbol(obj))) {
-    process_items();
-  }
-    
-  # Trim the preallocated vector to the actual number of children placed in it.
-  if (last_child == 0) list() else children[1:last_child]
+
+    if (is.environment(obj)) {
+        process_env();
+    }
+
+    process_slots <- function() {
+        is_S4 <- isS4(obj);
+        names <- NA_if_error(slotNames(class(obj)));
+
+        if (!is.null(count)) {
+            names <- head(names, count);
+            count <<- count - length(names);
+        }
+
+        for (name in names) {
+            name <- force_toString(name);
+            # If a binding has an empty name, or it wasn't a string, it cannot be accessed, so ignore it.
+            if (name == '') {
+                next;
+            }
+
+            name_sym <- symbol_token(name);
+
+            # For S4 objects, slots can be accessed with '@'. For other objects, we have to
+            # use slot(). Still, always use '@' as accessor name to show to the user.
+            accessor <- paste0('@', name_sym, collapse = '');
+            if (is_S4) {
+                slot_expr <- paste0(expr, accessor, collapse = '')
+            } else {
+                slot_expr <- paste0('methods::slot((', expr, '), ', deparse_str(name), ')', collapse = '')
+            }
+
+            value <- eval_and_describe(slot_expr, environment(), '@', fields, slot(obj, name), repr);
+
+            child <- list(value);
+            names(child) <- accessor;
+            last_child <<- last_child + 1;
+            children[[last_child]] <<- child;
+        }
+    }
+
+    # Not just S4 objects have slots, so run this on everything - slotNames() will always
+    # do the right thing.
+    process_slots();
+
+    process_items <- function() {
+        n <- length(obj);
+
+        names <- names(obj);
+        if (!is.character(names)) {
+            names <- NULL;
+        }
+
+        # For list and language, we always want to show their children, even if there's only one.
+        # For vectors, we don't want to show the child if that's the only item in the vector, to
+        # avoid presenting an infinitely recursive model (a vector of size 1 has the only child,
+        # which is another vector of size 1 etc). However, we do want to show the only child if
+        # it is named, so that the name is exposed.
+        if (n != 1 || !is.atomic(obj) || (length(names) >= 1 && !(is.null(names[[1]]) || is.na(names[[1]]) || names[[1]] == ''))) {
+            if (!is.null(count)) {
+                n <- min(n, count);
+                count <<- count - n;
+            }
+
+            if (n >= 1) {
+                for (i in 1:n) {
+                    # Start with the assumption that this is an unnamed item, accessed by position.
+                    accessor <- paste0('[[', as.double(i), ']]', collapse = '');
+                    kind <- '[[';
+
+                    # If it has a name, it is a named item - but only if that name is unique, or
+                    # if this item corresponds to the first mention of that name - i.e. if we have
+                    # c(1,2,3), and names() is c('x','y','x'), then c[[1]] is named 'x', but c[[3]]
+                    # is effectively unnamed, because there's no way to address it by name.
+                    name <- tryCatch({
+                        names[[i]]
+                    }, error = function(e) {
+                        NULL
+                    });
+                    name <- force_toString(name);
+                    if (name != '' && match(name, names, -1) == i) {
+                        kind <- '$';
+                        # Named items can be accessed with '$' in lists, but other types require brackets.
+                        if (is.list(obj)) {
+                            accessor <- paste0('$', symbol_token(name), collapse = '');
+                        } else {
+                            accessor <- paste0('[[', deparse_str(name), ']]', collapse = '');
+                        }
+                    }
+
+                    value <- eval_and_describe(paste0(expr, accessor, collapse = ''), environment(), kind, fields, obj[[i]], repr);
+
+                    child <- list(value);
+                    names(child) <- accessor;
+                    last_child <<- last_child + 1;
+                    children[[last_child]] <<- child;
+                }
+            }
+        }
+    }
+
+    # If it is an atomic vector, a list or a language object, it might have children,
+    # some of which are possibly named.
+    if (is.atomic(obj) || is.list(obj) || (is.language(obj) && !is.symbol(obj))) {
+        process_items();
+    }
+
+    # Trim the preallocated vector to the actual number of children placed in it.
+    if (last_child == 0) list() else children[1:last_child]
 }

--- a/src/Host/Client/Impl/rtvs/R/graphics.R
+++ b/src/Host/Client/Impl/rtvs/R/graphics.R
@@ -26,14 +26,14 @@ graphics.ide.clearplots <- function(device_id) {
 }
 
 graphics.ide.copyplot <- function(source_device_id, source_plot_id, target_device_id) {
-   invisible(external_embedded('ide_graphicsdevice_copy_plot', source_device_id, source_plot_id, target_device_id))
+    invisible(external_embedded('ide_graphicsdevice_copy_plot', source_device_id, source_plot_id, target_device_id))
 }
 
 graphics.ide.removeplot <- function(device_id, plot_id) {
     invisible(external_embedded('ide_graphicsdevice_remove_plot', device_id, plot_id))
 }
 
-graphics.ide.selectplot <- function(device_id, plot_id, force_render=TRUE) {
+graphics.ide.selectplot <- function(device_id, plot_id, force_render = TRUE) {
     invisible(external_embedded('ide_graphicsdevice_select_plot', device_id, plot_id, force_render))
 }
 

--- a/src/Host/Client/Impl/rtvs/R/grid.R
+++ b/src/Host/Client/Impl/rtvs/R/grid.R
@@ -2,89 +2,89 @@
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
 grid_header_format <- function(x)
-	if (is.na(x)) NULL else format(x)
+    if (is.na(x)) NULL else format(x)
 
 # Given a 2D data object and indices of columns, returns a vector of row indices indicating the appropriate order
 # of rows if the data is sorted by the columns specified. A positive column index indicates ascending order, and
 # a positive index indicates descending order. If a column cannot be sorted (e.g. because it contains values of
 # different types, or otherwise incomparable), it is ignored.
 grid_order <- function(x, ...) {
-	col_idxs <- c(...)
+    col_idxs <- c(...)
 
-	# order() will do the heavy lifting, but we need to prepare the arguments for it.
-	# Use xtfrm() to get a vector of integers that will sort in the same order as the original data -
-	# this allows us to negate those integers to obtain descending order.
-	# If the column is a list (and hence can contain heterogenous values that cannot be meaningfully
-	# compared), xtfrm will raise an error; handle that by producing a vector of zeroes, which will
-	# make that column a no-op for order().
-	args <- list()
-	for (col_idx in col_idxs) {
-		col <- x[, abs(col_idx)]
-		args[[length(args) + 1]] <- tryCatch(
-			xtfrm(col) * sign(col_idx),
-			error = function(e) replicate(length(col), 0))
-	}
+    # order() will do the heavy lifting, but we need to prepare the arguments for it.
+    # Use xtfrm() to get a vector of integers that will sort in the same order as the original data -
+    # this allows us to negate those integers to obtain descending order.
+    # If the column is a list (and hence can contain heterogenous values that cannot be meaningfully
+    # compared), xtfrm will raise an error; handle that by producing a vector of zeroes, which will
+    # make that column a no-op for order().
+    args <- list()
+    for (col_idx in col_idxs) {
+        col <- x[, abs(col_idx)]
+        args[[length(args) + 1]] <- tryCatch(
+            xtfrm(col) * sign(col_idx),
+            error = function(e) replicate(length(col), 0))
+    }
 
-	do.call(order, args)
+    do.call(order, args)
 }
 
 grid_data <- function(x, rows, cols, row_selector) {
-  # If it's a 1D vector, turn it into a single-column 2D matrix, then process as such.
-  d <- dim(x);
-  if (is.null(d) || length(d) == 1) {
-    vp <- grid_data(matrix(x), rows, cols, row_selector)
-    vp$is_1d <- TRUE;
-    return(vp);
-  }
+    # If it's a 1D vector, turn it into a single-column 2D matrix, then process as such.
+    d <- dim(x);
+    if (is.null(d) || length(d) == 1) {
+        vp <- grid_data(matrix(x), rows, cols, row_selector)
+        vp$is_1d <- TRUE;
+        return(vp);
+    }
 
-  if (missing(rows)) {
-    rows <- 1:d[[1]];
-  }
-  if (missing(cols)) {
-    cols <- 1:d[[2]];
-  }
+    if (missing(rows)) {
+        rows <- 1:d[[1]];
+    }
+    if (missing(cols)) {
+        cols <- 1:d[[2]];
+    }
 
-  if (!missing(row_selector)) {
-      x <- x[row_selector(x),, drop = FALSE]
-  }
-  x <- x[rows, cols, drop = FALSE]
+    if (!missing(row_selector)) {
+        x <- x[row_selector(x),, drop = FALSE]
+    }
+    x <- x[rows, cols, drop = FALSE]
 
-  # Process and format values column by column, then flatten the resulting list of character vectors.
-  max_length <- 100 - 3
-  data <- c(lapply(1:ncol(x), function(i) {
-    lapply(format(x[,i], trim = TRUE, justify = "none"), function(s) {
-        if (is.na(s)) { 'NA' }
-        else if (nchar(s) <= max_length) { s }
-        else { paste0(substr(s, 1, max_length), '...', collapse = '') }
-    })
-  }), recursive = TRUE)
+    # Process and format values column by column, then flatten the resulting list of character vectors.
+    max_length <- 100 - 3
+    data <- c(lapply(1:ncol(x), function(i) {
+        lapply(format(x[, i], trim = TRUE, justify = "none"), function(s) {
+            if (is.na(s)) { 'NA' }
+            else if (nchar(s) <= max_length) { s }
+            else { paste0(substr(s, 1, max_length), '...', collapse = '') }
+        })
+    }), recursive = TRUE)
 
-  # Any names in the original data will flow through, but we don't want them.
-  names(data) <- NULL;
+    # Any names in the original data will flow through, but we don't want them.
+    names(data) <- NULL;
 
-  rn <- row.names(x);
-  cn <- colnames(x);
+    rn <- row.names(x);
+    cn <- colnames(x);
 
-  # Format row names
-  x.rownames <- NULL;
-  if (length(rn) > 0) {
-    x.rownames <- sapply(rn, grid_header_format, USE.NAMES = FALSE);
-  }
+    # Format row names
+    x.rownames <- NULL;
+    if (length(rn) > 0) {
+        x.rownames <- sapply(rn, grid_header_format, USE.NAMES = FALSE);
+    }
 
-  # Format column names
-  x.colnames <- NULL;
-  if (!is.null(cn) && (length(cn) > 0)) {
-    x.colnames <- sapply(cn, grid_header_format, USE.NAMES = FALSE);
-  }
+    # Format column names
+    x.colnames <- NULL;
+    if (!is.null(cn) && (length(cn) > 0)) {
+        x.colnames <- sapply(cn, grid_header_format, USE.NAMES = FALSE);
+    }
 
-  # assign return value
-  vp <- list();
-  vp$row.start <- rows[1];
-  vp$row.count <- length(rows);
-  vp$row.names <- as.list(x.rownames);
-  vp$col.start <- cols[1];
-  vp$col.count <- length(cols);
-  vp$col.names <- as.list(x.colnames);
-  vp$data <- as.list(data);
-  vp;
+    # assign return value
+    vp <- list();
+    vp$row.start <- rows[1];
+    vp$row.count <- length(rows);
+    vp$row.names <- as.list(x.rownames);
+    vp$col.start <- cols[1];
+    vp$col.count <- length(cols);
+    vp$col.names <- as.list(x.colnames);
+    vp$data <- as.list(data);
+    vp;
 }

--- a/src/Host/Client/Impl/rtvs/R/mirror.R
+++ b/src/Host/Client/Impl/rtvs/R/mirror.R
@@ -6,24 +6,24 @@ original_mirror <- as.environment(list(url = NULL))
 # If url is not NULL, set CRAN mirror to that URL.
 # If it is NULL, restore CRAN mirror URL to the original value that it had before the first call to set_mirror.
 set_mirror <- function(url) {
-  repos <- getOption('repos')
+    repos <- getOption('repos')
 
-  if (is.null(url)) {
-    if (!is.null(original_mirror$url)) {
-      repos[['CRAN']] <- original_mirror$url
-	}
+    if (is.null(url)) {
+        if (!is.null(original_mirror$url)) {
+            repos[['CRAN']] <- original_mirror$url
+        }
 
-	# If the only mirror on the list is @CRAN@, it will trigger the mirror selector UI every time.
-	# To avoid that, override it to point to the automatic mirror redirection service that will pick the right one by itself. 
-    if (identical(repos[['CRAN']], '@CRAN@')) {
-	  repos[['CRAN']] <- 'https://cloud.r-project.org/'
-	}
-  } else {
-	if (is.null(original_mirror$url)) {
-       original_mirror$url <- repos[['CRAN']]
-	}
-    repos[['CRAN']] <- url
-  }
+        # If the only mirror on the list is @CRAN@, it will trigger the mirror selector UI every time.
+        # To avoid that, override it to point to the automatic mirror redirection service that will pick the right one by itself. 
+        if (identical(repos[['CRAN']], '@CRAN@')) {
+            repos[['CRAN']] <- 'https://cloud.r-project.org/'
+        }
+    } else {
+        if (is.null(original_mirror$url)) {
+            original_mirror$url <- repos[['CRAN']]
+        }
+        repos[['CRAN']] <- url
+    }
 
-  options(repos = repos)
+    options(repos = repos)
 }

--- a/src/Host/Client/Impl/rtvs/R/overrides.R
+++ b/src/Host/Client/Impl/rtvs/R/overrides.R
@@ -2,30 +2,31 @@
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
 view <- function(x, title) {
-  if(is.function(x) || is.data.frame(x) || is.table(x) || 
-     is.matrix(x) || is.list(x) || is.ts(x) || length(x) > 1) {
-    dep <- deparse(substitute(x), backtick = TRUE)
-    if (missing(title)) {
-      title <- dep[1]
+    if (is.function(x) || is.data.frame(x) || is.table(x) ||
+        is.matrix(x) || is.list(x) || is.ts(x) || length(x) > 1) {
+
+        dep <- deparse(substitute(x), backtick = TRUE)
+        if (missing(title)) {
+            title <- dep[1]
+        }
+        invisible(rtvs:::send_notification('!View', dep, title))
+    } else {
+        print(x)
     }
-    invisible(rtvs:::send_notification('!View', dep, title))
-  } else {
-    print(x)
-  }
 }
 
 open_url <- function(url) {
-  rtvs:::send_notification('!WebBrowser', url)
+    rtvs:::send_notification('!WebBrowser', url)
 }
 
 setwd <- function(dir) {
-  old <- .Internal(setwd(dir))
-  rtvs:::send_notification('!SetWD', dir)
-  invisible(old)
+    old <- .Internal(setwd(dir))
+    rtvs:::send_notification('!SetWD', dir)
+    invisible(old)
 }
 
 redirect_functions <- function(...) {
-  attach(as.environment(
+    attach(as.environment(
            list(View = rtvs:::view,
                 library = rtvs:::library,
                 install.packages = rtvs:::install.packages,
@@ -34,31 +35,31 @@ redirect_functions <- function(...) {
 }
 
 library <- function(...) {
-  if (nargs() == 0) {
-    invisible(rtvs:::send_notification('!Library'))
-  } else {
-    base::library(...)
-  }
+    if (nargs() == 0) {
+        invisible(rtvs:::send_notification('!Library'))
+    } else {
+        base::library(...)
+    }
 }
 
 show_file <- function(files, header, title, delete.file) {
-  cFiles <- length(files)
-  for (i in cFiles) {
-    if ((i > length(header)) || !nzchar(header[[i]])) {
-      tabName <- title
-    } else {
-      tabName <- header[[i]]
+    cFiles <- length(files)
+    for (i in cFiles) {
+        if ((i > length(header)) || !nzchar(header[[i]])) {
+            tabName <- title
+        } else {
+            tabName <- header[[i]]
+        }
+        invisible(rtvs:::send_notification('!ShowFile', files[[i]], tabName, delete.file))
     }
-    invisible(rtvs:::send_notification('!ShowFile', files[[i]], tabName, delete.file))
-  }
 }
 
 install.packages <- function(...) {
-  utils::install.packages(...)
-  invisible(rtvs:::send_notification('!PackagesInstalled'))
+    utils::install.packages(...)
+    invisible(rtvs:::send_notification('!PackagesInstalled'))
 }
 
 remove.packages <- function(...) {
-  utils::remove.packages(...)
-  invisible(rtvs:::send_notification('!PackagesRemoved'))
+    utils::remove.packages(...)
+    invisible(rtvs:::send_notification('!PackagesRemoved'))
 }

--- a/src/Host/Client/Impl/rtvs/R/packages.R
+++ b/src/Host/Client/Impl/rtvs/R/packages.R
@@ -2,86 +2,86 @@
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
 packages.installed <- function() {
-  pkgs <- installed.packages(fields = c('Title', 'Author', 'Description'))
-  pkgs <- pkgs[!duplicated(pkgs[, 'Package']),]
-  pkgs <- apply(pkgs, 1, as.list)
-  unname(pkgs)
+    pkgs <- installed.packages(fields = c('Title', 'Author', 'Description'))
+    pkgs <- pkgs[!duplicated(pkgs[, 'Package']),]
+    pkgs <- apply(pkgs, 1, as.list)
+    unname(pkgs)
 }
 
 packages.loaded <- function() {
-  as.list(.packages())
+    as.list(.packages())
 }
 
 packages.libpaths <- function() {
-  as.list(.libPaths())
+    as.list(.libPaths())
 }
 
 download.packages.rds <- function(repo.url) {
   # download the repository's packages.rds and return path to the temp file
-  pkg.rds.url <- gsub("src/contrib", "web/packages/packages.rds", repo.url)
-  pkg.rds.path <- tempfile('pkg', fileext = '.rds')
-  suppressWarnings(download.file(pkg.rds.url, destfile = pkg.rds.path, quiet = TRUE, mode = "wb"))
-  return(pkg.rds.path)
+    pkg.rds.url <- gsub("src/contrib", "web/packages/packages.rds", repo.url)
+    pkg.rds.path <- tempfile('pkg', fileext = '.rds')
+    suppressWarnings(download.file(pkg.rds.url, destfile = pkg.rds.path, quiet = TRUE, mode = "wb"))
+    return(pkg.rds.path)
 }
 
 read.packages.rds <- function(pkg.rds.path) {
   # read packages.rds into a data frame, only keep details fields
-  details.fields <- c('Package', 'Title', 'Description', 'Built', 'URL', 'Author')
-  extra <- readRDS(pkg.rds.path)
-  extra <- as.data.frame(extra, stringsAsFactors = FALSE, rownames = extra[, 'Package'])
-  return(extra[details.fields])
+    details.fields <- c('Package', 'Title', 'Description', 'Built', 'URL', 'Author')
+    extra <- readRDS(pkg.rds.path)
+    extra <- as.data.frame(extra, stringsAsFactors = FALSE, rownames = extra[, 'Package'])
+    return(extra[details.fields])
 }
 
 add.details <- function(repo.available, repo.url) {
-  # fetch details from the repository's packages.rds file
-  # and merge those details with the packages data frame passed in.
-  # if we can't download or read the repo's packages.rds file,
-  # we return the original package data frame (this happens for repos
-  # that are not CRAN mirrors).
-  tryCatch({
-      pkg.rds.path <- download.packages.rds(repo.url)
-      repo.details <- read.packages.rds(pkg.rds.path)
-      repo.available.with.details <- merge(repo.available, repo.details, by = 'Package', all.x = TRUE)
+    # fetch details from the repository's packages.rds file
+    # and merge those details with the packages data frame passed in.
+    # if we can't download or read the repo's packages.rds file,
+    # we return the original package data frame (this happens for repos
+    # that are not CRAN mirrors).
+    tryCatch({
+        pkg.rds.path <- download.packages.rds(repo.url)
+        repo.details <- read.packages.rds(pkg.rds.path)
+        repo.available.with.details <- merge(repo.available, repo.details, by = 'Package', all.x = TRUE)
 
-      # merged data frame lost its row names, so add them back
-      rownames(repo.available.with.details) <- repo.available.with.details[, 'Package']
+        # merged data frame lost its row names, so add them back
+        rownames(repo.available.with.details) <- repo.available.with.details[, 'Package']
 
-      unlink(pkg.rds.path)
-      return(repo.available.with.details)
+        unlink(pkg.rds.path)
+        return(repo.available.with.details)
     },
     error = function(e) {
-      # we couldn't get the details from packages.rds, so we
-      # return the original data frame, which doesn't have the details
-      return(repo.available)
+        # we couldn't get the details from packages.rds, so we
+        # return the original data frame, which doesn't have the details
+        return(repo.available)
     }
   )
 }
 
 packages.available <- function() {
-  # retrieve all available packages from all repos
-  base.fields <- c('Package', 'Version', 'Depends', 'Imports', 'Suggests',
+    # retrieve all available packages from all repos
+    base.fields <- c('Package', 'Version', 'Depends', 'Imports', 'Suggests',
                    'Enhances', 'License', 'NeedsCompilation', 'Repository')
-  all.available <- available.packages()
-  all.available <- as.data.frame(all.available, stringsAsFactors = FALSE)
-  all.available <- all.available[base.fields]
+    all.available <- available.packages()
+    all.available <- as.data.frame(all.available, stringsAsFactors = FALSE)
+    all.available <- all.available[base.fields]
 
-  # the urls of the repos we'll need to get additional details from
-  repo.urls <- unique(all.available[, 'Repository'])
+    # the urls of the repos we'll need to get additional details from
+    repo.urls <- unique(all.available[, 'Repository'])
 
-  # we return an unnamed list
-  # each element in that list is a named list
-  # ie. Package='abc', Version='1.0', Title='', etc.
-  res <- list()
-  for (repo.url in repo.urls) {
-    # the available packages from this repo
-    repo.available <- all.available[all.available$Repository == repo.url,]
+    # we return an unnamed list
+    # each element in that list is a named list
+    # ie. Package='abc', Version='1.0', Title='', etc.
+    res <- list()
+    for (repo.url in repo.urls) {
+        # the available packages from this repo
+        repo.available <- all.available[all.available$Repository == repo.url,]
 
-    # merge details from this repo's packages.rds
-    repo.available.with.details <- add.details(repo.available, repo.url)
+        # merge details from this repo's packages.rds
+        repo.available.with.details <- add.details(repo.available, repo.url)
 
-    # append to our result each row of the dataframe as a named list
-    res <- append(res, apply(repo.available.with.details, 1, function(x) as.list(x)))
-  }
+        # append to our result each row of the dataframe as a named list
+        res <- append(res, apply(repo.available.with.details, 1, function(x) as.list(x)))
+    }
 
-  return(unname(res))
+    return(unname(res))
 }

--- a/src/Host/Client/Impl/rtvs/R/repr.R
+++ b/src/Host/Client/Impl/rtvs/R/repr.R
@@ -6,16 +6,16 @@
 #
 # If `max_length` is not NULL, the representation is trimmed if it exceeds the provided length. 
 make_repr_deparse <- function(max_length = NULL) {
-	function(obj) {
-		paste0(collapse = '',
-			if (is.null(max_length)) {
-				deparse(obj)
-			} else {
-				# Force max length into range permitted by deparse
-				cutoff <- min(max(max_length, 20), 500);
-				deparse(obj, width.cutoff = cutoff, nlines = 1)
-			})
-	}
+    function(obj) {
+        paste0(collapse = '',
+            if (is.null(max_length)) {
+                deparse(obj)
+            } else {
+                # Force max length into range permitted by deparse
+                cutoff <- min(max(max_length, 20), 500);
+                deparse(obj, width.cutoff = cutoff, nlines = 1)
+            })
+    }
 }
 
 # Returns a repr function, suitable for use with `describe_object`, that uses `str` to
@@ -34,31 +34,31 @@ make_repr_deparse <- function(max_length = NULL) {
 # `max_length`. Sufficient number of characters is discarded from the result to ensure
 # that the overall length is no more than `max_length`.
 make_repr_str <- function(max_length = NULL, expected_length = NULL, overflow_suffix = '...') {
-	function(obj) {
-	  con <- memory_connection(max_length, expected_length, overflow_suffix, eof_marker = '\n');
-	  on.exit(close(con), add = TRUE);
+    function(obj) {
+        con <- memory_connection(max_length, expected_length, overflow_suffix, eof_marker = '\n');
+        on.exit(close(con), add = TRUE);
 
-	  tryCatch({
-		if (length(obj) == 1) {
-		  if (any(class(obj) == 'factor')) {
-			if (is.na(obj) && !is.nan(obj)) {
-			  cat('NA', file = con);
-			} else {
-			  capture.output(str(levels(obj)[[obj]], max.level = 0, give.head = FALSE), file = con);
-			}
-		  } else {
-			capture.output(str(obj, max.level = 0, give.head = FALSE), file = con);
-		  }
-		} else {
-		  capture.output(str(obj, max.level = 0, give.head = TRUE), file = con);
-		}
-	  }, error = function(e) {
-	  });
-    
-	  str <- memory_connection_tochar(con);
-	  if (length(str) == 0) NA else str;
-	}
+        tryCatch({
+            if (length(obj) == 1) {
+                if (any(class(obj) == 'factor')) {
+                    if (is.na(obj) && !is.nan(obj)) {
+                        cat('NA', file = con);
+                    } else {
+                        capture.output(str(levels(obj)[[obj]], max.level = 0, give.head = FALSE), file = con);
+                    }
+                } else {
+                    capture.output(str(obj, max.level = 0, give.head = FALSE), file = con);
+                }
+            } else {
+                capture.output(str(obj, max.level = 0, give.head = TRUE), file = con);
+            }
+        }, error = function(e) {
+        });
+
+        str <- memory_connection_tochar(con);
+        if (length(str) == 0) NA else str;
+    }
 }
 
 repr_toString <- function(obj)
-	paste0(toString(obj), collapse = '')
+paste0(toString(obj), collapse = '')

--- a/src/Host/Client/Impl/rtvs/R/traceback.R
+++ b/src/Host/Client/Impl/rtvs/R/traceback.R
@@ -2,34 +2,34 @@
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
 describe_traceback <- function() {
-  calls <- sys.calls();
-  nframe <- sys.nframe();
+    calls <- sys.calls();
+    nframe <- sys.nframe();
 
-  frames <- vector('list', nframe);
+    frames <- vector('list', nframe);
 
-  for (i in 1:nframe) {
-    frame <- list();
-    call <- sys.call(i);
-    env <- sys.frame(i - 1);
-    
-    frame$call <- if (is.null(call)) NULL else deparse_str(call);
+    for (i in 1:nframe) {
+        frame <- list();
+        call <- sys.call(i);
+        env <- sys.frame(i - 1);
 
-    frame$filename <- NA_if_error(force_toString(utils::getSrcFilename(call, full.names = TRUE)));
-    if (identical(frame$filename, '')) {
-      frame$filename <- NA;
+        frame$call <- if (is.null(call)) NULL else deparse_str(call);
+
+        frame$filename <- NA_if_error(force_toString(utils::getSrcFilename(call, full.names = TRUE)));
+        if (identical(frame$filename, '')) {
+            frame$filename <- NA;
+        }
+
+        frame$line_number <- NA_if_error(force_number(utils::getSrcLocation(call, which = 'line')));
+
+        # For nameless environments like those of functions, it will be something useless like
+        # <environment: 0x0000000012aaabb0>, so omit it for them - callers are expected to use
+        # $call of the calling environment in that case if they need a UI label.
+        if (!identical(environmentName(env), '')) {
+            frame$env_name <- format(env);
+        }
+
+        frames[[i]] <- frame;
     }
-    
-    frame$line_number <- NA_if_error(force_number(utils::getSrcLocation(call, which = 'line')));
 
-	# For nameless environments like those of functions, it will be something useless like
-	# <environment: 0x0000000012aaabb0>, so omit it for them - callers are expected to use
-	# $call of the calling environment in that case if they need a UI label.
-	if (!identical(environmentName(env), '')) {
-	  frame$env_name <- format(env);
-	}
-   
-    frames[[i]] <- frame;
-  }
-
-  frames
+    frames
 }

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -4,11 +4,11 @@
 version <- 1
 
 call_embedded <- function(name, ...) {
-  .Call(paste0('Microsoft.R.Host::Call.', name, collapse = ''), ..., PACKAGE = '(embedding)')
+    .Call(paste0('Microsoft.R.Host::Call.', name, collapse = ''), ..., PACKAGE = '(embedding)')
 }
 
 external_embedded <- function(name, ...) {
-  .External(paste0('Microsoft.R.Host::External.', name, collapse = ''), ..., PACKAGE = '(embedding)')
+    .External(paste0('Microsoft.R.Host::External.', name, collapse = ''), ..., PACKAGE = '(embedding)')
 }
 
 send_notification <- function(name, ...) {
@@ -20,39 +20,39 @@ send_request_and_get_response <- function(name, ...) {
 }
 
 memory_connection <- function(max_length = NA, expected_length = NA, overflow_suffix = '', eof_marker = '') {
-  call_embedded('memory_connection', max_length, expected_length, overflow_suffix, eof_marker)
+    call_embedded('memory_connection', max_length, expected_length, overflow_suffix, eof_marker)
 }
 
 memory_connection_overflown <- function(con) {
-  call_embedded('memory_connection_overflown', con)
+    call_embedded('memory_connection_overflown', con)
 }
 
 memory_connection_tochar <- function(con) {
-  call_embedded('memory_connection_tochar', con)
+    call_embedded('memory_connection_tochar', con)
 }
 
 unevaluated_promise <- function(name, env) {
-  call_embedded("unevaluated_promise", name, env)
+    call_embedded("unevaluated_promise", name, env)
 }
 
 is_missing <- function(name, env) {
-  call_embedded("is_missing", name, env)
+    call_embedded("is_missing", name, env)
 }
 
 is_rdebug <- function(obj) {
-  call_embedded("is_rdebug", obj)
+    call_embedded("is_rdebug", obj)
 }
 
 set_rdebug <- function(obj, debug) {
-  call_embedded("set_rdebug", obj, debug)
+    call_embedded("set_rdebug", obj, debug)
 }
 
 browser_set_debug <- function(n = 1, skip_toplevel = 0) {
-  call_embedded("browser_set_debug", n, skip_toplevel)
+    call_embedded("browser_set_debug", n, skip_toplevel)
 }
 
 toJSON <- function(obj) {
-  call_embedded("toJSON", obj)
+    call_embedded("toJSON", obj)
 }
 
 create_blob <- function(obj) {
@@ -72,71 +72,71 @@ set_disconnect_callback <- function(callback) {
 }
 
 NA_if_error <- function(expr) {
-  tryCatch(expr, error = function(e) { NA })
+    tryCatch(expr, error = function(e) { NA })
 }
 
 NULL_if_error <- function(expr) {
-  tryCatch(expr, error = function(e) { NULL })
+    tryCatch(expr, error = function(e) { NULL })
 }
 
 # Like toString, but guarantees that result is a single-element character vector.
 force_toString <- function(obj) {
-  if (is.null(obj) || (length(obj) == 1 && is.atomic(obj) && is.na(obj) && !is.nan(obj))) {
-    return('');
-  }
-  s <- paste0(toString(obj), collapse='');
-  if (!is.character(s) || length(s) != 1 || is.na(s)) '' else s;
+    if (is.null(obj) || (length(obj) == 1 && is.atomic(obj) && is.na(obj) && !is.nan(obj))) {
+        return('');
+    }
+    s <- paste0(toString(obj), collapse = '');
+    if (!is.character(s) || length(s) != 1 || is.na(s)) '' else s;
 }
 
 # Guarantees that result is a single-element numeric vector or NA.
 force_number <- function(x) {
-  if (!is.numeric(x) || length(x) != 1) NA else x;
+    if (!is.numeric(x) || length(x) != 1) NA else x;
 }
 
 # Like dput, but returns the value as string rather than printing it, and can limit
 # the output to a desired length.
 dput_str <- function(obj, max_length = NA, expected_length = NA, overflow_suffix = '...') {
-  con <- memory_connection(max_length, expected_length, overflow_suffix);
-  on.exit(close(con), add = TRUE);
-  
-  tryCatch({
-    dput(obj, con);
-  }, error = function(e) {
-  });
-  
+    con <- memory_connection(max_length, expected_length, overflow_suffix);
+    on.exit(close(con), add = TRUE);
+
+    tryCatch({
+        dput(obj, con);
+    }, error = function(e) {
+    });
+
   # Strip leading and trailing whitespace - it is never significant, and there's always
   # at least a trailing '\n' that dput always outputs.
-  gsub("^\\s+|\\s+$", "", memory_connection_tochar(con))
+    gsub("^\\s+|\\s+$", "", memory_connection_tochar(con))
 }
 
 # Like deparse, but always returns a single string.
 deparse_str <- function(x)
-    paste0(deparse(x), collapse = '')
+paste0(deparse(x), collapse = '')
 
 # Makes a symbol token (properly quoted with backticks if necessary) out of a symbol or a string.
 symbol_token <- function(name) {
-  s <- force_toString(name);
+    s <- force_toString(name);
 
   # If it's an empty string, it's not a valid symbol, even if quoted.
-  if (identical(s, '')) {
-      return(NULL);
-  }
+    if (identical(s, '')) {
+        return(NULL);
+    }
 
   # If it's a valid identifier, it's good to go as is. Because the definition of identifier in R
   # is locale-dependent, be conservative and match ASCII only; excessive quoting is always safe.
-  if (grepl('^[A-Za-z_.][A-Za-z0-9_.]*$', name)) {
-      return(s);
-  }
+    if (grepl('^[A-Za-z_.][A-Za-z0-9_.]*$', name)) {
+        return(s);
+    }
 
   # Deparse it - this will take care of all the necessary escaping for everything other than
   # backticks, but will also put double quotes around that we'll remove later.
-  s <- deparse_str(force_toString(s));
+    s <- deparse_str(force_toString(s));
 
   # Escape any backticks.
-  s <- gsub('`', '\\`', s, fixed = TRUE);
+    s <- gsub('`', '\\`', s, fixed = TRUE);
 
   # Replace surrounding quotes with backticks.
-  paste0('`', substr(s, 2, nchar(s) - 1), '`', collapse = '')
+    paste0('`', substr(s, 2, nchar(s) - 1), '`', collapse = '')
 }
 
 # Like eval, but will not enter Browse mode if env has its debug bit set
@@ -155,19 +155,19 @@ safe_eval <- function(expr, env) {
 export_to_csv <- function(expr, sep, dec) {
     res <- expr
     ln <- length(res) + 1
-    filepath <- tempfile('export_', fileext='.csv')
+    filepath <- tempfile('export_', fileext = '.csv')
     on.exit(unlink(filepath))
-    write.table(res, file=filepath, qmethod='double', col.names=NA, sep=sep, dec=dec)
+    write.table(res, file = filepath, qmethod = 'double', col.names = NA, sep = sep, dec = dec)
     create_blob(readBin(filepath, 'raw', file.info(filepath)$size))
 }
 
 # Helper to export current plot to image
 export_to_image <- function(device_id, plot_id, device, width, height, resolution) {
     prev_device_num <- dev.cur()
-    graphics.ide.selectplot(device_id, plot_id, force_render=FALSE)
-    filepath <- tempfile('plot_', fileext='.dat')
+    graphics.ide.selectplot(device_id, plot_id, force_render = FALSE)
+    filepath <- tempfile('plot_', fileext = '.dat')
     on.exit(unlink(filepath))
-    dev.copy(device=device,filename=filepath,width=width,height=height,res=resolution)
+    dev.copy(device = device, filename = filepath, width = width, height = height, res = resolution)
     dev.off()
     dev.set(prev_device_num)
     create_blob(readBin(filepath, 'raw', file.info(filepath)$size))
@@ -176,10 +176,10 @@ export_to_image <- function(device_id, plot_id, device, width, height, resolutio
 # Helper to export current plot to pdf
 export_to_pdf <- function(device_id, plot_id, width, height) {
     prev_device_num <- dev.cur()
-    graphics.ide.selectplot(device_id, plot_id, force_render=FALSE)
-    filepath <- tempfile('plot_',fileext='.pdf')
+    graphics.ide.selectplot(device_id, plot_id, force_render = FALSE)
+    filepath <- tempfile('plot_', fileext = '.pdf')
     on.exit(unlink(filepath))
-    dev.copy(device=pdf,file=filepath,width=width,height=height)
+    dev.copy(device = pdf, file = filepath, width = width, height = height)
     dev.off()
     dev.set(prev_device_num)
     create_blob(readBin(filepath, 'raw', file.info(filepath)$size))
@@ -207,7 +207,7 @@ rmarkdown_publish <- function(blob_id, output_format, encoding) {
     output_filepath <- tempfile('rmd_', fileext = fileext);
     on.exit(unlink(output_filepath));
 
-    rmarkdown::render(rmdpath, output_format = output_format, output_file = output_filepath,  output_dir = tempdir(), encoding = encoding);
+    rmarkdown::render(rmdpath, output_format = output_format, output_file = output_filepath, output_dir = tempdir(), encoding = encoding);
     create_blob(readBin(output_filepath, 'raw', file.info(output_filepath)$size));
 }
 
@@ -216,7 +216,7 @@ as.lock_state <- function(x) {
 }
 
 package_lock_state <- function(package_name, lib_path) {
-    files <- dir(path = paste0(lib_path,'/', package_name), pattern = '\\.', recursive = TRUE, ignore.case = TRUE, full.names = TRUE)
+    files <- dir(path = paste0(lib_path, '/', package_name), pattern = '\\.', recursive = TRUE, ignore.case = TRUE, full.names = TRUE)
     fstate <- call_embedded('get_file_lock_state', files);
     as.lock_state(fstate);
 }
@@ -250,50 +250,50 @@ save_to_project_folder <- function(blob_id, project_name, dest_dir) {
 autosave_filename <- '~/.Autosave.RData';
 
 query_reload_autosave <- function() {
-	if (!file.exists(autosave_filename)) {
-		return(FALSE);
-	}
+    if (!file.exists(autosave_filename)) {
+        return(FALSE);
+    }
 
-	msg <- 'Previous R session terminated unexpectedly due to connectivity issues, and its global workspace has been saved to image "%s". Would you like to reload it?';
-	res <- winDialog('yesno', sprintf(msg, autosave_filename));
+    msg <- 'Previous R session terminated unexpectedly due to connectivity issues, and its global workspace has been saved to image "%s". Would you like to reload it?';
+    res <- winDialog('yesno', sprintf(msg, autosave_filename));
 
-	if (identical(res, 'YES')) {
-		# Use try instead of tryCatch, so that any errors are printed as usual.
-		loaded <- FALSE;
-		try({
-			load(autosave_filename, envir = .GlobalEnv);
-			loaded <- TRUE;
-		});
+    if (identical(res, 'YES')) {
+        # Use try instead of tryCatch, so that any errors are printed as usual.
+        loaded <- FALSE;
+        try({
+            load(autosave_filename, envir = .GlobalEnv);
+            loaded <- TRUE;
+        });
 
-		if (loaded) {
-			message(sprintf('Loaded workspace from autosaved image "%s".\n', autosave_filename));
-			# If we loaded the file successfully, it's safe to delete it - this session contains the reloaded
-			# state now, and if there's another disconnect, it will be autosaved again.
-			return(TRUE);
-		} else {
-			warning(sprintf('Failed to load workspace from autosaved image "%s".\n', autosave_filename), call. = FALSE, immediate. = TRUE);
-			return(FALSE);
-		}
-	} else {
-		msg <- 'Delete autosaved workspace image "%s"?';
-		res <- winDialog('yesno', sprintf(msg, autosave_filename));
-		return(identical(res, 'YES'));
-	}
+        if (loaded) {
+            message(sprintf('Loaded workspace from autosaved image "%s".\n', autosave_filename));
+            # If we loaded the file successfully, it's safe to delete it - this session contains the reloaded
+            # state now, and if there's another disconnect, it will be autosaved again.
+            return(TRUE);
+        } else {
+            warning(sprintf('Failed to load workspace from autosaved image "%s".\n', autosave_filename), call. = FALSE, immediate. = TRUE);
+            return(FALSE);
+        }
+    } else {
+        msg <- 'Delete autosaved workspace image "%s"?';
+        res <- winDialog('yesno', sprintf(msg, autosave_filename));
+        return(identical(res, 'YES'));
+    }
 }
 
 disconnect_callback <- function() {
-	message(sprintf('Autosaving workspace to image "%s" ...', autosave_filename));
-	save.image(autosave_filename);
-	message(' workspace saved successfully.\n');
+    message(sprintf('Autosaving workspace to image "%s" ...', autosave_filename));
+    save.image(autosave_filename);
+    message(' workspace saved successfully.\n');
 }
 
 enable_autosave <- function(delete_existing) {
-	try({
-		set_disconnect_callback(disconnect_callback);
+    try({
+        set_disconnect_callback(disconnect_callback);
 
-		if (delete_existing) {
-			message(sprintf('Deleting autosaved workspace image "%s".\n', autosave_filename));
-			unlink(autosave_filename);
-		}
-	});
+        if (delete_existing) {
+            message(sprintf('Deleting autosaved workspace image "%s".\n', autosave_filename));
+            unlink(autosave_filename);
+        }
+    });
 }

--- a/src/Host/Protocol/Impl/Microsoft.R.Host.Protocol.csproj
+++ b/src/Host/Protocol/Impl/Microsoft.R.Host.Protocol.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Message.cs" />
     <Compile Include="SessionCreateRequest.cs" />
     <Compile Include="SessionInfo.cs" />
+    <Compile Include="SessionState.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/Host/Protocol/Impl/SessionInfo.cs
+++ b/src/Host/Protocol/Impl/SessionInfo.cs
@@ -8,5 +8,7 @@ namespace Microsoft.R.Host.Protocol {
         public string InterpreterId { get; set; }
 
         public string CommandLineArguments { get; set; }
+
+        public SessionState State { get; set; }
     }
 }

--- a/src/Host/Protocol/Impl/SessionState.cs
+++ b/src/Host/Protocol/Impl/SessionState.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Microsoft.R.Host.Broker.Sessions {
+namespace Microsoft.R.Host.Protocol {
     public enum SessionState {
         Running,
         Dormant,


### PR DESCRIPTION
Resolve #2425: Automatically save host state when connection to client is lost
Resolve #2427: Prompt to reload saved session state

Disable reconnecting to live sessions.

When client disconnects from a websocket connection to broker, have broker disconnect from the host, so that the latter can shut down.

When shutting down host due to disconnect, save workspace image.

When starting a new session, check for autosaved workspace image, and prompt user to reload it.

When VS is closed, gracefully terminate any running hosts instead of just disconnecting from them.

When switching from one connection to another, gracefully terminate the old host once the switch is successful.

Expose session state in /sessions endpoint in the broker.