### PR TITLE
Two bug fixes + several test fixes

### DIFF
--- a/src/Common/Core/Impl/Threading/AsyncReaderWriterLock.Queue.cs
+++ b/src/Common/Core/Impl/Threading/AsyncReaderWriterLock.Queue.cs
@@ -142,7 +142,8 @@ namespace Microsoft.Common.Core.Threading {
 
                     var erLock = (item as ExclusiveReaderLockSource)?.ExclusiveReaderLock;
                     if (erLock != null) {
-                        Interlocked.CompareExchange(ref erLock.Tail, previous as ExclusiveReaderLockSource, item);
+                        var previousErlSource = previous as ExclusiveReaderLockSource;
+                        Interlocked.CompareExchange(ref erLock.Tail, previousErlSource?.ExclusiveReaderLock == erLock ? previousErlSource : null, item);
                     }
                     
                     Unlink(item);

--- a/src/Common/Core/Test/Tasks/FailOnTimeoutTest.cs
+++ b/src/Common/Core/Test/Tasks/FailOnTimeoutTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Common.Core.Test.Tasks {
                 throw new InvalidOperationException();
             };
 
-            Func<Task> f = () => createTask().FailOnTimeout(200);
+            Func<Task> f = () => createTask().FailOnTimeout(400);
             f.ShouldThrow<InvalidOperationException>();
         }
 
@@ -33,7 +33,7 @@ namespace Microsoft.Common.Core.Test.Tasks {
             var cts = new CancellationTokenSource();
             cts.CancelAfter(100);
 
-            Func<Task> f = () => Task.Delay(300, cts.Token).FailOnTimeout(200);
+            Func<Task> f = () => Task.Delay(700, cts.Token).FailOnTimeout(400);
             f.ShouldThrow<TaskCanceledException>();
         }
 

--- a/src/Common/Core/Test/Threading/AsyncReaderWriterLockTest.cs
+++ b/src/Common/Core/Test/Threading/AsyncReaderWriterLockTest.cs
@@ -1336,6 +1336,56 @@ namespace Microsoft.Common.Core.Test.Threading {
         } 
 
         [Test]
