### PR TITLE
3 bug fixes

### DIFF
--- a/src/Host/Client/Impl/Resources.Designer.cs
+++ b/src/Host/Client/Impl/Resources.Designer.cs
@@ -241,8 +241,7 @@ namespace Microsoft.R.Host.Client {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Interactive Window is disconnected from R Session.
-        ///Open Workspaces window and either select local R interpreter or try connecting to a remote machine..
+        ///   Looks up a localized string similar to Interactive Window is disconnected from R Session..
         /// </summary>
         internal static string RHostDisconnected {
             get {

--- a/src/Host/Client/Impl/Resources.resx
+++ b/src/Host/Client/Impl/Resources.resx
@@ -118,8 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="RHostDisconnected" xml:space="preserve">
-    <value>Interactive Window is disconnected from R Session.
-Open Workspaces window and either select local R interpreter or try connecting to a remote machine.</value>
+    <value>Interactive Window is disconnected from R Session.</value>
   </data>
   <data name="RSessionProvider_ConnectionFailed" xml:space="preserve">
     <value>Connecting to R Workspace failed.

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -216,7 +216,7 @@ namespace Microsoft.R.Host.Client.Session {
         public async Task EnsureHostStartedAsync(RHostStartupInfo startupInfo, IRSessionCallback callback, int timeout = 3000, CancellationToken cancellationToken = default(CancellationToken)) {
             using (_disposeToken.Link(ref cancellationToken))
             using (await _initializationLock.WaitAsync(cancellationToken)) {
-                if (_initializationTcs.Task.Status != TaskStatus.RanToCompletion) {
+                if (_initializationTcs.Task.Status != TaskStatus.RanToCompletion || !_isHostRunning) {
                     await StartHostAsyncBackground(startupInfo, callback, timeout, cancellationToken);
                 }
             }
@@ -225,7 +225,7 @@ namespace Microsoft.R.Host.Client.Session {
         public async Task StartHostAsync(RHostStartupInfo startupInfo, IRSessionCallback callback, int timeout = 3000, CancellationToken cancellationToken = default(CancellationToken)) {
             using (_disposeToken.Link(ref cancellationToken))
             using (await _initializationLock.WaitAsync(cancellationToken)) {
-                if (_initializationTcs.Task.Status != TaskStatus.RanToCompletion) {
+                if (_initializationTcs.Task.Status != TaskStatus.RanToCompletion || !_isHostRunning) {
                     await StartHostAsyncBackground(startupInfo, callback, timeout, cancellationToken);
                 } else {
                     throw new InvalidOperationException("Another instance of RHost is running for this RSession. Stop it before starting new one.");

--- a/src/Host/Client/Impl/Session/RSessionProvider.cs
+++ b/src/Host/Client/Impl/Session/RSessionProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.R.Host.Client.Session {
 
                 try {
                     await session.StartHostAsync(new RHostStartupInfo {
-                        Name = "IsolatedRHost" + session.Id,
+                        Name = "Isolated_" + (startupInfo.Name ?? session.Id.ToString()),
                         CranMirrorName = startupInfo.CranMirrorName,
                         CodePage = startupInfo.CodePage
                     }, null, cancellationToken: cancellationToken);

--- a/src/Host/Client/Test/EventTaskSources.cs
+++ b/src/Host/Client/Test/EventTaskSources.cs
@@ -1,21 +1,32 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using Microsoft.Common.Core.Tasks;
 using Microsoft.R.ExecutionTracing;
 
 namespace Microsoft.R.Host.Client.Test {
     internal static class EventTaskSources {
         public static class IRSession {
-            public static readonly EventTaskSource<Microsoft.R.Host.Client.IRSession, Microsoft.R.Host.Client.ROutputEventArgs> Output =
-                new EventTaskSource<Microsoft.R.Host.Client.IRSession, Microsoft.R.Host.Client.ROutputEventArgs>(
+            public static readonly EventTaskSource<Client.IRSession, ROutputEventArgs> Output =
+                new EventTaskSource<Client.IRSession, ROutputEventArgs>(
                     (o, e) => o.Output += e,
                     (o, e) => o.Output -= e);
+
+            public static readonly EventTaskSource<Client.IRSession, RConnectedEventArgs> Connected =
+                new EventTaskSource<Client.IRSession, RConnectedEventArgs>(
+                    (o, e) => o.Connected += e,
+                    (o, e) => o.Connected -= e);
+
+            public static readonly EventTaskSource<Client.IRSession, EventArgs> Disconnected =
+                new EventTaskSource<Client.IRSession, EventArgs>(
+                    (o, e) => o.Disconnected += e,
+                    (o, e) => o.Disconnected -= e);
         }
 
         public static class IRExecutionTracer {
-            public static readonly EventTaskSource<Microsoft.R.ExecutionTracing.IRExecutionTracer, RBrowseEventArgs> Browse =
-                new EventTaskSource<Microsoft.R.ExecutionTracing.IRExecutionTracer, RBrowseEventArgs>(
+            public static readonly EventTaskSource<ExecutionTracing.IRExecutionTracer, RBrowseEventArgs> Browse =
+                new EventTaskSource<ExecutionTracing.IRExecutionTracer, RBrowseEventArgs>(
                     (o, e) => o.Browse += e,
                     (o, e) => o.Browse -= e);
         }

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
@@ -163,7 +163,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
                 return ActiveWindow;
             }
 
-            var evaluator = new RInteractiveEvaluator(RSession, History, Connections, Shell, _settings);
+            var evaluator = new RInteractiveEvaluator(RSessions, RSession, History, Connections, Shell, _settings);
 
             ActiveWindow = componentContainerFactory.Create(instanceId, evaluator, RSessions);
             var interactiveWindow = ActiveWindow.InteractiveWindow;

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -138,6 +138,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             // separate package query session to avoid freezing the REPL.
             try {
                 var startupInfo = new RHostStartupInfo {
+                    Name = "PackageManager",
                     CranMirrorName = _settings.CranMirror,
                     CodePage = _settings.RCodePage
                 };

--- a/src/R/Components/Impl/Resources.Designer.cs
+++ b/src/R/Components/Impl/Resources.Designer.cs
@@ -515,15 +515,6 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Interactive Window is disconnected from R Session. Click Reset to reconnect..
-        /// </summary>
-        public static string MicrosoftRHostDisconnected {
-            get {
-                return ResourceManager.GetString("MicrosoftRHostDisconnected", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Starting R Session....
         /// </summary>
         public static string MicrosoftRHostStarting {
@@ -533,7 +524,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to R Host process is stopped. Click Reset to start a new one..
+        ///   Looks up a localized string similar to R Host process is stopped. Click &quot;Reset&quot; to start a new one..
         /// </summary>
         public static string MicrosoftRHostStopped {
             get {
@@ -1181,11 +1172,29 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open Workspaces window and either select local R interpreter or try connecting to a remote machine..
+        /// </summary>
+        public static string ReconnectToBroker {
+            get {
+                return ResourceManager.GetString("ReconnectToBroker", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to R Interactive.
         /// </summary>
         public static string ReplWindowName {
             get {
                 return ResourceManager.GetString("ReplWindowName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Click &quot;Reset&quot; to start a new session..
+        /// </summary>
+        public static string RestartRHost {
+            get {
+                return ResourceManager.GetString("RestartRHost", resourceCulture);
             }
         }
         

--- a/src/R/Components/Impl/Resources.resx
+++ b/src/R/Components/Impl/Resources.resx
@@ -117,17 +117,20 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="MicrosoftRHostDisconnected" xml:space="preserve">
-    <value>Interactive Window is disconnected from R Session. Click Reset to reconnect.</value>
-  </data>
   <data name="MicrosoftRHostStopped" xml:space="preserve">
-    <value>R Host process is stopped. Click Reset to start a new one.</value>
+    <value>R Host process is stopped. Click "Reset" to start a new one.</value>
   </data>
   <data name="MicrosoftRHostStopping" xml:space="preserve">
     <value>Stopping R Session...</value>
   </data>
   <data name="MicrosoftRHostStarting" xml:space="preserve">
     <value>Starting R Session...</value>
+  </data>
+  <data name="RestartRHost" xml:space="preserve">
+    <value>Click "Reset" to start a new session.</value>
+  </data>
+  <data name="ReconnectToBroker" xml:space="preserve">
+    <value>Open Workspaces window and either select local R interpreter or try connecting to a remote machine.</value>
   </data>
   <data name="Error_Microsoft_R_Host_Missing" xml:space="preserve">
     <value>Microsoft.R.Host.exe is missing. Click OK to open download link in the default browser.</value>


### PR DESCRIPTION
- Fix #2639: Terminating R and then using REPL produces incorrect error
- Fix #2656: Reset doesn't work after RHost process is terminated
- Fix #2644: Package manager RHost session should use the name PackageManager
