### PR TITLE
Fix #2575: F5 hangs when Remote + Reset R Interactive is on

### DIFF
--- a/src/Common/Core/Impl/Microsoft.Common.Core.csproj
+++ b/src/Common/Core/Impl/Microsoft.Common.Core.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Threading\AsyncReaderWriterLock.Queue.cs" />
     <Compile Include="Threading\DelayedAsyncAction.cs" />
     <Compile Include="Threading\IAsyncReaderWriterLockToken.cs" />
+    <Compile Include="Threading\MainThreadExtensions.cs" />
     <Compile Include="Threading\IMainThread.cs" />
     <Compile Include="Threading\IReentrancyTokenFactory.cs" />
     <Compile Include="Tasks\ITaskService.cs" />

--- a/src/Common/Core/Impl/Security/SecurityService.cs
+++ b/src/Common/Core/Impl/Security/SecurityService.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Common.Core.Security {
         }
 
         public Task<Credentials> GetUserCredentialsAsync(string authority, bool invalidateStoredCredentials, CancellationToken cancellationToken = default(CancellationToken)) {
+            _coreShellLazy.Value.AssertIsOnMainThread();
+
             var showDialog = invalidateStoredCredentials;
             var credentials = new Credentials();
 

--- a/src/Common/Core/Impl/Security/SecurityService.cs
+++ b/src/Common/Core/Impl/Security/SecurityService.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Common.Core.Security {
             _coreShellLazy = coreShellLazy;
         }
 
-        public async Task<Credentials> GetUserCredentialsAsync(string authority, bool invalidateStoredCredentials, CancellationToken cancellationToken = default(CancellationToken)) {
+        public Task<Credentials> GetUserCredentialsAsync(string authority, bool invalidateStoredCredentials, CancellationToken cancellationToken = default(CancellationToken)) {
             var showDialog = invalidateStoredCredentials;
             var credentials = new Credentials();
 
@@ -37,7 +37,6 @@ namespace Microsoft.Common.Core.Security {
                     flags |= CREDUI_FLAGS_ALWAYS_SHOW_UI;
                 }
 
-                await _coreShellLazy.Value.SwitchToMainThreadAsync(cancellationToken);
                 var credui = new CREDUI_INFO {
                     cbSize = Marshal.SizeOf(typeof(CREDUI_INFO)),
                     hwndParent = _coreShellLazy.Value.AppConstants.ApplicationWindowHandle
@@ -59,7 +58,7 @@ namespace Microsoft.Common.Core.Security {
                 }
             }
 
-            return credentials;
+            return Task.FromResult(credentials);
         }
 
         public async Task<bool> ValidateX509CertificateAsync(X509Certificate certificate, string message, CancellationToken cancellationToken = default(CancellationToken)) {

--- a/src/Common/Core/Impl/Services/CoreServices.cs
+++ b/src/Common/Core/Impl/Services/CoreServices.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.Common.Core.IO;
 using Microsoft.Common.Core.Logging;
@@ -10,11 +11,13 @@ using Microsoft.Common.Core.Security;
 using Microsoft.Common.Core.Shell;
 using Microsoft.Common.Core.Tasks;
 using Microsoft.Common.Core.Telemetry;
+using Microsoft.Common.Core.Threading;
 
 namespace Microsoft.Common.Core.Services {
     [Export(typeof(ICoreServices))]
     public sealed class CoreServices : ICoreServices {
         private readonly IApplicationConstants _appConstants;
+        private readonly Lazy<IMainThread> _mainThread;
         private IActionLog _log;
 
         [ImportingConstructor]
@@ -25,6 +28,7 @@ namespace Microsoft.Common.Core.Services {
             , ISecurityService security
             , ITaskService tasks
             , ISettingsStorage settings
+            , Lazy<IMainThread> mainThread
             , [Import(AllowDefault = true)] IActionLog log = null
             , [Import(AllowDefault = true)] IFileSystem fs = null
             , [Import(AllowDefault = true)] IRegistry registry = null
@@ -42,6 +46,7 @@ namespace Microsoft.Common.Core.Services {
             Registry = registry ?? new RegistryImpl();
             FileSystem = fs ?? new FileSystem();
             Settings = settings;
+            _mainThread = mainThread;
         }
 
         public IActionLog Log => _log ?? (_log = LoggingServices.GetOrCreateLog(_appConstants.ApplicationName));
@@ -54,5 +59,6 @@ namespace Microsoft.Common.Core.Services {
         public ITaskService Tasks { get; }
         public ILoggingServices LoggingServices { get; }
         public ISettingsStorage Settings { get; }
+        public IMainThread MainThread => _mainThread.Value;
     }
 }

--- a/src/Common/Core/Impl/Services/ICoreServices.cs
+++ b/src/Common/Core/Impl/Services/ICoreServices.cs
@@ -8,6 +8,7 @@ using Microsoft.Common.Core.Security;
 using Microsoft.Common.Core.Shell;
 using Microsoft.Common.Core.Tasks;
 using Microsoft.Common.Core.Telemetry;
+using Microsoft.Common.Core.Threading;
 
 namespace Microsoft.Common.Core.Services {
     public interface ICoreServices {
@@ -20,5 +21,6 @@ namespace Microsoft.Common.Core.Services {
         ITelemetryService Telemetry { get; }
         ITaskService Tasks { get; }
         ISettingsStorage Settings { get; }
+        IMainThread MainThread { get; }
     }
 }

--- a/src/Common/Core/Impl/Shell/CoreShellExtensions.cs
+++ b/src/Common/Core/Impl/Shell/CoreShellExtensions.cs
@@ -11,7 +11,7 @@ using Microsoft.Common.Core.Threading;
 namespace Microsoft.Common.Core.Shell {
     public static class CoreShellExtensions {
         public static MainThreadAwaitable SwitchToMainThreadAsync(this ICoreShell coreShell, CancellationToken cancellationToken = default(CancellationToken))
-            => new MainThreadAwaitable((IMainThread)coreShell, cancellationToken);
+            => ((IMainThread)coreShell).SwitchToAsync(cancellationToken);
 
         public static async Task ShowErrorMessageAsync(this ICoreShell coreShell, string message, CancellationToken cancellationToken = default(CancellationToken)) {
             await coreShell.SwitchToMainThreadAsync(cancellationToken);

--- a/src/Common/Core/Impl/Threading/MainThreadExtensions.cs
+++ b/src/Common/Core/Impl/Threading/MainThreadExtensions.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading;
+
+namespace Microsoft.Common.Core.Threading {
+    public static class MainThreadExtensions {
+        public static MainThreadAwaitable SwitchToAsync(this IMainThread mainThread, CancellationToken cancellationToken = default(CancellationToken))
+            => new MainThreadAwaitable(mainThread, cancellationToken);
+    }
+}

--- a/src/Common/Core/Test/Fakes/Shell/TestCoreServices.cs
+++ b/src/Common/Core/Test/Fakes/Shell/TestCoreServices.cs
@@ -11,6 +11,7 @@ using Microsoft.Common.Core.Shell;
 using Microsoft.Common.Core.Tasks;
 using Microsoft.Common.Core.Telemetry;
 using Microsoft.Common.Core.Test.Telemetry;
+using Microsoft.Common.Core.Threading;
 using NSubstitute;
 
 namespace Microsoft.Common.Core.Test.Fakes.Shell {
@@ -24,6 +25,7 @@ namespace Microsoft.Common.Core.Test.Fakes.Shell {
                 Substitute.For<ISecurityService>(),
                 Substitute.For<ITaskService>(),
                 Substitute.For<ISettingsStorage>(),
+                Lazy.Create(() => Substitute.For<IMainThread>()),
                 Substitute.For<IActionLog>(),
                 fs ?? Substitute.For<IFileSystem>(),
                 registry ?? Substitute.For<IRegistry>(),
@@ -38,6 +40,7 @@ namespace Microsoft.Common.Core.Test.Fakes.Shell {
                 Substitute.For<ISecurityService>(),
                 new TestTaskService(),
                 Substitute.For<ISettingsStorage>(),
+                Lazy.Create(() => Substitute.For<IMainThread>()),
                 Substitute.For<IActionLog>(),
                 new FileSystem(),
                 new RegistryImpl(),

--- a/src/Host/Client/Impl/Host/RemoteBrokerClient.cs
+++ b/src/Host/Client/Impl/Host/RemoteBrokerClient.cs
@@ -26,7 +26,7 @@ namespace Microsoft.R.Host.Client.Host {
         }
 
         public RemoteBrokerClient(string name, Uri brokerUri, ICoreServices services, IConsole console)
-            : base(name, brokerUri, brokerUri.Fragment, new RemoteCredentialsDecorator(brokerUri, services.Security), services.Log, console) {
+            : base(name, brokerUri, brokerUri.Fragment, new RemoteCredentialsDecorator(brokerUri, services.Security, services.MainThread), services.Log, console) {
             _console = console;
             _services = services;
 

--- a/src/Host/Client/Impl/Program.cs
+++ b/src/Host/Client/Impl/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.Common.Core;
 using Microsoft.Common.Core.Logging;
 using Microsoft.Common.Core.Services;
 using Microsoft.Common.Core.Shell;
+using Microsoft.Common.Core.Threading;
 using Microsoft.R.Host.Client.Host;
 using Microsoft.R.Host.Client.Session;
 using static System.FormattableString;
@@ -22,7 +23,7 @@ namespace Microsoft.R.Host.Client {
             Console.CancelKeyPress += Console_CancelKeyPress;
 
             using (var logger = new Logger("Program", new MaxLoggingPermissions(), FileLogWriter.InTempFolder("Microsoft.R.Host.Client.Program"))) {
-                var services = new CoreServices(new AppConstants(), null, null, null, null, null);
+                var services = new CoreServices(new AppConstants(), null, null, null, null, null, Lazy.Create<IMainThread>(() => null));
                 var localConnector = new LocalBrokerClient("Program", args[0], services, new NullConsole());
                 var host = localConnector.ConnectAsync(new BrokerConnectionInfo("Program", new Program())).GetAwaiter().GetResult();
                 _evaluator = host;

--- a/src/Package/Impl/Shell/VsAppShell.cs
+++ b/src/Package/Impl/Shell/VsAppShell.cs
@@ -39,6 +39,7 @@ namespace Microsoft.VisualStudio.R.Package.Shell {
     [Export(typeof(ICoreShell))]
     [Export(typeof(IEditorShell))]
     [Export(typeof(IApplicationShell))]
+    [Export(typeof(IMainThread))]
     public sealed class VsAppShell : IApplicationShell, IMainThread, IIdleTimeService, IDisposable {
         private static VsAppShell _instance;
         private static IApplicationShell _testShell;


### PR DESCRIPTION
Switch to main thread before taking the credentials lock, to avoid deadlocking when main thread is waiting on the currently executing task.