### PR TITLE
Fix #2625: NRE in Variable Explorer when closing VS

### DIFF
--- a/src/Common/Core/Test/Fakes/Shell/TestCoreServices.cs
+++ b/src/Common/Core/Test/Fakes/Shell/TestCoreServices.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Common.Core.IO;
 using Microsoft.Common.Core.Logging;
@@ -25,7 +26,7 @@ namespace Microsoft.Common.Core.Test.Fakes.Shell {
                 Substitute.For<ISecurityService>(),
                 Substitute.For<ITaskService>(),
                 Substitute.For<ISettingsStorage>(),
-                Lazy.Create(() => Substitute.For<IMainThread>()),
+                new Lazy<IMainThread>(() => new TestMainThread()),
                 Substitute.For<IActionLog>(),
                 fs ?? Substitute.For<IFileSystem>(),
                 registry ?? Substitute.For<IRegistry>(),
@@ -40,7 +41,7 @@ namespace Microsoft.Common.Core.Test.Fakes.Shell {
                 Substitute.For<ISecurityService>(),
                 new TestTaskService(),
                 Substitute.For<ISettingsStorage>(),
-                Lazy.Create(() => Substitute.For<IMainThread>()),
+                new Lazy<IMainThread>(() => new TestMainThread()),
                 Substitute.For<IActionLog>(),
                 new FileSystem(),
                 new RegistryImpl(),

--- a/src/Common/Core/Test/Fakes/Shell/TestCoreShell.cs
+++ b/src/Common/Core/Test/Fakes/Shell/TestCoreShell.cs
@@ -68,8 +68,12 @@ namespace Microsoft.Common.Core.Test.Fakes.Shell {
         public ICoreServices Services => TestCoreServices.CreateReal();
 
         #region IMainThread
-        public int ThreadId => MainThread.ManagedThreadId;
-        public void Post(Action action, CancellationToken cancellationToken) => UIThreadHelper.Instance.InvokeAsync(action, cancellationToken).DoNotWait();
+
+        public int ThreadId => Services.MainThread.ThreadId;
+
+        public void Post(Action action, CancellationToken cancellationToken) =>
+            Services.MainThread.Post(action, cancellationToken);
+
         #endregion
     }
 }

--- a/src/Common/Core/Test/Fakes/Shell/TestMainThread.cs
+++ b/src/Common/Core/Test/Fakes/Shell/TestMainThread.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using Microsoft.Common.Core.Threading;
+using Microsoft.UnitTests.Core.Threading;
+
+namespace Microsoft.Common.Core.Test.Fakes.Shell {
+    [ExcludeFromCodeCoverage]
+    public class TestMainThread : IMainThread {
+        public int ThreadId => UIThreadHelper.Instance.Thread.ManagedThreadId;
+
+        public void Post(Action action, CancellationToken cancellationToken) =>
+            UIThreadHelper.Instance.InvokeAsync(action, cancellationToken).DoNotWait();
+    }
+}

--- a/src/Common/Core/Test/Microsoft.Common.Core.Test.csproj
+++ b/src/Common/Core/Test/Microsoft.Common.Core.Test.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Disposables\DisposeTokenTest.cs" />
     <Compile Include="EnumerableExtensionsTest.cs" />
     <Compile Include="Extensions\IOExtensionsTest.cs" />
+    <Compile Include="Fakes\Shell\TestMainThread.cs" />
     <Compile Include="Fakes\Shell\TestFileDialog.cs" />
     <Compile Include="Fakes\Shell\TestProgressDialog.cs" />
     <Compile Include="Fakes\Shell\TestTaskService.cs" />

--- a/src/Package/Impl/DataInspect/Definitions/IREnvironmentProvider.cs
+++ b/src/Package/Impl/DataInspect/Definitions/IREnvironmentProvider.cs
@@ -2,15 +2,15 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect {
     internal interface IREnvironmentProvider : IDisposable, INotifyPropertyChanged {
         ObservableCollection<IREnvironment> Environments { get; }
         IREnvironment SelectedEnvironment { get; }
-        Task RefreshEnvironmentsAsync();
+        Task RefreshEnvironmentsAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Package/Impl/DataInspect/VariableView.xaml.cs
+++ b/src/Package/Impl/DataInspect/VariableView.xaml.cs
@@ -11,7 +11,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
-using System.Windows.Media;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.Shell;
 using Microsoft.Common.Wpf.Extensions;
@@ -25,7 +24,6 @@ using Microsoft.R.Support.Settings;
 using Microsoft.R.Wpf.Themes;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
-using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.R.Package.Commands;
 using Microsoft.VisualStudio.R.Package.Commands.R;
 using Microsoft.VisualStudio.R.Package.Shell;
@@ -67,7 +65,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             var workflow = VsAppShell.Current.ExportProvider.GetExportedValue<IRInteractiveWorkflowProvider>().GetOrCreate();
             _session = workflow.RSession;
 
-            _environmentProvider = new REnvironmentProvider(_session);
+            _environmentProvider = new REnvironmentProvider(_session, shell.Services.MainThread);
             EnvironmentComboBox.DataContext = _environmentProvider;
             _environmentProvider.RefreshEnvironmentsAsync().DoNotWait();
         }

--- a/src/Package/Test/DataInspect/REnvironmentProviderTest.cs
+++ b/src/Package/Test/DataInspect/REnvironmentProviderTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.R.Package.Test.DataInspect {
             // Wait for prompt to appear.
             using (await _session.BeginInteractionAsync()) { }
 
-            var envProvider = new REnvironmentProvider(_session);
+            var envProvider = new REnvironmentProvider(_session, new TestMainThread());
             var envTcs = new TaskCompletionSource<IREnvironment[]>();
             envProvider.Environments.CollectionChanged += (sender, args) => {
                 envTcs.TrySetResult(envProvider.Environments.ToArray());


### PR DESCRIPTION
Cancel refresh operation in REnvironmentProvider when the latter is disposed.