### PR TITLE
Fix #2570: AsyncReaderWriterLock hangs on requesting WriterLock after cancellation

### DIFF
--- a/src/Common/Core/Impl/Microsoft.Common.Core.csproj
+++ b/src/Common/Core/Impl/Microsoft.Common.Core.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Telemetry\TelemetryArea.cs" />
     <Compile Include="Telemetry\TelemetryServiceBase.cs" />
     <Compile Include="Threading\BinaryAsyncLock.cs" />
+    <Compile Include="Threading\AsyncReaderWriterLock.Queue.cs" />
     <Compile Include="Threading\DelayedAsyncAction.cs" />
     <Compile Include="Threading\IAsyncReaderWriterLockToken.cs" />
     <Compile Include="Threading\IMainThread.cs" />

--- a/src/Common/Core/Impl/Threading/AsyncReaderWriterLock.Queue.cs
+++ b/src/Common/Core/Impl/Threading/AsyncReaderWriterLock.Queue.cs
@@ -1,0 +1,239 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Microsoft.Common.Core.Threading {
+    public partial class AsyncReaderWriterLock {
+        internal class Queue<TQueueItem> : IEnumerable<TQueueItem> where TQueueItem: class, IQueueItem {
+            private IQueueItem _head;
+            private IQueueItem _tail;
+            private IQueueItem _wTail;
+
+            /// <summary>
+            /// Adds a reader item
+            /// </summary>
+            /// <remarks>
+            /// 1. R−→R−→R  ―►  R−→R−→R−→R
+            ///          ↑               ↑
+            ///      _tail           _tail
+            /// 
+            /// 
+            /// 2.  _wTail       _wTail
+            ///          ↓            ↓
+            ///    R−→R−→W  ―►  R−→R−→W−→R
+            ///          ↑               ↑
+            ///      _tail           _tail
+            /// 
+            /// 
+            /// 3.  _wTail          _wTail
+            ///          ↓               ↓
+            ///    R−→W−→W−→R  ―►  R−→W−→W−→R−→R
+            ///             ↑                  ↑
+            ///         _tail              _tail
+            /// </remarks>
+            /// <param name="item"></param>
+            /// <param name="isAddedAfterWriter"></param>
+            public void AddReader(TQueueItem item, out bool isAddedAfterWriter) {
+                var wTail = _wTail;
+                UpdateTail(item);
+
+                var newWTail = SpinWhileWTailIsPendingRemoval();
+                isAddedAfterWriter = wTail != newWTail && newWTail != null
+                    ? IsFirstEqualOrBeforeSecond(item, newWTail)
+                    : newWTail != null;
+            }
+
+            private IQueueItem SpinWhileWTailIsPendingRemoval() {
+                var wTail = _wTail;
+                if (wTail == null || !wTail.IsPendingRemoval) {
+                    return wTail;
+                }
+
+                var sw = new SpinWait();
+                while (wTail != null && wTail.IsPendingRemoval) {
+                    sw.SpinOnce();
+                    wTail = _wTail;
+                }
+
+                return wTail;
+            }
+
+            private static bool IsFirstEqualOrBeforeSecond(IQueueItem first, IQueueItem second) {
+                while (first != null) {
+                    if (first == second) {
+                        return true;
+                    }
+                    first = first.Next;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Adds a writer item
+            /// </summary>
+            /// <remarks>
+            /// 1.                  _wTail
+            ///                          ↓
+            ///    R−→R−→R  ―►  R−→R−→R−→W
+            ///          ↑               ↑
+            ///      _tail           _tail
+            /// 
+            /// 
+            /// 2.  _wTail          _wTail
+            ///          ↓               ↓
+            ///    R−→R−→W  ―►  R−→R−→W−→W
+            ///          ↑               ↑
+            ///      _tail           _tail
+            /// 
+            /// 
+            /// 3.  _wTail             _wTail
+            ///          ↓                  ↓
+            ///    R−→W−→W−→R  ―►  R−→W−→W−→W−→R
+            ///          ↑                     ↑
+            ///      _tail                 _tail
+            /// </remarks>
+            /// <param name="item"></param>
+            public IQueueItem AddWriter(TQueueItem item) {
+                while (true) {
+                    var tail = _tail;
+                    // Case 1. No writers in the queue. Update _wTail and the _tail
+                    var wTail = Interlocked.CompareExchange(ref _wTail, item, null);
+                    if (wTail == null) {
+                        UpdateTail(item);
+                        return item;
+                    }
+
+                    // Case 2. No readers in front of a writer, _tail and _wTail point at the same item. Update _wTail.Next, _tail and _wTail
+                    if (wTail == tail && wTail.TrySetNext(item, null) == null) {
+                        Interlocked.Exchange(ref _tail, item);
+                        Interlocked.Exchange(ref _wTail, item);
+                        return item;
+                    }
+
+                    // Case 3. Readers in front of writers. wTail.Next points to reader. Update item.Next, _wTail.Next and _wTail
+                    var wTailNext = wTail.Next;
+                    if (wTailNext == null || wTailNext.IsWriter || wTail.IsRemoved) {
+                        continue;
+                    }
+
+                    item.TrySetNext(wTailNext, item.Next);
+                    
+                    if (wTail.TrySetNext(item, wTailNext) == wTailNext && !wTail.IsRemoved && Interlocked.CompareExchange(ref _wTail, item, wTail) == wTail) {
+                        return item;
+                    }
+                }
+            }
+            
+            /// <summary>
+            /// Updates tail
+            /// </summary>
+            /// <param name="item">item to set as a tail</param>
+            /// <returns>Previous tail</returns>
+            private void UpdateTail(TQueueItem item) {
+                while (true) {
+                    var tail = Interlocked.CompareExchange(ref _tail, item, null);
+                    if (tail == null) {
+                        Interlocked.Exchange(ref _head, item);
+                        return;
+                    }
+                    
+                    if (tail.TrySetNext(item, null) == null && Interlocked.CompareExchange(ref _tail, item, tail) == tail) {
+                        return;
+                    }
+                }
+            }
+
+            public void Remove(TQueueItem item) {
+                if (item == _head || item == _wTail) {
+                    CleanupFromHead();
+                }
+            }
+
+            private void CleanupFromHead() {
+                var head = _head;
+                while (head != null && head.IsPendingRemoval) {
+                    var next = head.Next;
+
+                    head.MarkRemoved();
+                    Interlocked.CompareExchange(ref _tail, null, head);
+                    Interlocked.CompareExchange(ref _wTail, null, head);
+                    head = Interlocked.CompareExchange(ref _head, next, head) == head ? next : _head;
+                }
+
+                if (head == null) {
+                    return;
+                }
+
+                var item = head;
+                var lastWriter = head.IsWriter ? head : null;
+
+                // If new head is pending removal, another thread will handle further cleanup
+                while (!head.IsPendingRemoval) {
+                    var next = item.Next;
+                    if (next == null) {
+                       return; 
+                    }
+
+                    if (next.IsPendingRemoval) {
+                        next.MarkRemoved();
+                        Interlocked.CompareExchange(ref _tail, item, next);
+                        Interlocked.CompareExchange(ref _wTail, lastWriter, next);
+                        item.TrySetNext(next.Next, next);
+                        continue;
+                    }
+
+                    if (next.IsWriter) {
+                        lastWriter = next;
+                    }
+
+                    item = next;
+                }
+            }
+
+            public IEnumerable<TQueueItem> GetFirstReaders() {
+                var item = _head;
+                while (item != null && (item.IsPendingRemoval || !item.IsWriter)) {
+                    if (!item.IsPendingRemoval) {
+                        yield return (TQueueItem)item;
+                    }
+
+                    item = item.Next;
+                }
+            }
+
+            public TQueueItem GetFirstAsWriter() {
+                var head = _head;
+                if (head != null && !head.IsPendingRemoval && head.IsWriter) {
+                    return (TQueueItem)head;
+                }
+
+                return null;
+            }
+
+            public IEnumerator<TQueueItem> GetEnumerator() {
+                var item = _head;
+                while (item != null) {
+                    if (!item.IsPendingRemoval) {
+                        yield return (TQueueItem)item;
+                    }
+                    item = item.Next;
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        internal interface IQueueItem {
+            bool IsWriter { get; }
+            bool IsPendingRemoval { get; }
+            bool IsRemoved { get; }
+            IQueueItem Next { get; }
+
+            void MarkRemoved();
+            IQueueItem TrySetNext(IQueueItem value, IQueueItem comparand);
+        }
+    }
+}

--- a/src/Common/Core/Test/Threading/AsyncReaderWriterLockTest.cs
+++ b/src/Common/Core/Test/Threading/AsyncReaderWriterLockTest.cs
@@ -737,6 +737,38 @@ namespace Microsoft.Common.Core.Test.Threading {
             task1.Should().BeRanToCompletion();
             task2.Should().NotBeCompleted();
         }
+        
+        [Test]
+        public void WriteRead_CancelSecond_ReleaseFirst_Read() {
+            var cts = new CancellationTokenSource();
+
+            var task1 = _arwl.WriterLockAsync(CancellationToken.None);
+            var task2 = _arwl.ReaderLockAsync(cts.Token);
+
+            cts.Cancel();
+            task1.Result.Dispose();
+            var task3 = _arwl.ReaderLockAsync(CancellationToken.None);
+
+            task1.Should().BeRanToCompletion();
+            task2.Should().BeCanceled();
+            task3.Should().BeRanToCompletion();
+        }
+
+        [Test]
+        public void WriteRead_CancelSecond_ReleaseFirst_Write() {
+            var cts = new CancellationTokenSource();
+
+            var task1 = _arwl.WriterLockAsync(CancellationToken.None);
+            var task2 = _arwl.ReaderLockAsync(cts.Token);
+
+            cts.Cancel();
+            task1.Result.Dispose();
+            var task3 = _arwl.WriterLockAsync(CancellationToken.None);
+
+            task1.Should().BeRanToCompletion();
+            task2.Should().BeCanceled();
+            task3.Should().BeRanToCompletion();
+        }
 
         [Test]
         public void Write_Release_Read() {
@@ -882,6 +914,38 @@ namespace Microsoft.Common.Core.Test.Threading {
 
             task1.Should().BeRanToCompletion();
             task2.Should().NotBeCompleted();
+        }
+        
+        [Test]
+        public void WriteWrite_CancelSecond_ReleaseFirst_Read() {
+            var cts = new CancellationTokenSource();
+
+            var task1 = _arwl.WriterLockAsync(CancellationToken.None);
+            var task2 = _arwl.WriterLockAsync(cts.Token);
+
+            cts.Cancel();
+            task1.Result.Dispose();
+            var task3 = _arwl.ReaderLockAsync(CancellationToken.None);
+
+            task1.Should().BeRanToCompletion();
+            task2.Should().BeCanceled();
+            task3.Should().BeRanToCompletion();
+        }
+
+        [Test]
+        public void WriteWrite_CancelSecond_ReleaseFirst_Write() {
+            var cts = new CancellationTokenSource();
+
+            var task1 = _arwl.WriterLockAsync(CancellationToken.None);
+            var task2 = _arwl.WriterLockAsync(cts.Token);
+
+            cts.Cancel();
+            task1.Result.Dispose();
+            var task3 = _arwl.WriterLockAsync(CancellationToken.None);
+
+            task1.Should().BeRanToCompletion();
+            task2.Should().BeCanceled();
+            task3.Should().BeRanToCompletion();
         }
 
         [Test]

--- a/src/Common/Core/Test/Threading/MainThreadAwaitableTest.cs
+++ b/src/Common/Core/Test/Threading/MainThreadAwaitableTest.cs
@@ -59,10 +59,12 @@ namespace Microsoft.Common.Core.Test.Threading {
 
         [Test]
         public void GetResult_ThrowOnBackgroundThread() {
-            var awaitable = new MainThreadAwaitable(_mainThread);
+            var cts = new CancellationTokenSource();
+            var awaitable = new MainThreadAwaitable(_mainThread, cts.Token);
+            cts.Cancel();
 
             Action a = () => awaitable.GetAwaiter().GetResult();
-            a.ShouldThrow<InvalidOperationException>();
+            a.ShouldThrow<OperationCanceledException>();
         }
         
         private sealed class TestMainThread : IMainThread {


### PR DESCRIPTION
- Separated lock items queue from the rest of the logic
- Some new tests added