### PR TITLE
Fix #2535: Can't view list when inside a function and subsequent debugger hang

### DIFF
--- a/src/Debugger/Impl/AD7CustomViewer.cs
+++ b/src/Debugger/Impl/AD7CustomViewer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.R.Debugger {
                 return VSConstants.E_FAIL;
             }
 
-            property.StackFrame.Engine.GridViewProvider.ShowDataGrid(property.EvaluationResult);
+            property.StackFrame.Engine.GridViewProvider.ShowDataGrid(property.EvaluationResult.ToEnvironmentIndependentResult());
             return VSConstants.S_OK;
         }
     }

--- a/src/Host/Client/Impl/DataInspection/IREvaluationResultInfo.cs
+++ b/src/Host/Client/Impl/DataInspection/IREvaluationResultInfo.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.R.ExecutionTracing;
 using Microsoft.R.Host.Client;
 using static System.FormattableString;
 
@@ -39,7 +38,7 @@ namespace Microsoft.R.DataInspection {
         string Expression { get; }
 
         /// <summary>
-        /// Name of the result. This corresponds to the <c>name</c> parameter of <see cref="RTracer.EvaluateAsync"/>.
+        /// Name of the result. This corresponds to the <c>name</c> parameter of <see cref="RSessionExtensions.TryEvaluateAndDescribeAsync"/>.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -47,6 +46,16 @@ namespace Microsoft.R.DataInspection {
         /// and is primarily useful in that scenario. See the documentation of that method for more information.
         /// </para>
         string Name { get; }
+
+        /// <summary>
+        /// Creates a copy of this result that can be evaluated in any environment (rather than just the one designated by
+        /// <see cref="EnvironmentExpression"/>) to produce the same value.
+        /// </summary>
+        /// <remarks>
+        /// No evaluation takes place. The new result is identical to the one on which the method was called, except that
+        /// <see cref="EnvironmentExpression"/> is incorporated directly into <see cref="Expression"/>. 
+        /// </remarks>
+        IREvaluationResultInfo ToEnvironmentIndependentResult();
     }
 
     public static class REvaluationResultInfoExtensions {
@@ -90,5 +99,11 @@ namespace Microsoft.R.DataInspection {
         /// <exception cref="RException">Evaluation of the expression produced an error.</exception>
         public static Task<IRValueInfo> GetValueAsync(this IREvaluationResultInfo info, REvaluationResultProperties properties, string repr, CancellationToken cancellationToken = default(CancellationToken)) =>
             info.Session.EvaluateAndDescribeAsync(info.EnvironmentExpression, info.Expression, info.Name, properties, repr, cancellationToken);
+
+        /// <summary>
+        /// Computes the expression that can be used to produce the same value in any environment.
+        /// </summary>
+        public static string GetEnvironmentIndependentExpression(this IREvaluationResultInfo info) =>
+            info.EnvironmentExpression + "$" + info.Expression;
     }
 }

--- a/src/Host/Client/Impl/DataInspection/RActiveBindingInfo.cs
+++ b/src/Host/Client/Impl/DataInspection/RActiveBindingInfo.cs
@@ -10,13 +10,21 @@ namespace Microsoft.R.DataInspection {
         public IRValueInfo ComputedValue { get; }
 
         internal RActiveBindingInfo(IRSession session, string environmentExpression, string expression, string name, JObject json)
-            : base(session, environmentExpression, expression, name) {
+            : this(session, environmentExpression, expression, name, (IRValueInfo)null) {
+
             JObject bindingResultJson = json.Value<JObject>(FieldNames.ComputedValue);
-            if(bindingResultJson == null) {
-                ComputedValue = null;
-            } else {
+            if (bindingResultJson != null) {
                 ComputedValue = new RValueInfo(session, environmentExpression, expression, name, bindingResultJson);
-            }    
+            }
         }
+
+        internal RActiveBindingInfo(IRSession session, string environmentExpression, string expression, string name, IRValueInfo computedValue)
+            : base(session, environmentExpression, expression, name) {
+
+            ComputedValue = computedValue;
+        }
+
+        public override IREvaluationResultInfo ToEnvironmentIndependentResult() =>
+            new RActiveBindingInfo(Session, EnvironmentExpression, this.GetEnvironmentIndependentExpression(), Name, ComputedValue);
     }
 }

