### PR TITLE
#2735, #2750, #2753

### DIFF
--- a/src/Host/Client/Impl/Definitions/GuidList.cs
+++ b/src/Host/Client/Impl/Definitions/GuidList.cs
@@ -6,5 +6,7 @@ using System;
 namespace Microsoft.R.Host.Client {
     public static class GuidList {
         public static readonly Guid InteractiveWindowRSessionGuid = new Guid("77E2BCD9-BEED-47EF-B51E-2B892260ECA7");
+        public static readonly Guid PackageManagerRSessionGuid = new Guid("61C93E8D-D24D-4012-82F4-093086A4FB08");
+        public static readonly Guid IntellisenseRSessionGuid = new Guid("8BEF9C06-39DC-4A64-B7F3-0C68353362C9");
     }
 }

--- a/src/Host/Client/Impl/Definitions/IRSessionSwitchBrokerTransaction.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionSwitchBrokerTransaction.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Common.Core.Threading;
 
 namespace Microsoft.R.Host.Client {
     public interface IRSessionSwitchBrokerTransaction : IDisposable {

--- a/src/Host/Client/Impl/Host/RemoteBrokerClient.cs
+++ b/src/Host/Client/Impl/Host/RemoteBrokerClient.cs
@@ -77,8 +77,8 @@ namespace Microsoft.R.Host.Client.Host {
                     Log.WriteAsync(LogVerbosity.Minimal, MessageCategory.Warning, Resources.Trace_UntrustedCertificate.FormatInvariant(certificate.Subject)).DoNotWait();
 
                     var message = Resources.CertificateSecurityWarning.FormatInvariant(Uri.Host);
-                    var task = _services.Security.ValidateX509CertificateAsync(certificate, message);
-                    _services.Tasks.Wait(task);
+                    var task = _services.Security.ValidateX509CertificateAsync(certificate, message, _cancellationToken);
+                    _services.Tasks.Wait(task, _cancellationToken);
 
                     _certificateValidationResult = task.Result;
                     if (_certificateValidationResult.Value) {

--- a/src/Host/Client/Impl/Host/RemoteBrokerClient.cs
+++ b/src/Host/Client/Impl/Host/RemoteBrokerClient.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;

--- a/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
+++ b/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
@@ -116,7 +116,6 @@
     <Compile Include="Extensions\DirectoryExtensions.cs" />
     <Compile Include="NativeMethods.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Definitions\GuidList.cs" />
     <Compile Include="Definitions\IRSessionCallback.cs" />
     <Compile Include="Definitions\RHostStartupInfo.cs" />
     <Compile Include="Extensions\RStringExtensions.cs" />

--- a/src/Host/Client/Impl/Session/RSessionProvider.cs
+++ b/src/Host/Client/Impl/Session/RSessionProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.R.Host.Client.Session {
         public IEnumerable<IRSession> GetSessions() {
             return _sessions.Values;
         }
-        
+
         public void Dispose() {
             if (!_disposeToken.TryMarkDisposed()) {
                 return;
@@ -227,10 +227,8 @@ namespace Microsoft.R.Host.Client.Session {
         }
 
         private async Task SwitchBrokerAsync(CancellationToken cancellationToken) {
-            RSession primary;
-            if(_sessions.TryGetValue(GuidList.IntellisenseRSessionGuid, out primary)) {
-                var t = primary.StartSwitchingBroker();
-                var transactions = new List<IRSessionSwitchBrokerTransaction>() { t };
+            var transactions = _sessions.Values.Select(s => s.StartSwitchingBroker()).ExcludeDefault().ToList();
+            if (transactions.Any()) {
                 await SwitchSessionsAsync(transactions, cancellationToken);
             } else {
                 // Ping isn't enough here - need a "full" test with RHost
@@ -297,7 +295,7 @@ namespace Microsoft.R.Host.Client.Session {
                     ct.ThrowIfCancellationRequested();
                 } catch (OperationCanceledException) when (t.IsSessionDisposed) {
                     ct.ThrowIfCancellationRequested();
-                }  
+                }
             }, cancellationToken);
         }
 
@@ -309,7 +307,7 @@ namespace Microsoft.R.Host.Client.Session {
                     ct.ThrowIfCancellationRequested();
                 } catch (OperationCanceledException) when (s.IsDisposed) {
                     ct.ThrowIfCancellationRequested();
-                }  
+                }
             }, cancellationToken);
         }
 

--- a/src/Host/Client/Impl/Session/RSessionProvider.cs
+++ b/src/Host/Client/Impl/Session/RSessionProvider.cs
@@ -227,8 +227,10 @@ namespace Microsoft.R.Host.Client.Session {
         }
 
         private async Task SwitchBrokerAsync(CancellationToken cancellationToken) {
-            var transactions = _sessions.Values.Select(s => s.StartSwitchingBroker()).ExcludeDefault().ToList();
-            if (transactions.Any()) {
+            RSession primary;
+            if(_sessions.TryGetValue(GuidList.IntellisenseRSessionGuid, out primary)) {
+                var t = primary.StartSwitchingBroker();
+                var transactions = new List<IRSessionSwitchBrokerTransaction>() { t };
                 await SwitchSessionsAsync(transactions, cancellationToken);
             } else {
                 // Ping isn't enough here - need a "full" test with RHost

--- a/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml.cs
@@ -35,7 +35,13 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View {
         }
 
         private void ButtonConnect_Click(object sender, RoutedEventArgs e) {
-            Model?.Connect(GetConnection(e));
+            var connection = GetConnection(e);
+            if (connection != Model.EditedConnection) {
+                Model?.CancelEdit();
+            } else {
+                Model?.Save(connection);
+            }
+            Model?.Connect(connection);
         }
 
         private void ButtonAdd_Click(object sender, RoutedEventArgs e) {

--- a/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml.cs
@@ -76,7 +76,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View {
 
         private void Connection_KeyUp(object sender, KeyEventArgs e) {
             if (e.Key == Key.Enter) {
-                Model?.Connect(GetConnection(e));
+                HandleConnect(e);
             }
         }
 
@@ -94,13 +94,16 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View {
         }
 
         private void HandleConnect(RoutedEventArgs e) {
-            var connection = GetConnection(e);
-            if (connection != Model.EditedConnection) {
-                Model?.CancelEdit();
-            } else {
-                Model?.Save(connection);
+            var model = Model;
+            if (model != null) {
+                var connection = GetConnection(e);
+                if (connection != model.EditedConnection) {
+                    model.CancelEdit();
+                } else {
+                    model.Save(connection);
+                }
+                model.Connect(connection);
             }
-            Model?.Connect(connection);
         }
     }
 }

--- a/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml.cs
@@ -35,13 +35,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View {
         }
 
         private void ButtonConnect_Click(object sender, RoutedEventArgs e) {
-            var connection = GetConnection(e);
-            if (connection != Model.EditedConnection) {
-                Model?.CancelEdit();
-            } else {
-                Model?.Save(connection);
-            }
-            Model?.Connect(connection);
+            HandleConnect(e);
         }
 
         private void ButtonAdd_Click(object sender, RoutedEventArgs e) {
@@ -87,11 +81,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View {
         }
 
         private void Connection_MouseDoubleClick(object sender, MouseButtonEventArgs e) {
-            var connection = GetConnection(e);
-            if (connection != Model.EditedConnection) {
-                Model?.CancelEdit();
-                Model?.Connect(GetConnection(e));
-            }
+            HandleConnect(e);
             e.Handled = true;
         }
 
@@ -101,6 +91,16 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View {
 
         private void PathTextBox_TextChanged(object sender, TextChangedEventArgs e) {
             ((sender as TextBox)?.DataContext as IConnectionViewModel)?.UpdateName();
+        }
+
+        private void HandleConnect(RoutedEventArgs e) {
+            var connection = GetConnection(e);
+            if (connection != Model.EditedConnection) {
+                Model?.CancelEdit();
+            } else {
+                Model?.Save(connection);
+            }
+            Model?.Connect(connection);
         }
     }
 }

--- a/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml.cs
@@ -81,7 +81,9 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View {
         }
 
         private void Connection_MouseDoubleClick(object sender, MouseButtonEventArgs e) {
-            if ((e.Source as ListBoxItem)?.IsSelected == false) {
+            var connection = GetConnection(e);
+            if (connection != Model.EditedConnection) {
+                Model?.CancelEdit();
                 Model?.Connect(GetConnection(e));
             }
             e.Handled = true;

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
@@ -239,7 +239,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
 
         private void Write(string message) {
             if (CurrentWindow != null && !_crProcessor.ProcessMessage(message)) {
-                CurrentWindow.Write(message);
+                _coreShell.DispatchOnUIThread(() => CurrentWindow.Write(message));
             }
         }
 

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
@@ -60,7 +60,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             RSessions = new RSessionProvider(coreShell.Services, new InteractiveWindowConsole(this));
             RSessions.BrokerChanging += OnBrokerChanging;
 
-            RSession = RSessions.GetOrCreate(GuidList.InteractiveWindowRSessionGuid);
+            RSession = RSessions.GetOrCreate(SessionGuids.InteractiveWindowRSessionGuid);
             Connections = connectionsProvider.CreateConnectionManager(this);
 
             History = historyProvider.CreateRHistory(this);

--- a/src/R/Components/Impl/InteractiveWorkflow/SessionGuids.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/SessionGuids.cs
@@ -3,8 +3,8 @@
 
 using System;
 
-namespace Microsoft.R.Host.Client {
-    public static class GuidList {
+namespace Microsoft.R.Components.InteractiveWorkflow {
+    public static class SessionGuids {
         public static readonly Guid InteractiveWindowRSessionGuid = new Guid("77E2BCD9-BEED-47EF-B51E-2B892260ECA7");
         public static readonly Guid PackageManagerRSessionGuid = new Guid("61C93E8D-D24D-4012-82F4-093086A4FB08");
         public static readonly Guid IntellisenseRSessionGuid = new Guid("8BEF9C06-39DC-4A64-B7F3-0C68353362C9");

--- a/src/R/Components/Impl/Microsoft.R.Components.csproj
+++ b/src/R/Components/Impl/Microsoft.R.Components.csproj
@@ -146,6 +146,7 @@
     <Compile Include="InteractiveWorkflow\Commands\SessionInformationCommand.cs" />
     <Compile Include="InteractiveWorkflow\Commands\TerminateRCommand.cs" />
     <Compile Include="InteractiveWorkflow\Commands\InterruptRCommand.cs" />
+    <Compile Include="InteractiveWorkflow\SessionGuids.cs" />
     <Compile Include="InteractiveWorkflow\Implementation\CarriageReturnProcessor.cs" />
     <Compile Include="Plots\Commands\ShowMainPlotWindowCommand.cs" />
     <Compile Include="Plots\Implementation\Commands\PlotHistoryCommand.cs" />

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -22,8 +22,6 @@ using static System.FormattableString;
 
 namespace Microsoft.R.Components.PackageManager.Implementation {
     internal class RPackageManager : IRPackageManager {
-        private static readonly Guid SessionId = new Guid("61C93E8D-D24D-4012-82F4-093086A4FB08");
-
         private readonly IRSession _session;
         private readonly IRSettings _settings;
         private readonly IRInteractiveWorkflow _interactiveWorkflow;
@@ -50,7 +48,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
         public IRPackageManagerVisualComponent VisualComponent { get; private set; }
 
         public RPackageManager(IRSettings settings, IRInteractiveWorkflow interactiveWorkflow, Action dispose) {
-            _session = interactiveWorkflow.RSessions.GetOrCreate(SessionId);
+            _session = interactiveWorkflow.RSessions.GetOrCreate(GuidList.PackageManagerRSessionGuid);
             _settings = settings;
             _interactiveWorkflow = interactiveWorkflow;
             _loadedPackagesEvent = new DirtyEventSource(this);

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Common.Core;
 using Microsoft.Common.Core.Disposables;
 using Microsoft.Common.Core.Events;
 using Microsoft.R.Components.InteractiveWorkflow;
@@ -48,7 +47,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
         public IRPackageManagerVisualComponent VisualComponent { get; private set; }
 
         public RPackageManager(IRSettings settings, IRInteractiveWorkflow interactiveWorkflow, Action dispose) {
-            _session = interactiveWorkflow.RSessions.GetOrCreate(GuidList.PackageManagerRSessionGuid);
+            _session = interactiveWorkflow.RSessions.GetOrCreate(SessionGuids.PackageManagerRSessionGuid);
             _settings = settings;
             _interactiveWorkflow = interactiveWorkflow;
             _loadedPackagesEvent = new DirtyEventSource(this);

--- a/src/R/Editor/Test/Script/RHostScript.cs
+++ b/src/R/Editor/Test/Script/RHostScript.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.R.Host.Client.Host;
+using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Interpreters;
 using Microsoft.R.Support.Settings;
 
@@ -35,7 +35,7 @@ namespace Microsoft.R.Host.Client.Test.Script {
         public async Task InitializeAsync(IRSessionCallback clientApp = null) {
             _clientApp = clientApp ?? _clientApp;
 
-            Session = SessionProvider.GetOrCreate(GuidList.InteractiveWindowRSessionGuid);
+            Session = SessionProvider.GetOrCreate(SessionGuids.InteractiveWindowRSessionGuid);
             if (Session.IsHostRunning) {
                 await Session.StopHostAsync();
             }

--- a/src/R/Support/Impl/Help/IntelliSenseRSession.cs
+++ b/src/R/Support/Impl/Help/IntelliSenseRSession.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.Common.Core.Shell;
@@ -45,7 +44,7 @@ namespace Microsoft.R.Support.Help {
                 }
 
                 if (Session == null) {
-                    Session = _sessionProvider.GetOrCreate(GuidList.IntellisenseRSessionGuid);
+                    Session = _sessionProvider.GetOrCreate(SessionGuids.IntellisenseRSessionGuid);
                 }
 
                 if (!Session.IsHostRunning) {

--- a/src/R/Support/Impl/Help/IntelliSenseRSession.cs
+++ b/src/R/Support/Impl/Help/IntelliSenseRSession.cs
@@ -14,7 +14,6 @@ using Microsoft.R.Support.Settings;
 namespace Microsoft.R.Support.Help {
     [Export(typeof(IIntellisenseRSession))]
     public sealed class IntelliSenseRSession : IIntellisenseRSession {
-        private static readonly Guid SessionId = new Guid("8BEF9C06-39DC-4A64-B7F3-0C68353362C9");
         private readonly ICoreShell _coreShell;
         private readonly IRSessionProvider _sessionProvider;
         private readonly BinaryAsyncLock _lock = new BinaryAsyncLock();
@@ -46,7 +45,7 @@ namespace Microsoft.R.Support.Help {
                 }
 
                 if (Session == null) {
-                    Session = _sessionProvider.GetOrCreate(SessionId);
+                    Session = _sessionProvider.GetOrCreate(GuidList.IntellisenseRSessionGuid);
                 }
 
                 if (!Session.IsHostRunning) {

--- a/src/Setup/Definitions.wxi
+++ b/src/Setup/Definitions.wxi
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
-  <?define ProductName="R Tools for Visual Studio 2015" ?>
+  <?define ProductNamePart1="R Tools " ?>
+  <?define ProductNamePart2=" for Visual Studio 15 Preview" ?>
+  <?define ProductName="$(var.ProductNamePart1)$(var.ProductVersion)$(var.ProductNamePart2)" ?>
 
   <!-- 
      Uncomment this to simulate loc build.


### PR DESCRIPTION
#2735 Setup no longer displays version of the product
#2753 Occasional deadlock in ValidateX509CertificateAsync 
 - mostly workaround, rejecting calls on UI thread and added cancellation handling
#2750 Double-click on connection for switching no longer works 

Minor changes in session naming - consolidate session names in one place.