### PR TITLE
Fix #2721: AF in cat(), argument type mismatch in protocol message

### DIFF
--- a/src/Common/Core/Impl/Json/Json.cs
+++ b/src/Common/Core/Impl/Json/Json.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Common.Core.Json {
+    public static class Json {
+        /// <summary>
+        /// Like <see cref="JToken.Parse(string)"/>, but does not automatically deserialize strings that look like dates to <see cref="System.DateTime"/>.
+        /// </summary>
+        /// <remarks>
+        /// Workaround for https://github.com/JamesNK/Newtonsoft.Json/issues/862.
+        /// </remarks>
+        public static JToken ParseToken(string json, JsonLoadSettings settings = null) {
+            using (JsonReader reader = new JsonTextReader(new StringReader(json))) {
+                reader.DateParseHandling = DateParseHandling.None;
+
+                JToken t = JToken.Load(reader, settings);
+                if (reader.Read() && reader.TokenType != JsonToken.Comment) {
+                    throw new JsonReaderException("Additional text found in JSON string after parsing content.");
+                }
+                return t;
+            }
+        }
+
+        /// <summary>
+        /// Like <see cref="JsonConvert.DeserializeObject{T}(string)"/>, but does not automatically deserialize strings that look like dates to <see cref="System.DateTime"/>.
+        /// </summary>
+        /// <remarks>
+        /// Workaround for  https://github.com/JamesNK/Newtonsoft.Json/issues/862.
+        /// </remarks>
+        public static T DeserializeObject<T>(string value) {
+            JsonSerializer jsonSerializer = JsonSerializer.CreateDefault(null);
+            jsonSerializer.CheckAdditionalContent = true;
+
+            using (JsonTextReader reader = new JsonTextReader(new StringReader(value))) {
+                reader.DateParseHandling = DateParseHandling.None;
+                return jsonSerializer.Deserialize<T>(reader);
+            }
+        }
+    }
+}

--- a/src/Common/Core/Impl/Microsoft.Common.Core.csproj
+++ b/src/Common/Core/Impl/Microsoft.Common.Core.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Composition\NamedExportLocator.cs" />
     <Compile Include="Extensions\ClipboardExtensions.cs" />
     <Compile Include="Disposables\DisposableBag.cs" />
+    <Compile Include="Json\Json.cs" />
     <Compile Include="Logging\FileLogWriter.cs" />
     <Compile Include="Logging\GeneralLog.cs" />
     <Compile Include="Logging\IActionLinesLog.cs" />

--- a/src/Common/Core/Impl/project.json
+++ b/src/Common/Core/Impl/project.json
@@ -1,12 +1,13 @@
 ﻿{
   "dependencies": {
     "MicroBuild.Core": "0.2.0",
-    "Microsoft.Tpl.Dataflow": "4.5.24"
+    "Microsoft.Tpl.Dataflow": "4.5.24",
+    "Newtonsoft.Json": "8.0.3"
   },
   "frameworks": {
-    "net46": { }
+    "net46": {}
   },
   "runtimes": {
-    "win": { }
+    "win": {}
   }
 }

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.Diagnostics;
+using Microsoft.Common.Core.Json;
 using Microsoft.Common.Core.Logging;
 using Microsoft.Common.Core.Shell;
 using Newtonsoft.Json;
@@ -101,7 +102,7 @@ namespace Microsoft.R.Host.Client {
 
             _log.Response(json, _rLoopDepth);
 
-            var token = JToken.Parse(json);
+            var token = Json.ParseToken(json);
 
             var value = token as JValue;
             if (value != null && value.Value == null) {

--- a/src/Package/Impl/SurveyNews/SurveyNewsFeedClient.cs
+++ b/src/Package/Impl/SurveyNews/SurveyNewsFeedClient.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft.Common.Core;
+using Microsoft.Common.Core.Json;
 using Newtonsoft.Json;
 
 namespace Microsoft.VisualStudio.R.Package.SurveyNews {
@@ -59,7 +60,7 @@ namespace Microsoft.VisualStudio.R.Package.SurveyNews {
                     if (endIndex > 0) {
                         text = text.Substring(startIndex + 5, endIndex - startIndex - 5);
                         try {
-                            return JsonConvert.DeserializeObject<SurveyNewsFeed>(text);
+                            return Json.DeserializeObject<SurveyNewsFeed>(text);
                         } catch (JsonReaderException ex) {
                             throw new SurveyNewsFeedException("Error deserializing json of survey/news feed.", ex);
                         }

--- a/src/R/Components/Impl/Plots/Implementation/PlotClipboardData.cs
+++ b/src/R/Components/Impl/Plots/Implementation/PlotClipboardData.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using Microsoft.Common.Core.Json;
 using Newtonsoft.Json;
 
 namespace Microsoft.R.Components.Plots.Implementation {
@@ -23,9 +24,10 @@ namespace Microsoft.R.Components.Plots.Implementation {
             return JsonConvert.SerializeObject(data);
         }
 
+
         public static PlotClipboardData Parse(string text) {
             try {
-                return JsonConvert.DeserializeObject<PlotClipboardData>(text);
+                return Json.DeserializeObject<PlotClipboardData>(text);
             } catch (JsonReaderException) {
                 return null;
             }


### PR DESCRIPTION
Work around JamesNK/Newtonsoft.Json#862 by explicitly requesting no "smart" date parsing during JSON deserialization.