### PR TITLE
Fix #2736: Connection should not turn green until REPL opens

### DIFF
--- a/src/Package/Impl/Repl/IActiveRInteractiveWindowTracker.cs
+++ b/src/Package/Impl/Repl/IActiveRInteractiveWindowTracker.cs
@@ -8,6 +8,5 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
     public interface IActiveRInteractiveWindowTracker {
         IInteractiveWindowVisualComponent LastActiveWindow { get; }
         bool IsActive { get; }
-        event EventHandler<InteractiveWindowChangedEventArgs> LastActiveWindowChanged;
     }
 }

--- a/src/Package/Impl/Repl/VsActiveRInteractiveWindowTracker.cs
+++ b/src/Package/Impl/Repl/VsActiveRInteractiveWindowTracker.cs
@@ -20,8 +20,6 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
         public IInteractiveWindowVisualComponent LastActiveWindow => _lastActiveWindow;
         public bool IsActive => _isActive;
 
-        public event EventHandler<InteractiveWindowChangedEventArgs> LastActiveWindowChanged;
-
         public void OnFrameCreated(IVsWindowFrame frame) {
         }
 
@@ -53,8 +51,6 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
                 return;
             }
 
-            var handler = LastActiveWindowChanged;
-            handler?.Invoke(this, new InteractiveWindowChangedEventArgs(oldInteractiveWindow, newInteractiveWindow));
             IVsUIShell shell = VsAppShell.Current.GetGlobalService<IVsUIShell>(typeof(SVsUIShell));
             shell.UpdateCommandUI(1);
         }

--- a/src/R/Components/Impl/InteractiveWorkflow/ActiveWindowChangedEventArgs.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/ActiveWindowChangedEventArgs.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.R.Components.InteractiveWorkflow {
+    public class ActiveWindowChangedEventArgs {
+        public ActiveWindowChangedEventArgs(IInteractiveWindowVisualComponent window) {
+            Window = window;
+        }
+
+        public IInteractiveWindowVisualComponent Window { get; }
+    }
+}

--- a/src/R/Components/Impl/InteractiveWorkflow/IRInteractiveWorkflow.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/IRInteractiveWorkflow.cs
@@ -22,6 +22,8 @@ namespace Microsoft.R.Components.InteractiveWorkflow {
         IRInteractiveWorkflowOperations Operations { get; }
         IInteractiveWindowVisualComponent ActiveWindow { get; }
 
+        event EventHandler<ActiveWindowChangedEventArgs> ActiveWindowChanged;
+
         Task<IInteractiveWindowVisualComponent> GetOrCreateVisualComponentAsync(int instanceId = 0);
     }
 }

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
@@ -61,9 +61,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             _crProcessor?.Dispose();
         }
 
-        public async Task<ExecutionResult> InitializeAsync() {
-            return await InitializeAsync(false);
-        }
+        public Task<ExecutionResult> InitializeAsync() => InitializeAsync(false);
 
         private async Task<ExecutionResult> InitializeAsync(bool isResetting) {
             try {

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.Disposables;
@@ -28,6 +29,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
         private readonly IRSettings _settings;
         private readonly RInteractiveWorkflowOperations _operations;
 
+        private TaskCompletionSource<IInteractiveWindowVisualComponent> _visualComponentTcs;
         private bool _replLostFocus;
         private bool _debuggerJustEnteredBreakMode;
 
@@ -42,6 +44,8 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
         public IRInteractiveWorkflowOperations Operations => _operations;
 
         public IInteractiveWindowVisualComponent ActiveWindow { get; private set; }
+
+        public event EventHandler<ActiveWindowChangedEventArgs> ActiveWindowChanged;
 
         public RInteractiveWorkflow(IConnectionManagerProvider connectionsProvider
             , IRHistoryProvider historyProvider
@@ -150,28 +154,35 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             return wss.IsRProjectActive;
         }
 
-        public async Task<IInteractiveWindowVisualComponent> GetOrCreateVisualComponentAsync(int instanceId = 0) {
+        public Task<IInteractiveWindowVisualComponent> GetOrCreateVisualComponentAsync(int instanceId = 0) {
             Shell.AssertIsOnMainThread();
 
-            if (ActiveWindow != null) {
+            if (_visualComponentTcs == null) {
+                _visualComponentTcs = new TaskCompletionSource<IInteractiveWindowVisualComponent>();
+                CreateVisualComponentAsync(instanceId).DoNotWait();
+            } else if (instanceId != 0) {
                 // Right now only one instance of interactive window is allowed
-                if (instanceId != 0) {
-                    throw new InvalidOperationException("Right now only one instance of interactive window is allowed");
-                }
-
-                return ActiveWindow;
+                throw new InvalidOperationException("Right now only one instance of interactive window is allowed");
             }
 
+            return _visualComponentTcs.Task;
+        }
+
+        private async Task CreateVisualComponentAsync(int instanceId) {
             var factory = Shell.ExportProvider.GetExportedValue<IInteractiveWindowComponentContainerFactory>();
             var evaluator = new RInteractiveEvaluator(RSessions, RSession, History, Connections, Shell, _settings);
 
-            ActiveWindow = factory.Create(instanceId, evaluator, RSessions);
-            var interactiveWindow = ActiveWindow.InteractiveWindow;
+            var window = factory.Create(instanceId, evaluator, RSessions);
+            var interactiveWindow = window.InteractiveWindow;
             interactiveWindow.TextView.Closed += (_, __) => evaluator.Dispose();
             _operations.InteractiveWindow = interactiveWindow;
+
             await interactiveWindow.InitializeAsync();
+
+            ActiveWindow = window;
             ActiveWindow.Container.UpdateCommandStatus(true);
-            return ActiveWindow;
+            _visualComponentTcs.SetResult(ActiveWindow);
+            ActiveWindowChanged?.Invoke(this, new ActiveWindowChangedEventArgs(window));
         }
 
         public void Dispose() {

--- a/src/R/Components/Impl/Microsoft.R.Components.csproj
+++ b/src/R/Components/Impl/Microsoft.R.Components.csproj
@@ -143,6 +143,7 @@
       <DependentUpon>HostLoadIndicator.xaml</DependentUpon>
     </Compile>
     <Compile Include="Information\HostLoadIndicatorViewModel.cs" />
+    <Compile Include="InteractiveWorkflow\ActiveWindowChangedEventArgs.cs" />
     <Compile Include="InteractiveWorkflow\Commands\SessionInformationCommand.cs" />
     <Compile Include="InteractiveWorkflow\Commands\TerminateRCommand.cs" />
     <Compile Include="InteractiveWorkflow\Commands\InterruptRCommand.cs" />


### PR DESCRIPTION
- Added `RInteractiveWorkflow.ActiveWindowChanged` event that is used by `ConnectionManager`
- Changed `RInteractiveWorkflow.ActiveWindow` to return null until REPL is actually initialized
- Removed unused event from `IActiveRInteractiveWindowTracker`