### PR TITLE
Fix #2326: Crash after switching back to local

### DIFF
--- a/src/Host/Client/Impl/Resources.Designer.cs
+++ b/src/Host/Client/Impl/Resources.Designer.cs
@@ -166,6 +166,53 @@ namespace Microsoft.R.Host.Client {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The following exception occurred during initialization of R session, and the session has been terminated:
+        ///
+        ///{0}.
+        /// </summary>
+        internal static string Error_SessionInitialization {
+            get {
+                return ResourceManager.GetString("Error_SessionInitialization", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to enable workspace auto-saving: {0}.
+        /// </summary>
+        internal static string Error_SessionInitializationAutosave {
+            get {
+                return ResourceManager.GetString("Error_SessionInitializationAutosave", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to set R locale to codepage {0}: {1}.
+        /// </summary>
+        internal static string Error_SessionInitializationCodePage {
+            get {
+                return ResourceManager.GetString("Error_SessionInitializationCodePage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to set CRAN mirror to {0}: {1}.
+        /// </summary>
+        internal static string Error_SessionInitializationMirror {
+            get {
+                return ResourceManager.GetString("Error_SessionInitializationMirror", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to set options(): {0}.
+        /// </summary>
+        internal static string Error_SessionInitializationOptions {
+            get {
+                return ResourceManager.GetString("Error_SessionInitializationOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to R broker process did not start:  {0}.
         /// </summary>
         internal static string Error_UnableToStartBrokerException {

--- a/src/Host/Client/Impl/Resources.resx
+++ b/src/Host/Client/Impl/Resources.resx
@@ -212,4 +212,21 @@ This should never happen with a production Remote R Services, so please check wi
 
 If you using a test Remote R Server with a self-signed certificate and are certain about the remote machine security, click OK, otherwise cancel the connection.</value>
   </data>
+  <data name="Error_SessionInitialization" xml:space="preserve">
+    <value>The following exception occurred during initialization of R session, and the session has been terminated:
+
+{0}</value>
+  </data>
+  <data name="Error_SessionInitializationAutosave" xml:space="preserve">
+    <value>Failed to enable workspace auto-saving: {0}</value>
+  </data>
+  <data name="Error_SessionInitializationCodePage" xml:space="preserve">
+    <value>Failed to set R locale to codepage {0}: {1}</value>
+  </data>
+  <data name="Error_SessionInitializationMirror" xml:space="preserve">
+    <value>Failed to set CRAN mirror to {0}: {1}</value>
+  </data>
+  <data name="Error_SessionInitializationOptions" xml:space="preserve">
+    <value>Failed to set options(): {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
Improve exception handling when initializing the new session. For errors that will not cause other components to malfunciton later (e.g. setting codepage or mirror), print out the error, but continue. For errors that may cause major malfunctions, print out the detailed error and terminate the session immediately, but avoid VS crashing.