### PR TITLE
Fix #2572: User count returned when connecting to remote is incorrect.

### DIFF
--- a/src/Host/Broker/Impl/Security/TlsConfiguration.cs
+++ b/src/Host/Broker/Impl/Security/TlsConfiguration.cs
@@ -43,8 +43,12 @@ namespace Microsoft.R.Host.Broker.Security {
             var certName = _securityOptions.X509CertificateName ?? Invariant($"CN={Environment.MachineName}");
             certificate = Certificates.GetCertificateForEncryption(certName);
             if (certificate == null) {
+#if DEBUG
+                return null;
+#else
                 _logger.LogCritical(Resources.Critical_NoTlsCertificate, certName);
                 Environment.Exit((int)BrokerExitCodes.NoCertificate);
+#endif
             }
 
             _logger.LogInformation(Resources.Trace_CertificateIssuer, certificate.Issuer);

--- a/src/Host/Broker/Impl/Sessions/SessionManager.cs
+++ b/src/Host/Broker/Impl/Sessions/SessionManager.cs
@@ -18,6 +18,8 @@ using Microsoft.R.Host.Protocol;
 
 namespace Microsoft.R.Host.Broker.Sessions {
     public class SessionManager {
+        private const int MaximumConcurrentClientWindowsUsers = 1;
+
         private readonly InterpreterManager _interpManager;
         private readonly LoggingOptions _loggingOptions;
         private readonly ILogger _hostOutputLogger, _messageLogger, _sessionLogger;
@@ -77,7 +79,6 @@ namespace Microsoft.R.Host.Broker.Sessions {
             }
         }
 
-        private const int MaximumConcurrentClientWindowsUsers = 1;
         private bool IsUserAllowedToCreateSession(IIdentity user) {
             lock (_sessions) {
                 int activeUsers = _sessions.Keys.Where((k) => _sessions[k].Count > 0).Count();
@@ -150,6 +151,10 @@ namespace Microsoft.R.Host.Broker.Sessions {
                 lock (_sessions) {
                     var userSessions = GetOrCreateSessionList(session.User);
                     userSessions.Remove(session);
+
+                    if (userSessions.Count == 0) {
+                        _sessions.Remove(session.User.Name);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Clean up user entries for users who have no remaining sessions.

Allow no SSL for remote in debug builds only, for ease of testing.