### PR TITLE
Switched Credential UI back CredUIPromptForCredentials instead of CredUIPromptForWindowsCredentials

### DIFF
--- a/src/Common/Core/Impl/NativeMethods.cs
+++ b/src/Common/Core/Impl/NativeMethods.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Common.Core {
         public const int CREDUI_FLAGS_KEEP_USERNAME = 0x100000;
 
         [DllImport("credui", CharSet = CharSet.Auto)]
-        public static extern int CredUIPromptForWindowsCredentials(
+        public static extern int CredUIPromptForCredentials(
             ref CREDUI_INFO pUiInfo,
             string pszTargetName,
             IntPtr Reserved,

--- a/src/Common/Core/Impl/Security/SecurityServices.cs
+++ b/src/Common/Core/Impl/Security/SecurityServices.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Common.Core.Security {
 
                 // For password, use native memory so it can be securely freed.
                 passwordStorage = SecurityUtilities.CreatePasswordBuffer();
-                int err = CredUIPromptForWindowsCredentials(ref credui, authority, IntPtr.Zero, 0,
+                int err = CredUIPromptForCredentials(ref credui, authority, IntPtr.Zero, 0,
                                           userNameBuilder, userNameBuilder.Capacity,
                                           passwordStorage, CREDUI_MAX_PASSWORD_LENGTH, ref save, flags);
                 if (err != 0) {


### PR DESCRIPTION
CredUIPromptForWindowsCredentials  does not provide a delayed save feature. Until we have a similar blessed mechanism with the newer API it seems better to use the older one. Fixes #2478