### PR TITLE
Fix #2484: Reload .RData shows in local connection case

### DIFF
--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -254,7 +254,7 @@ query_reload_autosave <- function() {
         return(FALSE);
     }
 
-    msg <- 'Previous R session terminated unexpectedly due to connectivity issues, and its global workspace has been saved to image "%s". Would you like to reload it?';
+    msg <- 'Previous R session terminated unexpectedly, and its global workspace has been saved to image "%s". Would you like to reload it?';
     res <- winDialog('yesno', sprintf(msg, autosave_filename));
 
     if (identical(res, 'YES')) {


### PR DESCRIPTION
Change message so that it is applicable to situations where the disconnect was caused by VS and/or broker crashing or being forcibly terminated.