### PR TITLE
Several plot operations no longer change the active graphics device.

### DIFF
--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -164,6 +164,7 @@ export_to_csv <- function(expr, sep, dec) {
 # Helper to export current plot to image
 export_to_image <- function(device_id, plot_id, device, width, height, resolution) {
     prev_device_num <- dev.cur()
+    graphics.ide.setactivedeviceid(device_id)
     graphics.ide.selectplot(device_id, plot_id, force_render = FALSE)
     filepath <- tempfile('plot_', fileext = '.dat')
     on.exit(unlink(filepath))
@@ -176,6 +177,7 @@ export_to_image <- function(device_id, plot_id, device, width, height, resolutio
 # Helper to export current plot to pdf
 export_to_pdf <- function(device_id, plot_id, width, height) {
     prev_device_num <- dev.cur()
+    graphics.ide.setactivedeviceid(device_id)
     graphics.ide.selectplot(device_id, plot_id, force_render = FALSE)
     filepath <- tempfile('plot_', fileext = '.pdf')
     on.exit(unlink(filepath))

--- a/src/R/Components/Impl/Plots/IRPlotDeviceVisualComponent.cs
+++ b/src/R/Components/Impl/Plots/IRPlotDeviceVisualComponent.cs
@@ -23,6 +23,8 @@ namespace Microsoft.R.Components.Plots {
         IRPlot ActivePlot { get; }
         Task<LocatorResult> StartLocatorModeAsync(CancellationToken ct);
         void EndLocatorMode();
+        // Functions below are for use by tests
         void ClickPlot(int x, int y);
+        Task ResizePlotAsync(int pixelWidth, int pixelHeight, int resolution);
     }
 }

--- a/src/R/Components/Impl/Plots/Implementation/RPlotDeviceVisualComponent.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotDeviceVisualComponent.cs
@@ -147,6 +147,10 @@ namespace Microsoft.R.Components.Plots.Implementation {
             _viewModel.ClickPlot(x, y);
         }
 
+        public async Task ResizePlotAsync(int pixelWidth, int pixelHeight, int resolution) {
+            await _viewModel.ResizePlotAsync(pixelWidth, pixelHeight, resolution);
+        }
+
         public void Dispose() {
             _disposableBag.TryDispose();
         }


### PR DESCRIPTION
Had to adjust the exporting code, as it was relying on `selectplot` to change the active device, which it no longer does.
Add some tests to ensure active plot device doesn't get changed when it shouldn't.

Fixes https://github.com/Microsoft/RTVS/issues/2538
See also https://github.com/Microsoft/R-Host/pull/98