### PR TITLE
Create process should use fully qualified path to exe.

### DIFF
--- a/src/Package/Impl/ProjectSystem/Commands/OpenCommandPromptCommand.cs
+++ b/src/Package/Impl/ProjectSystem/Commands/OpenCommandPromptCommand.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
-using Microsoft.VisualStudio.ProjectSystem;
-using Microsoft.VisualStudio.R.Package.Commands;
-using Microsoft.Common.Core.OS;
+using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
 using Microsoft.Common.Core.Services;
+using Microsoft.VisualStudio.R.Package.Commands;
 #if VS14
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 #endif
@@ -21,7 +21,9 @@ namespace Microsoft.VisualStudio.R.Package.ProjectSystem.Commands {
 
         protected override void SetFlags(ProcessStartInfo psi, string path) {
             psi.WorkingDirectory = path;
-            psi.FileName = "cmd.exe";
+            var sys32 = Environment.GetFolderPath(Environment.SpecialFolder.System);
+            var cmd = Path.Combine(sys32, "cmd.exe");
+            psi.FileName = cmd;
             psi.UseShellExecute = false;
         }
     }


### PR DESCRIPTION
Fixes #2627

Please let me know if there are other locations where we don't use fully qualified paths.