### PR TITLE
Fix #2756: View() fails for list with externalptr

### DIFF
--- a/src/Host/Client/Impl/rtvs/R/repr.R
+++ b/src/Host/Client/Impl/rtvs/R/repr.R
@@ -39,7 +39,7 @@ make_repr_str <- function(max_length = NULL, expected_length = NULL, overflow_su
         on.exit(close(con), add = TRUE);
 
         tryCatch({
-            if (length(obj) == 1) {
+            if (length(obj) == 1 && typeof(obj) != 'externalptr') {
                 if (any(class(obj) == 'factor')) {
                     if (is.na(obj) && !is.nan(obj)) {
                         cat('NA', file = con);

--- a/src/Package/TestApp/Data/GridDataTest.cs
+++ b/src/Package/TestApp/Data/GridDataTest.cs
@@ -281,5 +281,13 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Data {
             { "[3,]",   "1",        "20" },
         }, sort: new[] { 1, 2 });
 
+        [Test]
+        [Category.R.DataGrid]
+        public Task ExternalPtrGrid() => Test("matrix(list(1, .Internal(address(2)), 3, 4), 2, 2)", 1, 1, new[,] {
+            { null,     "[,1]",             "[,2]" },
+            { "[1,]",   "1",                "3" },
+            { "[2,]",   "<externalptr> ",    "4" },
+        });
+
     }
 }


### PR DESCRIPTION
Gracefully handle externalptr and other non-formattable values when processing grid data.