--- a/src/Host/Client/Impl/DataInspection/RErrorInfo.cs
+++ b/src/Host/Client/Impl/DataInspection/RErrorInfo.cs
@@ -16,5 +16,8 @@ namespace Microsoft.R.DataInspection {
         public override string ToString() {
             return Invariant($"ERROR: {ErrorText}");
         }
+
+        public override IREvaluationResultInfo ToEnvironmentIndependentResult() =>
+            new RErrorInfo(Session, EnvironmentExpression, this.GetEnvironmentIndependentExpression(), Name, ErrorText);
     }
 }

--- a/src/Host/Client/Impl/DataInspection/REvaluationResultInfo.cs
+++ b/src/Host/Client/Impl/DataInspection/REvaluationResultInfo.cs
@@ -42,5 +42,7 @@ namespace Microsoft.R.DataInspection {
 
             return new RValueInfo(session, environmentExpression, expression, name, json);
         }
+
+        public abstract IREvaluationResultInfo ToEnvironmentIndependentResult();
     }
 }

--- a/src/Host/Client/Impl/DataInspection/RPromiseInfo.cs
+++ b/src/Host/Client/Impl/DataInspection/RPromiseInfo.cs
@@ -16,5 +16,8 @@ namespace Microsoft.R.DataInspection {
         public override string ToString() {
             return Invariant($"PROMISE: {Code}");
         }
+
+        public override IREvaluationResultInfo ToEnvironmentIndependentResult() =>
+            new RPromiseInfo(Session, EnvironmentExpression, this.GetEnvironmentIndependentExpression(), Name, Code);
     }
 }

--- a/src/Host/Client/Impl/DataInspection/RValueInfo.cs
+++ b/src/Host/Client/Impl/DataInspection/RValueInfo.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Linq;
 using static System.FormattableString;
 using static Microsoft.R.Host.Client.REvaluationResult;
 
-    namespace Microsoft.R.DataInspection {
+namespace Microsoft.R.DataInspection {
     internal sealed class RValueInfo : REvaluationResultInfo, IRValueInfo {
         public string Representation { get; }
 
@@ -60,6 +60,37 @@ using static Microsoft.R.Host.Client.REvaluationResult;
 
                 return false;
             }
+        }
+
+        internal RValueInfo(
+            IRSession session,
+            string environmentExpression,
+            string expression,
+            string name,
+            string representation,
+            RChildAccessorKind accessorKind,
+            string typeName,
+            IReadOnlyList<string> classes,
+            int? length,
+            int? attributeCount,
+            int? slotCount,
+            int? nameCount,
+            IReadOnlyList<int> dim,
+            RValueFlags flags,
+            bool canCoerceToDataFrame
+        ) : base(session, environmentExpression, expression, name) {
+
+            Representation = representation;
+            AccessorKind = accessorKind;
+            TypeName = typeName;
+            Classes = classes;
+            Length = length;
+            AttributeCount = attributeCount;
+            SlotCount = slotCount;
+            NameCount = nameCount;
+            Dim = dim;
+            Flags = flags;
+            CanCoerceToDataFrame = canCoerceToDataFrame;
         }
 
         internal RValueInfo(IRSession session, string environmentExpression, string expression, string name, JObject json)
@@ -120,5 +151,9 @@ using static Microsoft.R.Host.Client.REvaluationResult;
                 }
             }
         }
+
+        public override IREvaluationResultInfo ToEnvironmentIndependentResult() =>
+            new RValueInfo(Session, EnvironmentExpression, this.GetEnvironmentIndependentExpression(), Name, Representation,
+                AccessorKind, TypeName, Classes, Length, AttributeCount, SlotCount, NameCount, Dim, Flags, CanCoerceToDataFrame);
     }
 }


### PR DESCRIPTION
Provide an environment-independent expression to the grid viewer, such that it can be evaluated in any environment with the same result.