+        public void ExclusiveRead_SecondExclusiveRead_ExclusiveRead_ReleaseSecond_ReleaseFirst() {
+            var erl1 = _arwl.CreateExclusiveReaderLock();
+            var erl2 = _arwl.CreateExclusiveReaderLock();
+            var task1 = erl1.WaitAsync();
+            var task2 = erl2.WaitAsync();
+            var task3 = erl1.WaitAsync();
+
+            task2.Result.Dispose();
+            task1.Result.Dispose();
+
+            task1.Should().BeRanToCompletion();
+            task2.Should().BeRanToCompletion();
+            task3.Should().BeRanToCompletion();
+        } 
+
+        [Test]
+        public void ExclusiveRead_SecondExclusiveRead_ReleaseSecond_ReleaseFirst_ExclusiveRead() {
+            var erl1 = _arwl.CreateExclusiveReaderLock();
+            var erl2 = _arwl.CreateExclusiveReaderLock();
+            var task1 = erl1.WaitAsync();
+            var task2 = erl2.WaitAsync();
+
+            task2.Result.Dispose();
+            task1.Result.Dispose();
+
+            var task3 = erl1.WaitAsync();
+
+            task1.Should().BeRanToCompletion();
+            task2.Should().BeRanToCompletion();
+            task3.Should().BeRanToCompletion();
+        } 
+
+        [Test]
+        public void ExclusiveRead_SecondExclusiveRead_ReleaseSecond_ReleaseFirst_SecondExclusiveRead() {
+            var erl1 = _arwl.CreateExclusiveReaderLock();
+            var erl2 = _arwl.CreateExclusiveReaderLock();
+            var task1 = erl1.WaitAsync();
+            var task2 = erl2.WaitAsync();
+
+            task2.Result.Dispose();
+            task1.Result.Dispose();
+
+            var task3 = erl2.WaitAsync();
+
+            task1.Should().BeRanToCompletion();
+            task2.Should().BeRanToCompletion();
+            task3.Should().BeRanToCompletion();
+        } 
+
+        [Test]
         public void ExclusiveRead_SecondExclusiveRead_ExclusiveRead_SecondExclusiveRead() {
             var erl1 = _arwl.CreateExclusiveReaderLock();
             var erl2 = _arwl.CreateExclusiveReaderLock();

--- a/src/Common/Core/Test/Threading/DelayedAsyncActionTest.cs
+++ b/src/Common/Core/Test/Threading/DelayedAsyncActionTest.cs
@@ -29,12 +29,12 @@ namespace Microsoft.Common.Core.Test.Threading {
         [Test]
         public async Task InvokeTwice_DuringTimeout() {
             var count = 0;
-            var action = new DelayedAsyncAction(200, () => Task.FromResult(Interlocked.Increment(ref count)));
+            var action = new DelayedAsyncAction(300, () => Task.FromResult(Interlocked.Increment(ref count)));
 
             action.Invoke();
             await Task.Delay(100);
             action.Invoke();
-            await Task.Delay(300);
+            await Task.Delay(500);
 
             count.Should().Be(1, "DelayedAction should be called only once");
         }
@@ -42,13 +42,13 @@ namespace Microsoft.Common.Core.Test.Threading {
         [Test]
         public async Task InvokeTwice_DuringTimeout_Concurrent() {
             var count = 0;
-            var action = new DelayedAsyncAction(200, () => Task.FromResult(Interlocked.Increment(ref count)));
+            var action = new DelayedAsyncAction(300, () => Task.FromResult(Interlocked.Increment(ref count)));
 
             ParallelTools.Invoke(4, async i => {
                 await Task.Delay(50 * i);
                 action.Invoke();
             });
-            await Task.Delay(500);
+            await Task.Delay(700);
 
             count.Should().Be(1, "DelayedAction should be called only once");
         }

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -769,10 +769,6 @@ if (rtvs:::version != {rtvsPackageVersion}) {{
                         return;
                     }
 
-                    if (_hostToSwitch == null) {
-                        Debugger.Launch();
-                    }
-
                     try {
                         var brokerClient = _session.BrokerClient;
                         var startupInfo = _session._startupInfo;

--- a/src/Host/Client/Test/Fixtures/SessionProviderFixture.cs
+++ b/src/Host/Client/Test/Fixtures/SessionProviderFixture.cs
@@ -8,8 +8,8 @@ using Microsoft.R.Host.Client.Session;
 using Xunit;
 
 namespace Microsoft.R.Host.Client.Test.Fixtures {
-    [ExcludeFromCodeCoverage]
     // Fixture doesn't import itself. Use AssemblyFixtureImportAttribute
+    [ExcludeFromCodeCoverage]
     public sealed class SessionProviderFixture: IAsyncLifetime {
         public IRSessionProvider SessionProvider { get; }
 

--- a/src/Languages/Editor/Test/LanguagesEditorMefCatalogFixture.cs
+++ b/src/Languages/Editor/Test/LanguagesEditorMefCatalogFixture.cs
@@ -12,12 +12,9 @@ using Microsoft.Languages.Editor.Test.Fakes.Shell;
 using Microsoft.UnitTests.Core.XUnit;
 
 namespace Microsoft.Languages.Editor.Test {
-    [AssemblyFixture]
+    // Fixture doesn't import itself. Use AssemblyFixtureImportAttribute
     [ExcludeFromCodeCoverage]
-    public sealed class LanguagesEditorMefCatalogFixture : LanguagesEditorMefCatalogFixtureBase { }
-
-    [ExcludeFromCodeCoverage]
-    public class LanguagesEditorMefCatalogFixtureBase : AssemblyMefCatalogFixture {
+    public class LanguagesEditorMefCatalogFixture : AssemblyMefCatalogFixture {
         protected override IEnumerable<string> GetBinDirectoryAssemblies() {
             return new[] {
                 "Microsoft.Languages.Editor.dll",

--- a/src/Languages/Editor/Test/Properties/AssemblyInfo.cs
+++ b/src/Languages/Editor/Test/Properties/AssemblyInfo.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.Languages.Editor.Test;
 using Microsoft.UnitTests.Core.XUnit;
 using Microsoft.UnitTests.References;
 
 [assembly: TestFrameworkOverride]
+[assembly: AssemblyFixtureImport(typeof(LanguagesEditorMefCatalogFixture))]
 #if VS14
 [assembly: Dev14AssemblyLoader]
 #endif

--- a/src/Markdown/Editor/Test/MarkdownEditorMefCatalogFixture.cs
+++ b/src/Markdown/Editor/Test/MarkdownEditorMefCatalogFixture.cs
@@ -5,15 +5,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.Languages.Editor.Test;
-using Microsoft.UnitTests.Core.XUnit;
 
 namespace Microsoft.Markdown.Editor.Test {
-    [AssemblyFixture]
+    // Fixture doesn't import itself. Use AssemblyFixtureImportAttribute
     [ExcludeFromCodeCoverage]
-    public sealed class MarkdownEditorMefCatalogFixture : MarkdownEditorMefCatalogFixtureBase { }
-
-    [ExcludeFromCodeCoverage]
-    public class MarkdownEditorMefCatalogFixtureBase : LanguagesEditorMefCatalogFixtureBase {
+    public class MarkdownEditorMefCatalogFixture : LanguagesEditorMefCatalogFixture {
         protected override IEnumerable<string> GetBinDirectoryAssemblies() => base.GetBinDirectoryAssemblies().Concat(new[] {
             "Microsoft.Markdown.Editor",
             "Microsoft.Markdown.Editor.Test"

--- a/src/Markdown/Editor/Test/Properties/AssemblyInfo.cs
+++ b/src/Markdown/Editor/Test/Properties/AssemblyInfo.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.Markdown.Editor.Test;
 using Microsoft.UnitTests.Core.XUnit;
 using Microsoft.UnitTests.References;
 
 [assembly: TestFrameworkOverride]
+[assembly: AssemblyFixtureImport(typeof(MarkdownEditorMefCatalogFixture))]
 #if VS14
 [assembly: Dev14AssemblyLoader]
 #endif

--- a/src/Package/Test/FakeFactories/TestRInteractiveWorkflowProviderFactory.cs
+++ b/src/Package/Test/FakeFactories/TestRInteractiveWorkflowProviderFactory.cs
@@ -21,17 +21,14 @@ using Microsoft.VisualStudio.R.Package.Utilities;
 
 namespace Microsoft.VisualStudio.R.Package.Test.FakeFactories {
     public static class TestRInteractiveWorkflowProviderFactory {
-        public static TestRInteractiveWorkflowProvider Create(IRSessionProvider sessionProvider = null
-            , IConnectionManagerProvider connectionsProvider = null
+        public static TestRInteractiveWorkflowProvider Create(IConnectionManagerProvider connectionsProvider = null
             , IRHistoryProvider historyProvider = null
             , IRPackageManagerProvider packagesProvider = null
             , IRPlotManagerProvider plotsProvider = null
             , IActiveWpfTextViewTracker activeTextViewTracker = null
             , IDebuggerModeTracker debuggerModeTracker = null
             , ICoreShell shell = null
-            , IRSettings settings = null
-            , IWorkspaceServices wss = null) {
-            sessionProvider = sessionProvider ?? new RSessionProviderMock();
+            , IRSettings settings = null) {
             connectionsProvider = connectionsProvider ?? ConnectionManagerProviderStubFactory.CreateDefault();
             historyProvider = historyProvider ?? RHistoryProviderStubFactory.CreateDefault();
             packagesProvider = packagesProvider ?? RPackageManagerProviderStubFactory.CreateDefault();
@@ -44,8 +41,7 @@ namespace Microsoft.VisualStudio.R.Package.Test.FakeFactories {
 
             return new TestRInteractiveWorkflowProvider(
                 connectionsProvider, historyProvider, packagesProvider, plotsProvider,
-                activeTextViewTracker, debuggerModeTracker, sessionProvider,
-                shell, settings, wss);
+                activeTextViewTracker, debuggerModeTracker, shell, settings);
         }
     }
 }

--- a/src/Package/Test/Project/CommandsTest.cs
+++ b/src/Package/Test/Project/CommandsTest.cs
@@ -36,11 +36,10 @@ namespace Microsoft.VisualStudio.R.Package.Test.Repl {
         private readonly TestRInteractiveWorkflowProvider _interactiveWorkflowProvider;
 
         public ProjectCommandsTest() {
-            var sessionProvider = new RSessionProvider(TestCoreServices.CreateReal());
             var connectionsProvider = VsAppShell.Current.ExportProvider.GetExportedValue<IConnectionManagerProvider>();
             var historyProvider = VsAppShell.Current.ExportProvider.GetExportedValue<IRHistoryProvider>();
             var packagesProvider = VsAppShell.Current.ExportProvider.GetExportedValue<IRPackageManagerProvider>();
-            _interactiveWorkflowProvider = TestRInteractiveWorkflowProviderFactory.Create(sessionProvider, connectionsProvider, historyProvider, packagesProvider);
+            _interactiveWorkflowProvider = TestRInteractiveWorkflowProviderFactory.Create(connectionsProvider, historyProvider, packagesProvider);
         }
 
         public void Dispose() {

--- a/src/Package/Test/Repl/CurrentDirectoryTest.cs
+++ b/src/Package/Test/Repl/CurrentDirectoryTest.cs
@@ -32,8 +32,6 @@ namespace Microsoft.VisualStudio.R.Package.Test.Repl {
         private readonly IRSessionProvider _sessionProvider;
 
         public CurrentDirectoryTest() {
-            _sessionProvider = new RSessionProvider(TestCoreServices.CreateReal());
-
             var connectionsProvider = VsAppShell.Current.ExportProvider.GetExportedValue<IConnectionManagerProvider>();
             var historyProvider = VsAppShell.Current.ExportProvider.GetExportedValue<IRHistoryProvider>();
             var packagesProvider = VsAppShell.Current.ExportProvider.GetExportedValue<IRPackageManagerProvider>();
@@ -41,8 +39,10 @@ namespace Microsoft.VisualStudio.R.Package.Test.Repl {
             var activeTextViewTracker = new ActiveTextViewTrackerMock(string.Empty, string.Empty);
             var debuggerModeTracker = new TestDebuggerModeTracker();
             _interactiveWorkflow = UIThreadHelper.Instance.Invoke(() => new RInteractiveWorkflow(
-                _sessionProvider, connectionsProvider, historyProvider, packagesProvider, plotsProvider, activeTextViewTracker,
-                debuggerModeTracker, VsAppShell.Current, RToolsSettings.Current, null, () => { }));
+                connectionsProvider, historyProvider, packagesProvider, plotsProvider, activeTextViewTracker,
+                debuggerModeTracker, VsAppShell.Current, RToolsSettings.Current));
+
+            _sessionProvider = _interactiveWorkflow.RSessions;
         }
 
         public async Task InitializeAsync() {

--- a/src/Package/TestApp/Help/HelpOnCurrentTest.cs
+++ b/src/Package/TestApp/Help/HelpOnCurrentTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Help {
 
                 var activeViewTrackerMock = new ActiveTextViewTrackerMock("  plot", RContentTypeDefinition.ContentType);
                 var activeReplTrackerMock = new ActiveRInteractiveWindowTrackerMock();
-                var interactiveWorkflowProvider = TestRInteractiveWorkflowProviderFactory.Create(SessionProvider, activeTextViewTracker: activeViewTrackerMock);
+                var interactiveWorkflowProvider = TestRInteractiveWorkflowProviderFactory.Create(activeTextViewTracker: activeViewTrackerMock);
                 var interactiveWorkflow = interactiveWorkflowProvider.GetOrCreate();
 
                 var component = ControlWindow.Component as IHelpVisualComponent;

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/InteractiveWindowConsole.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/InteractiveWindowConsole.cs
@@ -8,20 +8,18 @@ using Microsoft.R.Host.Client;
 
 namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
     public sealed class InteractiveWindowConsole : IConsole {
-        private readonly ICoreShell _coreShell;
-        private readonly Lazy<IRInteractiveWorkflow> _workflowLazy;
+        private readonly IRInteractiveWorkflow _workflow;
 
-        public InteractiveWindowConsole(ICoreShell coreShell, Lazy<IRInteractiveWorkflow> workflowLazy) {
-            _coreShell = coreShell;
-            _workflowLazy = workflowLazy;
+        public InteractiveWindowConsole(IRInteractiveWorkflow workflow) {
+            _workflow = workflow;
         }
 
         public void Write(string text) {
-            _coreShell.DispatchOnUIThread(() => _workflowLazy.Value.ActiveWindow?.InteractiveWindow?.WriteErrorLine(text));
+            _workflow.Shell.DispatchOnUIThread(() => _workflow.ActiveWindow?.InteractiveWindow?.WriteErrorLine(text));
         }
 
         public async Task<bool> PromptYesNoAsync(string text) {
-            var result = await _coreShell.ShowMessageAsync(text, MessageButtons.YesNo);
+            var result = await _workflow.Shell.ShowMessageAsync(text, MessageButtons.YesNo);
             return result == MessageButtons.Yes;
         }
     }

--- a/src/R/Components/Test/Fakes/InteractiveWindow/TestRInteractiveWorkflowProvider.cs
+++ b/src/R/Components/Test/Fakes/InteractiveWindow/TestRInteractiveWorkflowProvider.cs
@@ -6,7 +6,6 @@ using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.Common.Core.Shell;
-using Microsoft.Common.Core.Test.Fakes.Shell;
 using Microsoft.R.Components.ConnectionManager;
 using Microsoft.R.Components.History;
 using Microsoft.R.Components.InteractiveWorkflow;
@@ -16,7 +15,6 @@ using Microsoft.R.Components.Plots;
 using Microsoft.R.Components.Settings;
 using Microsoft.R.Components.Workspace;
 using Microsoft.R.Host.Client;
-using Microsoft.R.Host.Client.Session;
 using Microsoft.UnitTests.Core.Mef;
 
 namespace Microsoft.R.Components.Test.Fakes.InteractiveWindow {
@@ -25,7 +23,6 @@ namespace Microsoft.R.Components.Test.Fakes.InteractiveWindow {
     [Export(typeof(TestRInteractiveWorkflowProvider))]
     [PartMetadata(PartMetadataAttributeNames.SkipInEditorTestCompositionCatalog, null)]
     public class TestRInteractiveWorkflowProvider : IRInteractiveWorkflowProvider, IDisposable {
-        private readonly IRSessionProvider _sessionProvider;
         private readonly IConnectionManagerProvider _connectionManagerProvider;
         private readonly IRHistoryProvider _historyProvider;
         private readonly IRPackageManagerProvider _packagesProvider;
@@ -34,7 +31,6 @@ namespace Microsoft.R.Components.Test.Fakes.InteractiveWindow {
         private readonly IRSettings _settings;
         private readonly IActiveWpfTextViewTracker _activeTextViewTracker;
         private readonly IDebuggerModeTracker _debuggerModeTracker;
-        private readonly IWorkspaceServices _wss;
 
         private Lazy<IRInteractiveWorkflow> _instanceLazy;
         public IRSessionCallback HostClientApp { get; set; }
@@ -46,13 +42,8 @@ namespace Microsoft.R.Components.Test.Fakes.InteractiveWindow {
             , IRPlotManagerProvider plotsProvider
             , IActiveWpfTextViewTracker activeTextViewTracker
             , IDebuggerModeTracker debuggerModeTracker
-            // Required for the tests that create TestRInteractiveWorkflowProvider explicitly
-            , [Import(AllowDefault = true)] IRSessionProvider sessionProvider
             , ICoreShell shell
-            , IRSettings settings
-            , [Import(AllowDefault = true)] IWorkspaceServices wss
-            ) {
-            _sessionProvider = sessionProvider;
+            , IRSettings settings) {
             _connectionManagerProvider = connectionManagerProvider;
             _historyProvider = historyProvider;
             _packagesProvider = packagesProvider;
@@ -61,7 +52,6 @@ namespace Microsoft.R.Components.Test.Fakes.InteractiveWindow {
             _debuggerModeTracker = debuggerModeTracker;
             _shell = shell;
             _settings = settings;
-            _wss = wss;
         }
 
         public void Dispose() {
@@ -78,23 +68,14 @@ namespace Microsoft.R.Components.Test.Fakes.InteractiveWindow {
         public IRInteractiveWorkflow Active => _instanceLazy.IsValueCreated ? _instanceLazy.Value : null;
 
         private IRInteractiveWorkflow CreateRInteractiveWorkflow() {
-            var sessionProvider = _sessionProvider ?? new RSessionProvider(TestCoreServices.CreateReal());
-            return new RInteractiveWorkflow(sessionProvider
-                , _connectionManagerProvider
+            return new RInteractiveWorkflow(_connectionManagerProvider
                 , _historyProvider
                 , _packagesProvider
                 , _plotsProvider
                 , _activeTextViewTracker
                 , _debuggerModeTracker
                 , _shell
-                , _settings
-                , _wss
-                , () => DisposeInstance(sessionProvider));
-        }
-
-        private void DisposeInstance(IRSessionProvider sessionProvider) {
-            sessionProvider.Dispose();
-            _instanceLazy = null;
+                , _settings);
         }
     }
 }

--- a/src/R/Components/Test/InteractiveWorkflow/RInteractiveEvaluatorTest.cs
+++ b/src/R/Components/Test/InteractiveWorkflow/RInteractiveEvaluatorTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Components.Settings;
+using Microsoft.UnitTests.Core.FluentAssertions;
 using Microsoft.UnitTests.Core.Mef;
 using Microsoft.UnitTests.Core.Threading;
 using Microsoft.UnitTests.Core.XUnit;
@@ -34,6 +35,7 @@ namespace Microsoft.R.Components.Test.InteractiveWorkflow {
 
         public async Task InitializeAsync() {
             await _workflow.RSessions.TrySwitchBrokerAsync(nameof(RInteractiveEvaluatorTest));
+            await _workflow.RSession.HostStarted.Should().BeCompletedAsync(50000);
         }
 
         public async Task DisposeAsync() {

--- a/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
+++ b/src/R/Components/Test/PackageManager/PackageManagerIntegrationTest.cs
@@ -275,7 +275,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
             var workflow = UIThreadHelper.Instance.Invoke(() => _workflowProvider.GetOrCreate());
             var settings = _exportProvider.GetExportedValue<IRSettings>();
             await workflow.RSessions.TrySwitchBrokerAsync(nameof(PackageManagerIntegrationTest));
-            await workflow.RSession.StartHostAsync(new RHostStartupInfo {
+            await workflow.RSession.EnsureHostStartedAsync(new RHostStartupInfo {
                 Name = _testMethod.Name,
                 CranMirrorName = settings.CranMirror,
                 CodePage = settings.RCodePage

--- a/src/R/Components/Test/PackageManager/RPackageManagerViewModelTest.cs
+++ b/src/R/Components/Test/PackageManager/RPackageManagerViewModelTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.R.Components.Test.PackageManager {
             var settings = _exportProvider.GetExportedValue<IRSettings>();
             await _workflow.RSessions.TrySwitchBrokerAsync(nameof(RPackageManagerViewModelTest));
 
-            await _workflow.RSession.StartHostAsync(new RHostStartupInfo {
+            await _workflow.RSession.EnsureHostStartedAsync(new RHostStartupInfo {
                 Name = _testMethod.Name,
                 CranMirrorName = settings.CranMirror,
                 RHostCommandLineArguments = settings.LastActiveConnection.RCommandLineArguments,

--- a/src/R/Components/Test/Plots/RPlotIntegrationTest.cs
+++ b/src/R/Components/Test/Plots/RPlotIntegrationTest.cs
@@ -52,10 +52,10 @@ namespace Microsoft.R.Components.Test.Plots {
         }
 
         public async Task InitializeAsync() {
+            _replVisualComponent = await _workflow.GetOrCreateVisualComponent(_componentContainerFactory);
             await _workflow.RSessions.TrySwitchBrokerAsync(nameof(RPlotIntegrationTest));
 
             _plotDeviceVisualComponentContainerFactory.DeviceProperties = new PlotDeviceProperties(600, 500, 96);
-            _replVisualComponent = await _workflow.GetOrCreateVisualComponent(_componentContainerFactory);
         }
 
         public Task DisposeAsync() {

--- a/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
+++ b/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
@@ -32,13 +32,9 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
     [Collection(CollectionNames.NonParallel)]
     public class IntellisenseTest : FunctionIndexBasedTest {
         private readonly EditorHostMethodFixture _editorHost;
-        private readonly IRSessionProvider _sessionProvider;
 
         public IntellisenseTest(REditorApplicationMefCatalogFixture catalog, EditorHostMethodFixture editorHost) : base(catalog) {
             _editorHost = editorHost;
-
-            var workflow = ExportProvider.GetExportedValue<IRInteractiveWorkflowProvider>().GetOrCreate();
-            _sessionProvider = workflow.RSessions;
         }
 
         [Test]
@@ -121,7 +117,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
         [Test]
         public async Task R_LoadedPackageFunctionCompletion() {
             using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType))
-            using (new RHostScript(_sessionProvider)) {
+            using (new RHostScript(Workflow.RSessions)) {
                 script.Type("c");
                 script.DoIdle(200);
                 var session = script.GetCompletionSession();
@@ -132,10 +128,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
                 var item = list.FirstOrDefault(x => x.DisplayText == "codoc");
                 item.Should().BeNull();
 
-                var rSession = _sessionProvider.GetOrCreate(GuidList.InteractiveWindowRSessionGuid);
-                rSession.Should().NotBeNull();
-
-                await rSession.ExecuteAsync("library('tools')");
+                await Workflow.RSession.ExecuteAsync("library('tools')");
 
                 script.DoIdle(1000);
 
@@ -182,7 +175,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
         [Test]
         public async Task R_CompletionFilesUserFolder() {
             using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType))
-            using (new RHostScript(_sessionProvider)) {
+            using (new RHostScript(Workflow.RSessions)) {
                 var myDocs = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
                 var testFolder = Path.Combine(myDocs, "_rtvs_test_");
                 if (!Directory.Exists(testFolder)) {
@@ -235,7 +228,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
         [Category.Interactive]
         public async Task R_CompletionFunctionBraces01() {
             using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType))
-            using (var hostScript = new RHostScript(_sessionProvider)) {
+            using (var hostScript = new RHostScript(Workflow.RSessions)) {
 
                 string message = null;
                 hostScript.Session.Output += (s, e) => {
@@ -259,7 +252,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
         [Test]
         public async Task R_CompletionFunctionBraces02() {
             using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType))
-            using (var hostScript = new RHostScript(_sessionProvider)) {
+            using (var hostScript = new RHostScript(Workflow.RSessions)) {
 
                 string message = null;
                 hostScript.Session.Output += (s, e) => {
@@ -282,7 +275,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
         [Test]
         public async Task R_NoCompletionOnTab() {
             using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType))
-            using (new RHostScript(_sessionProvider)) {
+            using (new RHostScript(Workflow.RSessions)) {
 
                 script.DoIdle(100);
                 script.Type("f1<-function(x,y");
@@ -300,7 +293,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
         [Test]
         public async Task R_CompletionOnTab() {
             using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType))
-            using (new RHostScript(_sessionProvider)) {
+            using (new RHostScript(Workflow.RSessions)) {
 
                 REditorSettings.ShowCompletionOnTab = true;
                 script.DoIdle(100);
@@ -383,7 +376,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
         [Test]
         public async Task R_DeclaredVariablesCompletion01() {
             using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType))
-            using (var hostScript = new RHostScript(_sessionProvider)) {
+            using (var hostScript = new RHostScript(Workflow.RSessions)) {
 
                 await ExecuteRCode(hostScript.Session, "zzz111 <- 1\r\n");
                 await ExecuteRCode(hostScript.Session, "zzz111$y222 <- 2\r\n");
@@ -411,7 +404,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
         [Test]
         public async Task R_DeclaredVariablesCompletion02() {
             using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType))
-            using (var hostScript = new RHostScript(_sessionProvider)) {
+            using (var hostScript = new RHostScript(Workflow.RSessions)) {
 
                 await ExecuteRCode(hostScript.Session, "setClass('Person', representation(name = 'character', age = 'numeric'))\r\n");
                 await ExecuteRCode(hostScript.Session, "hadley <- new('Person', name = 'Hadley', age = 31)\r\n");
@@ -439,7 +432,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
         [Test]
         public async Task R_DeclaredVariablesCompletion03() {
             using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType))
-            using (var hostScript = new RHostScript(_sessionProvider)) {
+            using (var hostScript = new RHostScript(Workflow.RSessions)) {
 
                 await ExecuteRCode(hostScript.Session, "i1 <- 1\r\n");
                 PrimeIntellisenseProviders(script);
@@ -474,7 +467,7 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
         [Test]
         public async Task R_PackageVariablesCompletion() {
             using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType))
-            using (new RHostScript(_sessionProvider)) {
+            using (new RHostScript(Workflow.RSessions)) {
                 PrimeIntellisenseProviders(script);
                 script.DoIdle(1000);
 

--- a/src/R/Editor/Application.Test/Completion/ProvisionalTextTest.cs
+++ b/src/R/Editor/Application.Test/Completion/ProvisionalTextTest.cs
@@ -17,13 +17,16 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
     public sealed class RProvisionalTextTest : IDisposable {
         private readonly IExportProvider _exportProvider;
         private readonly EditorHostMethodFixture _editorHost;
+        private readonly bool _autoFormat;
 
         public RProvisionalTextTest(REditorApplicationMefCatalogFixture catalogFixture, EditorHostMethodFixture editorHost) {
             _exportProvider = catalogFixture.CreateExportProvider();
             _editorHost = editorHost;
+            _autoFormat = REditorSettings.AutoFormat;
         }
 
         public void Dispose() {
+            REditorSettings.AutoFormat = _autoFormat;
             _exportProvider.Dispose();
         }
 

--- a/src/R/Editor/Application.Test/Fixtures/REditorMefCatalogFixture.cs
+++ b/src/R/Editor/Application.Test/Fixtures/REditorMefCatalogFixture.cs
@@ -5,15 +5,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.R.Editor.Test;
-using Microsoft.UnitTests.Core.XUnit;
 
 namespace Microsoft.R.Editor.Application.Test {
-    [AssemblyFixture]
+    // Fixture doesn't import itself. Use AssemblyFixtureImportAttribute
     [ExcludeFromCodeCoverage]
-    public sealed class REditorApplicationMefCatalogFixture : REditorApplicationMefCatalogFixtureBase { }
-
-    [ExcludeFromCodeCoverage]
-    public class REditorApplicationMefCatalogFixtureBase : REditorMefCatalogFixtureBase {
+    public class REditorApplicationMefCatalogFixture : REditorMefCatalogFixture {
         protected override IEnumerable<string> GetBinDirectoryAssemblies() => base.GetBinDirectoryAssemblies().Concat(new[] {
             "Microsoft.Markdown.Editor",
             "Microsoft.Markdown.Editor.Test",

--- a/src/R/Editor/Application.Test/Formatting/AutoFormatTest.cs
+++ b/src/R/Editor/Application.Test/Formatting/AutoFormatTest.cs
@@ -17,13 +17,17 @@ namespace Microsoft.R.Editor.Application.Test.Formatting {
     public class AutoFormatTest : IDisposable {
         private readonly IExportProvider _exportProvider;
         private readonly EditorHostMethodFixture _editorHost;
+        private readonly bool _autoFormat;
 
         public AutoFormatTest(REditorApplicationMefCatalogFixture catalogFixture, EditorHostMethodFixture editorHost) {
             _exportProvider = catalogFixture.CreateExportProvider();
             _editorHost = editorHost;
+            _autoFormat = REditorSettings.AutoFormat;
+            REditorSettings.AutoFormat = true;
         }
 
         public void Dispose() {
+            REditorSettings.AutoFormat = _autoFormat;
             _exportProvider.Dispose();
         }
 

--- a/src/R/Editor/Application.Test/Properties/AssemblyInfo.cs
+++ b/src/R/Editor/Application.Test/Properties/AssemblyInfo.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.R.Editor.Application.Test;
 using Microsoft.R.Host.Client.Test.Fixtures;
 using Microsoft.UnitTests.Core.XUnit;
 using Microsoft.UnitTests.References;
 
 [assembly: TestFrameworkOverride]
-[assembly: AssemblyFixtureImport(typeof(SessionProviderFixture))]
+[assembly: AssemblyFixtureImport(typeof(SessionProviderFixture), typeof(REditorApplicationMefCatalogFixture))]
 #if VS14
 [assembly: Dev14AssemblyLoader]
 #endif

--- a/src/R/Editor/Test/Fixtures/REditorMefCatalogFixture.cs
+++ b/src/R/Editor/Test/Fixtures/REditorMefCatalogFixture.cs
@@ -5,15 +5,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.R.Support.Test;
-using Microsoft.UnitTests.Core.XUnit;
 
 namespace Microsoft.R.Editor.Test {
-    [AssemblyFixture]
+    // Fixture doesn't import itself. Use AssemblyFixtureImportAttribute
     [ExcludeFromCodeCoverage]
-    public sealed class REditorMefCatalogFixture : REditorMefCatalogFixtureBase { }
-
-    [ExcludeFromCodeCoverage]
-    public class REditorMefCatalogFixtureBase : RSupportMefCatalogFixtureBase {
+    public class REditorMefCatalogFixture : RSupportMefCatalogFixture {
         protected override IEnumerable<string> GetBinDirectoryAssemblies() => base.GetBinDirectoryAssemblies().Concat(new[] {
             "Microsoft.R.Editor",
             "Microsoft.R.Editor.Test"

--- a/src/R/Editor/Test/Formatting/AutoFormatTest.cs
+++ b/src/R/Editor/Test/Formatting/AutoFormatTest.cs
@@ -8,6 +8,7 @@ using Microsoft.Languages.Core.Formatting;
 using Microsoft.Languages.Editor.Shell;
 using Microsoft.Languages.Editor.Test.Text;
 using Microsoft.Languages.Editor.Text;
+using Microsoft.R.Components.ContentTypes;
 using Microsoft.R.Core.AST;
 using Microsoft.R.Editor.Formatting;
 using Microsoft.R.Editor.SmartIndent;
@@ -52,7 +53,7 @@ namespace Microsoft.R.Editor.Test.Formatting {
             ITextView textView = TextViewTest.MakeTextView("  x <- 1\r\n", 0, out ast);
             using (var document = new EditorDocumentMock(new EditorTreeMock(textView.TextBuffer, ast))) {
 
-                ISmartIndentProvider provider = _exportProvider.GetExportedValue<ISmartIndentProvider>();
+                ISmartIndentProvider provider = _exportProvider.GetExportedValue<ISmartIndentProvider>("ContentTypes", RContentTypeDefinition.ContentType);
                 SmartIndenter indenter = (SmartIndenter)provider.CreateSmartIndent(textView);
 
                 int? indent = indenter.GetDesiredIndentation(textView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(1), IndentStyle.Block);

--- a/src/R/Editor/Test/Formatting/SmartIndentTest.cs
+++ b/src/R/Editor/Test/Formatting/SmartIndentTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FluentAssertions;
+using Microsoft.R.Components.ContentTypes;
 using Microsoft.R.Core.AST;
 using Microsoft.R.Editor.Test.Mocks;
 using Microsoft.R.Editor.Test.Utility;
@@ -69,7 +70,7 @@ namespace Microsoft.R.Editor.Test.Formatting {
             ITextView textView = TextViewTest.MakeTextView(content, 0, out ast);
             var document = new EditorDocumentMock(new EditorTreeMock(textView.TextBuffer, ast));
 
-            ISmartIndentProvider provider = _exportProvider.GetExportedValue<ISmartIndentProvider>();
+            ISmartIndentProvider provider = _exportProvider.GetExportedValue<ISmartIndentProvider>("ContentTypes", RContentTypeDefinition.ContentType);
             ISmartIndent indenter = provider.CreateSmartIndent(textView);
             int? indent = indenter.GetDesiredIndentation(textView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(lineNum));
             indent.Should().HaveValue().And.Be(expectedIndent);

--- a/src/R/Editor/Test/Properties/AssemblyInfo.cs
+++ b/src/R/Editor/Test/Properties/AssemblyInfo.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.R.Editor.Test;
 using Microsoft.UnitTests.Core.XUnit;
 using Microsoft.UnitTests.References;
 
 [assembly: TestFrameworkOverride]
+[assembly: AssemblyFixtureImport(typeof(REditorMefCatalogFixture))]
 #if VS14
 [assembly: Dev14AssemblyLoader]
 #endif

--- a/src/R/Editor/Test/Utility/FunctionIndexBasedTest.cs
+++ b/src/R/Editor/Test/Utility/FunctionIndexBasedTest.cs
@@ -25,15 +25,16 @@ namespace Microsoft.R.Editor.Test.Utility {
             ExportProvider = catalog.CreateExportProvider();
             Workflow = UIThreadHelper.Instance.Invoke(() => ExportProvider.GetExportedValue<IRInteractiveWorkflowProvider>().GetOrCreate());
             EditorShell = ExportProvider.GetExportedValue<IEditorShell>();
-            PackageIndex = ExportProvider.GetExportedValue<IPackageIndex>();
             FunctionIndex = ExportProvider.GetExportedValue<IFunctionIndex>();
+            PackageIndex = ExportProvider.GetExportedValue<IPackageIndex>();
         }
 
-        public Task InitializeAsync() {
-            return PackageIndex.InitializeAsync(FunctionIndex);
+        public async Task InitializeAsync() {
+            await Workflow.RSessions.TrySwitchBrokerAsync(GetType().Name);
+            await PackageIndex.BuildIndexAsync();
         }
 
-        public virtual async Task DisposeAsync() {
+        public async Task DisposeAsync() {
             await PackageIndex.DisposeAsync(ExportProvider);
             ExportProvider.Dispose();
         }

--- a/src/R/Support/Impl/Help/Packages/PackageIndex.cs
+++ b/src/R/Support/Impl/Help/Packages/PackageIndex.cs
@@ -49,7 +49,10 @@ namespace Microsoft.R.Support.Help.Packages {
             _interactiveSession.PackagesRemoved += OnPackagesChanged;
         }
 
-        private void OnPackagesChanged(object sender, EventArgs e) => ScheduleIdleTimeRebuild();
+        private void OnPackagesChanged(object sender, EventArgs e) {
+            _buildIndexLock.EnqueueReset();
+            ScheduleIdleTimeRebuild();
+        }
 
         #region IPackageIndex
         /// <summary>

--- a/src/R/Support/Test/Functions/FunctionInfoTest.cs
+++ b/src/R/Support/Test/Functions/FunctionInfoTest.cs
@@ -31,8 +31,8 @@ namespace Microsoft.R.Support.Test.Functions {
         }
 
         public async Task InitializeAsync() {
-            await _workflow.RSessions.TrySwitchBrokerAsync(nameof(FunctionInfoTest));
-            await _packageIndex.InitializeAsync(_functionIndex);
+            await _workflow.RSessions.TrySwitchBrokerAsync(GetType().Name);
+            await _packageIndex.BuildIndexAsync();
         }
 
         public async Task DisposeAsync() {

--- a/src/R/Support/Test/Properties/AssemblyInfo.cs
+++ b/src/R/Support/Test/Properties/AssemblyInfo.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.R.Support.Test;
 using Microsoft.UnitTests.Core.XUnit;
 using Microsoft.UnitTests.References;
 
 [assembly: TestFrameworkOverride]
+[assembly: AssemblyFixtureImport(typeof(RSupportMefCatalogFixture))]
 #if VS14
 [assembly: Dev14AssemblyLoader]
 #endif

--- a/src/R/Support/Test/RSupportMefCatalogFixture.cs
+++ b/src/R/Support/Test/RSupportMefCatalogFixture.cs
@@ -9,16 +9,13 @@ using Microsoft.Common.Core.Extensions;
 using Microsoft.Languages.Editor.Test;
 using Microsoft.R.Components.Settings;
 using Microsoft.R.Support.Test.Utility;
-using Microsoft.UnitTests.Core.XUnit;
 
 namespace Microsoft.R.Support.Test {
-    [AssemblyFixture]
+    // Fixture doesn't import itself. Use AssemblyFixtureImportAttribute
     [ExcludeFromCodeCoverage]
-    public sealed class RSupportMefCatalogFixture : RSupportMefCatalogFixtureBase { }
-
-    [ExcludeFromCodeCoverage]
-    public class RSupportMefCatalogFixtureBase : LanguagesEditorMefCatalogFixtureBase {
+    public class RSupportMefCatalogFixture : LanguagesEditorMefCatalogFixture {
         protected override IEnumerable<string> GetBinDirectoryAssemblies() => base.GetBinDirectoryAssemblies().Concat(new[] {
+            "Microsoft.VisualStudio.InteractiveWindow.dll",
             "Microsoft.R.Support",
             "Microsoft.R.Support.Test"
         });

--- a/src/R/Support/Test/Utility/PackageIndexUtility.cs
+++ b/src/R/Support/Test/Utility/PackageIndexUtility.cs
@@ -27,11 +27,6 @@ namespace Microsoft.R.Support.Test.Utility {
             return tcs.Task;
         }
 
-        public static Task InitializeAsync(this IPackageIndex packageIndex, IFunctionIndex functionIndex) {
-            RToolsSettings.Current = new TestRToolsSettings();
-            return packageIndex.BuildIndexAsync();
-        } 
-
         public static async Task DisposeAsync(this IPackageIndex packageIndex, IExportProvider exportProvider) {
             var sessionProvider = exportProvider.GetExportedValue<IRInteractiveWorkflowProvider>().GetOrCreate().RSessions;
             if (sessionProvider != null) {

--- a/src/R/Support/Test/Utility/TestRToolsSettings.cs
+++ b/src/R/Support/Test/Utility/TestRToolsSettings.cs
@@ -21,9 +21,12 @@ namespace Microsoft.R.Support.Test.Utility {
     public sealed class TestRToolsSettings : IRToolsSettings {
         private readonly IConnectionInfo[] _connections;
 
-        public TestRToolsSettings(string connectionName = null) {
+        [ImportingConstructor]
+        public TestRToolsSettings() : this("Test") {}
+
+        public TestRToolsSettings(string connectionName) {
             _connections = new IConnectionInfo[] { new ConnectionInfo {
-                Name = connectionName ?? "Test",
+                Name = connectionName,
                 Path = new RInstallation().GetCompatibleEngines().First().InstallPath
             }};
         }
@@ -33,8 +36,7 @@ namespace Microsoft.R.Support.Test.Utility {
             set { }
         }
 
-        public IConnectionInfo 
-            LastActiveConnection {
+        public IConnectionInfo LastActiveConnection {
             get { return _connections[0]; }
             set { }
         }

--- a/src/UnitTests/Core/Impl/Mef/IExportProvider.cs
+++ b/src/UnitTests/Core/Impl/Mef/IExportProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 namespace Microsoft.UnitTests.Core.Mef {
     public interface IExportProvider : IDisposable {
         T GetExportedValue<T>();
+        T GetExportedValue<T>(string metadataKey, params object[] metadataValues);
         IEnumerable<Lazy<T>> GetExports<T>();
         IEnumerable<Lazy<T, TMetadataView>> GetExports<T, TMetadataView>();
     }

--- a/src/UnitTests/Core/Impl/Microsoft.UnitTests.Core.csproj
+++ b/src/UnitTests/Core/Impl/Microsoft.UnitTests.Core.csproj
@@ -87,6 +87,8 @@
     <Compile Include="XUnit\IMethodFixture.cs" />
     <Compile Include="XUnit\InlineArrayAttribute.cs" />
     <Compile Include="XUnit\InlineArrayDiscoverer.cs" />
+    <Compile Include="XUnit\IntRangeAttribute.cs" />
+    <Compile Include="XUnit\IntRangeDiscoverer.cs" />
     <Compile Include="XUnit\MefCatalogFixture.cs" />
     <Compile Include="XUnit\MessageBusInjections\ExecuteBeforeAfterAttributesMessageBusInjection.cs" />
     <Compile Include="XUnit\MessageBusInjections\ITestAfterStartingBeforeFinishedInjection.cs" />

--- a/src/UnitTests/Core/Impl/XUnit/InlineArrayAttribute.cs
+++ b/src/UnitTests/Core/Impl/XUnit/InlineArrayAttribute.cs
@@ -4,25 +4,22 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;
 
-namespace Microsoft.UnitTests.Core.XUnit
-{
+namespace Microsoft.UnitTests.Core.XUnit {
     [DataDiscoverer("Microsoft.UnitTests.Core.XUnit.InlineArrayDiscoverer", "Microsoft.UnitTests.Core")]
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     [ExcludeFromCodeCoverage]
-    public sealed class InlineArrayAttribute : DataAttribute
-    {
+    public sealed class InlineArrayAttribute : DataAttribute {
         private readonly object[] _array;
 
-        public InlineArrayAttribute(params object[] array)
-        {
+        public InlineArrayAttribute(params object[] array) {
             _array = array;
         }
 
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
+        public override IEnumerable<object[]> GetData(MethodInfo testMethod) {
             yield return new object[] { _array };
         }
     }

--- a/src/UnitTests/Core/Impl/XUnit/InlineArrayDiscoverer.cs
+++ b/src/UnitTests/Core/Impl/XUnit/InlineArrayDiscoverer.cs
@@ -7,21 +7,17 @@ using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace Microsoft.UnitTests.Core.XUnit
-{
+namespace Microsoft.UnitTests.Core.XUnit {
     [ExcludeFromCodeCoverage]
-    public class InlineArrayDiscoverer : IDataDiscoverer
-    {
+    public class InlineArrayDiscoverer : IDataDiscoverer {
         /// <inheritdoc/>
-        public virtual IEnumerable<object[]> GetData(IAttributeInfo dataAttribute, IMethodInfo testMethod)
-        {
+        public virtual IEnumerable<object[]> GetData(IAttributeInfo dataAttribute, IMethodInfo testMethod) {
             var args = (IEnumerable<object>)dataAttribute.GetConstructorArguments().Single() ?? Enumerable.Empty<object>();
             yield return new object[] { args.ToArray() };
         }
 
         /// <inheritdoc/>
-        public virtual bool SupportsDiscoveryEnumeration(IAttributeInfo dataAttribute, IMethodInfo testMethod)
-        {
+        public virtual bool SupportsDiscoveryEnumeration(IAttributeInfo dataAttribute, IMethodInfo testMethod) {
             return true;
         }
     }

--- a/src/UnitTests/Core/Impl/XUnit/IntRangeAttribute.cs
+++ b/src/UnitTests/Core/Impl/XUnit/IntRangeAttribute.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Microsoft.UnitTests.Core.XUnit {
+    [DataDiscoverer("Microsoft.UnitTests.Core.XUnit.IntRangeDiscoverer", "Microsoft.UnitTests.Core")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [ExcludeFromCodeCoverage]
+    public sealed class IntRangeAttribute : DataAttribute {
+        private readonly int _start;
+        private readonly int _count;
+        private readonly int _step;
+
+        public IntRangeAttribute(int count) : this(0, count, 1) {}
+
+        public IntRangeAttribute(int start, int count) : this(start, count, 1) {}
+
+        public IntRangeAttribute(int start, int count, int step) {
+            _start = start;
+            _count = count;
+            _step = step;
+        }
+
+        public override IEnumerable<object[]> GetData(MethodInfo testMethod) {
+            for (var i = 0; i < _count; i++) {
+                yield return new object[] { _start + i * _step };
+            }
+        }
+    }
+}

--- a/src/UnitTests/Core/Impl/XUnit/IntRangeDiscoverer.cs
+++ b/src/UnitTests/Core/Impl/XUnit/IntRangeDiscoverer.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.UnitTests.Core.XUnit {
+    public sealed class IntRangeDiscoverer : IDataDiscoverer {
+        /// <inheritdoc/>
+        public IEnumerable<object[]> GetData(IAttributeInfo dataAttribute, IMethodInfo testMethod) {
+            var args = dataAttribute.GetConstructorArguments().ToList();
+            var start = 0;
+            var count = 1;
+            var step = 1;
+            if (args.Count == 1) {
+                count = (int) args[0];
+            } else if (args.Count >= 2) {
+                start = (int)args[0];
+                count = (int)args[1];
+            }
+
+            if (args.Count >= 3) {
+                step = (int)args[2];
+            }
+
+            for (var i = 0; i < count; i++) {
+                yield return new object[] { start + i * step };
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool SupportsDiscoveryEnumeration(IAttributeInfo dataAttribute, IMethodInfo testMethod) {
+            return true;
+        }
+    }
+}

--- a/src/UnitTests/Core/Impl/XUnit/MefCatalogFixture.cs
+++ b/src/UnitTests/Core/Impl/XUnit/MefCatalogFixture.cs
@@ -6,15 +6,18 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Primitives;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using Microsoft.Common.Core.Disposables;
 using Microsoft.UnitTests.Core.Mef;
 
 namespace Microsoft.UnitTests.Core.XUnit {
     [ExcludeFromCodeCoverage]
     public abstract class MefCatalogFixture : IDisposable {
         private readonly Lazy<ComposablePartCatalog> _catalogLazy;
-        private readonly ConcurrentQueue<CompositionContainer> _containers = new ConcurrentQueue<CompositionContainer>();
+        private readonly ConcurrentQueue<IDisposable> _exportProviders = new ConcurrentQueue<IDisposable>();
 
         protected MefCatalogFixture() {
             _catalogLazy = new Lazy<ComposablePartCatalog>(CreateCatalog);
@@ -27,36 +30,71 @@ namespace Microsoft.UnitTests.Core.XUnit {
         public IExportProvider CreateExportProvider([CallerMemberName] string testName = null) {
             var container = new CompositionContainer(_catalogLazy.Value, CompositionOptions.DisableSilentRejection);
             AddValues(container, testName);
-            _containers.Enqueue(container);
-            return new TestExportProvider(container);
+            var exportProvider = new TestExportProvider(container);
+            _exportProviders.Enqueue(exportProvider);
+            return exportProvider;
         }
 
         public IExportProvider CreateExportProvider(CompositionBatch additionalValues, [CallerMemberName] string testName = null) {
             var container = new CompositionContainer(_catalogLazy.Value, CompositionOptions.DisableSilentRejection);
             AddValues(container, testName);
             container.Compose(additionalValues);
-            _containers.Enqueue(container);
-            return new TestExportProvider(container);
+            var exportProvider = new TestExportProvider(container);
+            _exportProviders.Enqueue(exportProvider);
+            return exportProvider;
         }
 
         void IDisposable.Dispose() {
-            CompositionContainer container;
-            while (_containers.TryDequeue(out container)) {
-                container.Dispose();
+            IDisposable exportProvider;
+            while (_exportProviders.TryDequeue(out exportProvider)) {
+                exportProvider.Dispose();
             }
         }
 
         private class TestExportProvider : IExportProvider {
+            private readonly DisposableBag _disposableBag;
             private readonly CompositionContainer _compositionContainer;
 
             public TestExportProvider(CompositionContainer compositionContainer) {
                 _compositionContainer = compositionContainer;
+                _disposableBag = DisposableBag.Create<TestExportProvider>()
+                    .Add(_compositionContainer);
             }
 
-            public void Dispose() => _compositionContainer.Dispose();
-            public T GetExportedValue<T>() => _compositionContainer.GetExportedValue<T>();
-            public IEnumerable<Lazy<T>> GetExports<T>() => _compositionContainer.GetExports<T>();
-            public IEnumerable<Lazy<T, TMetadataView>> GetExports<T, TMetadataView>() => _compositionContainer.GetExports<T, TMetadataView>();
+            public void Dispose() => _disposableBag.TryDispose();
+            public T GetExportedValue<T>() {
+                _disposableBag.ThrowIfDisposed();
+                return _compositionContainer.GetExportedValue<T>();
+            }
+
+            public T GetExportedValue<T>(string metadataKey, params object[] metadataValues) {
+                _disposableBag.ThrowIfDisposed();
+                var exports = _compositionContainer.GetExports<T, IDictionary<string, object>>();
+
+                return exports.Single(e => {
+                    object value;
+                    if (!e.Metadata.TryGetValue(metadataKey, out value)) {
+                        return false;
+                    }
+
+                    var enumerable = value as IEnumerable<object>;
+                    if (enumerable == null) {
+                        return metadataValues.Length == 1 && Equals(value, metadataValues[0]);
+                    }
+
+                    return metadataValues.Intersect(enumerable).Any();
+                }).Value;
+            }
+
+            public IEnumerable<Lazy<T>> GetExports<T>() {
+                _disposableBag.ThrowIfDisposed();
+                return _compositionContainer.GetExports<T>();
+            }
+
+            public IEnumerable<Lazy<T, TMetadataView>> GetExports<T, TMetadataView>() {
+                _disposableBag.ThrowIfDisposed();
+                return _compositionContainer.GetExports<T, TMetadataView>();
+            }
         }
     }
 }


### PR DESCRIPTION
- Fix #2645: VS stuck while connecting to remote
- Fix #2430: Restore connection if the last connection was local
- Increased delays for some of the tests
- Split RHostPipeFuzzTest into iterations + IntRangeAttribute
- Added DisposableBag wrapper around CompositionContained in the TestExportProvider
- Added GetExportedValue overload that supports metadata filtering
- Removed some dead code
- Fix several other tests