### PR TITLE
Explicit broker switch

### DIFF
--- a/src/Common/Core/Impl/TaskUtilities.cs
+++ b/src/Common/Core/Impl/TaskUtilities.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Common.Core {
         public static bool IsOnBackgroundThread() {
             var taskScheduler = TaskScheduler.Current;
             var syncContext = SynchronizationContext.Current;
-            return taskScheduler == TaskScheduler.Default && (syncContext == null || syncContext.GetType() == typeof(SynchronizationContext));
+            return taskScheduler == TaskScheduler.Default 
+                && (syncContext == null || syncContext.GetType() == typeof(SynchronizationContext) || Thread.CurrentThread.IsThreadPoolThread);
         }
 
         /// <summary>

--- a/src/Common/Core/Test/Microsoft.Common.Core.Test.csproj
+++ b/src/Common/Core/Test/Microsoft.Common.Core.Test.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Threading\BinaryAsyncLockTest.cs" />
     <Compile Include="Threading\DelayedAsyncActionTest.cs" />
     <Compile Include="Threading\MainThreadAwaitableTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utility\CommonTestData.cs" />
     <Compile Include="Fakes\Shell\TestCoreServices.cs" />
     <Compile Include="Utility\SupportedWpfProperties.cs" />

--- a/src/Common/Core/Test/Properties/AssemblyInfo.cs
+++ b/src/Common/Core/Test/Properties/AssemblyInfo.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Microsoft.UnitTests.Core.XUnit
-{
-    public enum ThreadType
-    {
-        Default = 0,
-        UI = 1,
-        Background = 2
-    }
-}
+using Microsoft.UnitTests.Core.XUnit;
+
+[assembly: TestFrameworkOverride]

--- a/src/Common/Core/Test/Threading/AsyncReaderWriterLockTest.cs
+++ b/src/Common/Core/Test/Threading/AsyncReaderWriterLockTest.cs
@@ -12,6 +12,7 @@ using Microsoft.UnitTests.Core.XUnit;
 
 namespace Microsoft.Common.Core.Test.Threading {
     [ExcludeFromCodeCoverage]
+    [ThreadType(ThreadType.Background)]
     public class AsyncReaderWriterLockTest {
         private readonly AsyncReaderWriterLock _arwl;
 

--- a/src/Host/Client/Impl/Definitions/IRSession.cs
+++ b/src/Host/Client/Impl/Definitions/IRSession.cs
@@ -30,7 +30,7 @@ namespace Microsoft.R.Host.Client {
         Task CancelAllAsync(CancellationToken cancellationToken = default(CancellationToken));
         Task StartHostAsync(RHostStartupInfo startupInfo, IRSessionCallback callback, int timeout = 3000, CancellationToken cancellationToken = default(CancellationToken));
         Task EnsureHostStartedAsync(RHostStartupInfo startupInfo, IRSessionCallback callback, int timeout = 3000, CancellationToken cancellationToken = default(CancellationToken));
-        Task StopHostAsync();
+        Task StopHostAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         IDisposable DisableMutatedOnReadConsole();
 

--- a/src/Host/Client/Impl/Definitions/IRSessionProvider.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionProvider.cs
@@ -14,6 +14,7 @@ namespace Microsoft.R.Host.Client {
         event EventHandler BrokerChanged;
         event EventHandler<BrokerStateChangedEventArgs> BrokerStateChanged;
 
+        bool HasBroker { get; }
         bool IsConnected { get; }
         IBrokerClient Broker { get; }
 

--- a/src/Host/Client/Impl/Host/BrokerClientProxy.cs
+++ b/src/Host/Client/Impl/Host/BrokerClientProxy.cs
@@ -27,6 +27,7 @@ namespace Microsoft.R.Host.Client.Host {
         public bool IsRemote => _broker.IsRemote;
         public Uri Uri => _broker.Uri;
         public bool IsVerified => _broker.IsVerified;
+        public bool HasBroker => _broker is NullBrokerClient;
 
         public Task<T> GetHostInformationAsync<T>(CancellationToken cancellationToken) => _broker.GetHostInformationAsync<T>(cancellationToken);
 

--- a/src/Host/Client/Impl/Host/BrokerClientProxy.cs
+++ b/src/Host/Client/Impl/Host/BrokerClientProxy.cs
@@ -27,7 +27,7 @@ namespace Microsoft.R.Host.Client.Host {
         public bool IsRemote => _broker.IsRemote;
         public Uri Uri => _broker.Uri;
         public bool IsVerified => _broker.IsVerified;
-        public bool HasBroker => _broker is NullBrokerClient;
+        public bool HasBroker => !(_broker is NullBrokerClient);
 
         public Task<T> GetHostInformationAsync<T>(CancellationToken cancellationToken) => _broker.GetHostInformationAsync<T>(cancellationToken);
 

--- a/src/Host/Client/Impl/Session/RSessionProvider.cs
+++ b/src/Host/Client/Impl/Session/RSessionProvider.cs
@@ -29,6 +29,7 @@ namespace Microsoft.R.Host.Client.Session {
         private Task _updateHostLoadLoopTask;
         private HostLoad _hostLoad;
 
+        public bool HasBroker => _brokerProxy.HasBroker;
         public bool IsConnected => _hostLoad != null;
 
         public IBrokerClient Broker => _brokerProxy;

--- a/src/Host/Client/Test/Mocks/RSessionMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionMock.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core.Disposables;
-using Microsoft.R.Host.Client.Host;
 
 namespace Microsoft.R.Host.Client.Test.Mocks {
     public sealed class RSessionMock : IRSession {
@@ -111,7 +110,7 @@ namespace Microsoft.R.Host.Client.Test.Mocks {
             return Task.CompletedTask;
         }
 
-        public Task StopHostAsync() {
+        public Task StopHostAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             IsHostRunning = false;
             Disconnected?.Invoke(this, EventArgs.Empty);
             return Task.CompletedTask;

--- a/src/Host/Client/Test/Mocks/RSessionProviderMock.cs
+++ b/src/Host/Client/Test/Mocks/RSessionProviderMock.cs
@@ -14,6 +14,7 @@ namespace Microsoft.R.Host.Client.Mocks {
         private readonly Dictionary<Guid, IRSession> _sessions = new Dictionary<Guid, IRSession>();
 
         public void Dispose() { }
+        public bool HasBroker { get; } = true;
         public bool IsConnected { get; } = true;
         public IBrokerClient Broker { get; } = new NullBrokerClient();
 
@@ -26,18 +27,14 @@ namespace Microsoft.R.Host.Client.Mocks {
             return session;
         }
 
-        public IEnumerable<IRSession> GetSessions() {
-            return _sessions.Values;
-        }
+        public IEnumerable<IRSession> GetSessions() => _sessions.Values;
 
         public Task<IRSessionEvaluation> BeginEvaluationAsync(RHostStartupInfo startupInfo, CancellationToken cancellationToken = new CancellationToken()) 
             => new RSessionMock().BeginEvaluationAsync(cancellationToken);
 
         public Task TestBrokerConnectionAsync(string name, string path, CancellationToken cancellationToken = default(CancellationToken)) => Task.FromResult(true);
 
-        public Task<bool> TrySwitchBrokerAsync(string name, string path = null, CancellationToken cancellationToken = default(CancellationToken)) {
-            return Task.FromResult(true);
-        }
+        public Task<bool> TrySwitchBrokerAsync(string name, string path = null, CancellationToken cancellationToken = default(CancellationToken)) => Task.FromResult(true);
 
 #pragma warning disable 67
         public event EventHandler BrokerChanging;

--- a/src/Package/Impl/Packages/R/RPackageToolWindowProvider.cs
+++ b/src/Package/Impl/Packages/R/RPackageToolWindowProvider.cs
@@ -24,8 +24,6 @@ namespace Microsoft.VisualStudio.R.Packages.R {
         [Import]
         private Lazy<IRHistoryVisualComponentContainerFactory> HistoryComponentContainerFactory { get; set; }
         [Import]
-        private Lazy<IConnectionManagerVisualComponentContainerFactory> ConnectionManagerComponentContainerFactory { get; set; }
-        [Import]
         private Lazy<IRPackageManagerVisualComponentContainerFactory> PackageManagerComponentContainerFactory { get; set; }
         [Import]
         private Lazy<IHelpVisualComponentContainerFactory> HelpVisualComponentContainerFactory { get; set; }
@@ -121,7 +119,7 @@ namespace Microsoft.VisualStudio.R.Packages.R {
 
         private IConnectionManagerVisualComponent CreateConnectionManagerToolWindow(int id) {
             var workflow = WorkflowProvider.Value.GetOrCreate();
-            return workflow.Connections.GetOrCreateVisualComponent(ConnectionManagerComponentContainerFactory.Value, id);
+            return workflow.Connections.GetOrCreateVisualComponent(id);
         }
 
         private IRPackageManagerVisualComponent CreatePackageManagerToolWindow(int id) {

--- a/src/Package/Impl/Repl/IActiveRInteractiveWindowTracker.cs
+++ b/src/Package/Impl/Repl/IActiveRInteractiveWindowTracker.cs
@@ -8,6 +8,5 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
     public interface IActiveRInteractiveWindowTracker {
         IInteractiveWindowVisualComponent LastActiveWindow { get; }
         bool IsActive { get; }
-        event EventHandler<InteractiveWindowChangedEventArgs> LastActiveWindowChanged;
     }
 }

--- a/src/Package/Impl/Repl/VsActiveRInteractiveWindowTracker.cs
+++ b/src/Package/Impl/Repl/VsActiveRInteractiveWindowTracker.cs
@@ -20,8 +20,6 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
         public IInteractiveWindowVisualComponent LastActiveWindow => _lastActiveWindow;
         public bool IsActive => _isActive;
 
-        public event EventHandler<InteractiveWindowChangedEventArgs> LastActiveWindowChanged;
-
         public void OnFrameCreated(IVsWindowFrame frame) {
         }
 
@@ -53,8 +51,6 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
                 return;
             }
 
-            var handler = LastActiveWindowChanged;
-            handler?.Invoke(this, new InteractiveWindowChangedEventArgs(oldInteractiveWindow, newInteractiveWindow));
             IVsUIShell shell = VsAppShell.Current.GetGlobalService<IVsUIShell>(typeof(SVsUIShell));
             shell.UpdateCommandUI(1);
         }

--- a/src/Package/Test/Repl/ReplCommandTest.cs
+++ b/src/Package/Test/Repl/ReplCommandTest.cs
@@ -34,12 +34,10 @@ namespace Microsoft.VisualStudio.R.Package.Test.Commands {
         private readonly VsDebuggerModeTracker _debuggerModeTracker;
         private readonly IRInteractiveWorkflow _workflow;
         private readonly IRInteractiveWorkflowProvider _workflowProvider;
-        private readonly IInteractiveWindowComponentContainerFactory _componentContainerFactory;
 
         public ReplCommandTest() {
             _debuggerModeTracker = new VsDebuggerModeTracker();
 
-            _componentContainerFactory = new InteractiveWindowComponentContainerFactoryMock(VsAppShell.Current);
             _workflowProvider = TestRInteractiveWorkflowProviderFactory.Create(debuggerModeTracker: _debuggerModeTracker);
             _workflow = _workflowProvider.GetOrCreate();
         }
@@ -56,7 +54,7 @@ namespace Microsoft.VisualStudio.R.Package.Test.Commands {
             var editorBuffer = new TextBufferMock(content, RContentTypeDefinition.ContentType);
             var tv = new TextViewMock(editorBuffer);
 
-            var commandFactory = new VsRCommandFactory(_workflowProvider, _componentContainerFactory);
+            var commandFactory = new VsRCommandFactory(_workflowProvider);
             var commands = UIThreadHelper.Instance.Invoke(() => commandFactory.GetCommands(tv, editorBuffer));
 
             await _workflow.RSession.HostStarted.Should().BeCompletedAsync();

--- a/src/R/Components/Impl/ConnectionManager/IConnectionManager.cs
+++ b/src/R/Components/Impl/ConnectionManager/IConnectionManager.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.R.Components.ConnectionManager {
     public interface IConnectionManager : IDisposable {
-        IConnectionManagerVisualComponent GetOrCreateVisualComponent(IConnectionManagerVisualComponentContainerFactory value, int id);
+        IConnectionManagerVisualComponent GetOrCreateVisualComponent(int id = 0);
 
         bool IsConnected { get; }
         IConnection ActiveConnection { get; }
@@ -28,5 +28,6 @@ namespace Microsoft.R.Components.ConnectionManager {
         Task ConnectAsync(IConnectionInfo connection, CancellationToken cancellationToken = default(CancellationToken));
         Task ReconnectAsync(CancellationToken cancellationToken = default(CancellationToken));
         Task TestConnectionAsync(IConnectionInfo connection, CancellationToken cancellationToken = default(CancellationToken));
+        Task<bool> TryConnectToPreviouslyUsedAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/R/Components/Impl/InteractiveWorkflow/ActiveWindowChangedEventArgs.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/ActiveWindowChangedEventArgs.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.R.Components.InteractiveWorkflow {
+    public class ActiveWindowChangedEventArgs {
+        public ActiveWindowChangedEventArgs(IInteractiveWindowVisualComponent window) {
+            Window = window;
+        }
+
+        public IInteractiveWindowVisualComponent Window { get; }
+    }
+}

--- a/src/R/Components/Impl/InteractiveWorkflow/IRInteractiveWorkflow.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/IRInteractiveWorkflow.cs
@@ -22,6 +22,8 @@ namespace Microsoft.R.Components.InteractiveWorkflow {
         IRInteractiveWorkflowOperations Operations { get; }
         IInteractiveWindowVisualComponent ActiveWindow { get; }
 
+        event EventHandler<ActiveWindowChangedEventArgs> ActiveWindowChanged;
+
         Task<IInteractiveWindowVisualComponent> GetOrCreateVisualComponentAsync(int instanceId = 0);
     }
 }

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
@@ -61,9 +61,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             _crProcessor?.Dispose();
         }
 
-        public async Task<ExecutionResult> InitializeAsync() {
-            return await InitializeAsync(false);
-        }
+        public Task<ExecutionResult> InitializeAsync() => InitializeAsync(false);
 
         private async Task<ExecutionResult> InitializeAsync(bool isResetting) {
             try {

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.Disposables;
@@ -28,6 +29,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
         private readonly IRSettings _settings;
         private readonly RInteractiveWorkflowOperations _operations;
 
+        private TaskCompletionSource<IInteractiveWindowVisualComponent> _visualComponentTcs;
         private bool _replLostFocus;
         private bool _debuggerJustEnteredBreakMode;
 
@@ -42,6 +44,8 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
         public IRInteractiveWorkflowOperations Operations => _operations;
 
         public IInteractiveWindowVisualComponent ActiveWindow { get; private set; }
+
+        public event EventHandler<ActiveWindowChangedEventArgs> ActiveWindowChanged;
 
         public RInteractiveWorkflow(IConnectionManagerProvider connectionsProvider
             , IRHistoryProvider historyProvider
@@ -150,28 +154,35 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             return wss.IsRProjectActive;
         }
 
-        public async Task<IInteractiveWindowVisualComponent> GetOrCreateVisualComponentAsync(int instanceId = 0) {
+        public Task<IInteractiveWindowVisualComponent> GetOrCreateVisualComponentAsync(int instanceId = 0) {
             Shell.AssertIsOnMainThread();
 
-            if (ActiveWindow != null) {
+            if (_visualComponentTcs == null) {
+                _visualComponentTcs = new TaskCompletionSource<IInteractiveWindowVisualComponent>();
+                CreateVisualComponentAsync(instanceId).DoNotWait();
+            } else if (instanceId != 0) {
                 // Right now only one instance of interactive window is allowed
-                if (instanceId != 0) {
-                    throw new InvalidOperationException("Right now only one instance of interactive window is allowed");
-                }
-
-                return ActiveWindow;
+                throw new InvalidOperationException("Right now only one instance of interactive window is allowed");
             }
 
+            return _visualComponentTcs.Task;
+        }
+
+        private async Task CreateVisualComponentAsync(int instanceId) {
             var factory = Shell.ExportProvider.GetExportedValue<IInteractiveWindowComponentContainerFactory>();
             var evaluator = new RInteractiveEvaluator(RSessions, RSession, History, Connections, Shell, _settings);
 
-            ActiveWindow = factory.Create(instanceId, evaluator, RSessions);
-            var interactiveWindow = ActiveWindow.InteractiveWindow;
+            var window = factory.Create(instanceId, evaluator, RSessions);
+            var interactiveWindow = window.InteractiveWindow;
             interactiveWindow.TextView.Closed += (_, __) => evaluator.Dispose();
             _operations.InteractiveWindow = interactiveWindow;
+
             await interactiveWindow.InitializeAsync();
+
+            ActiveWindow = window;
             ActiveWindow.Container.UpdateCommandStatus(true);
-            return ActiveWindow;
+            _visualComponentTcs.SetResult(ActiveWindow);
+            ActiveWindowChanged?.Invoke(this, new ActiveWindowChangedEventArgs(window));
         }
 
         public void Dispose() {

--- a/src/R/Components/Impl/Microsoft.R.Components.csproj
+++ b/src/R/Components/Impl/Microsoft.R.Components.csproj
@@ -143,6 +143,7 @@
       <DependentUpon>HostLoadIndicator.xaml</DependentUpon>
     </Compile>
     <Compile Include="Information\HostLoadIndicatorViewModel.cs" />
+    <Compile Include="InteractiveWorkflow\ActiveWindowChangedEventArgs.cs" />
     <Compile Include="InteractiveWorkflow\Commands\SessionInformationCommand.cs" />
     <Compile Include="InteractiveWorkflow\Commands\TerminateRCommand.cs" />
     <Compile Include="InteractiveWorkflow\Commands\InterruptRCommand.cs" />

--- a/src/R/Components/Test/InteractiveWorkflow/RInteractiveEvaluatorTest.cs
+++ b/src/R/Components/Test/InteractiveWorkflow/RInteractiveEvaluatorTest.cs
@@ -33,7 +33,6 @@ namespace Microsoft.R.Components.Test.InteractiveWorkflow {
 
         public async Task InitializeAsync() {
             await _workflow.RSessions.TrySwitchBrokerAsync(nameof(RInteractiveEvaluatorTest));
-            await _workflow.RSession.HostStarted.Should().BeCompletedAsync(50000);
         }
 
         public async Task DisposeAsync() {

--- a/src/R/Components/Test/InteractiveWorkflow/RInteractiveWorkflowCommandTest.cs
+++ b/src/R/Components/Test/InteractiveWorkflow/RInteractiveWorkflowCommandTest.cs
@@ -90,9 +90,9 @@ namespace Microsoft.R.Components.Test.InteractiveWorkflow {
 
                     var mutatedTask = EventTaskSources.IRSession.Mutated.Create(session);
 
-                    await command.InvokeAsync();
+                    await command.InvokeAsync().Should().BeCompletedAsync();
 
-                    await mutatedTask;
+                    await mutatedTask.Should().BeCompletedAsync();
                     (await session.EvaluateAsync<bool>("sourced", REvaluationKind.Normal)).Should().BeTrue();
                 }
             }

--- a/src/R/Components/Test/Plots/RPlotIntegrationTest.cs
+++ b/src/R/Components/Test/Plots/RPlotIntegrationTest.cs
@@ -50,8 +50,8 @@ namespace Microsoft.R.Components.Test.Plots {
         }
 
         public async Task InitializeAsync() {
-            _replVisualComponent = await _workflow.GetOrCreateVisualComponentAsync();
             await _workflow.RSessions.TrySwitchBrokerAsync(nameof(RPlotIntegrationTest));
+            _replVisualComponent = await _workflow.GetOrCreateVisualComponentAsync();
 
             _plotDeviceVisualComponentContainerFactory.DeviceProperties = new PlotDeviceProperties(600, 500, 96);
         }

--- a/src/UnitTests/Core/Impl/FluentAssertions/TaskAssertions.cs
+++ b/src/UnitTests/Core/Impl/FluentAssertions/TaskAssertions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,6 +55,10 @@ namespace Microsoft.UnitTests.Core.FluentAssertions {
         
         public Task<AndConstraint<TaskAssertions>> BeCompletedAsync(int timeout = 10000, string because = "", params object[] reasonArgs) {
             Subject.Should().NotBeNull();
+            if (Debugger.IsAttached) {
+                timeout = Math.Max(100000, timeout);
+            }
+
             var timeoutTask = Task.Delay(timeout);
             var state = new BeCompletedAsyncContinuationState(timeout, because, reasonArgs);
             return Task.WhenAny(timeoutTask, Subject)

--- a/src/UnitTests/Core/Impl/Microsoft.UnitTests.Core.csproj
+++ b/src/UnitTests/Core/Impl/Microsoft.UnitTests.Core.csproj
@@ -133,6 +133,7 @@
     <Compile Include="XUnit\TestRunner.cs" />
     <Compile Include="XUnit\TestTraceListener.cs" />
     <Compile Include="XUnit\ThreadType.cs" />
+    <Compile Include="XUnit\ThreadTypeAttribute.cs" />
     <Compile Include="XUnit\TraceFailException.cs" />
     <Compile Include="XUnit\UnitTestTraitDiscoverer.cs" />
     <Compile Include="XUnit\TestForTypesTestCase.cs" />

--- a/src/UnitTests/Core/Impl/XUnit/CompositeTestDiscoverer.cs
+++ b/src/UnitTests/Core/Impl/XUnit/CompositeTestDiscoverer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.UnitTests.Core.XUnit {
         }
 
         protected override IXunitTestCase CreateTestCaseForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow) {
-            var parameters = new TestParameters(theoryAttribute);
+            var parameters = new TestParameters(testMethod, theoryAttribute);
             return new TestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, parameters, dataRow);
         }
     }

--- a/src/UnitTests/Core/Impl/XUnit/TestCase.cs
+++ b/src/UnitTests/Core/Impl/XUnit/TestCase.cs
@@ -58,7 +58,7 @@ namespace Microsoft.UnitTests.Core.XUnit {
             }
 
             messageBusOverride.AddAfterStartingBeforeFinished(new VerifyGlobalProviderMessageBusInjection());
-            return runner.RunAsync();
+            return ThreadType == ThreadType.Background ? Task.Run(() => runner.RunAsync()) : runner.RunAsync();
         }
 
         protected virtual object[] GetTestMethodArguments() => TestMethodArguments;

--- a/src/UnitTests/Core/Impl/XUnit/TestDiscoverer.cs
+++ b/src/UnitTests/Core/Impl/XUnit/TestDiscoverer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.UnitTests.Core.XUnit {
         }
 
         protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute) {
-            var parameters = new TestParameters(factAttribute);
+            var parameters = new TestParameters(testMethod, factAttribute);
             return new TestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, parameters);
         }
     }

--- a/src/UnitTests/Core/Impl/XUnit/TestForTypesDiscoverer.cs
+++ b/src/UnitTests/Core/Impl/XUnit/TestForTypesDiscoverer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.UnitTests.Core.XUnit {
 
         public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
         {
-            TestForTypesParameters parameters = new TestForTypesParameters(factAttribute);
+            TestForTypesParameters parameters = new TestForTypesParameters(testMethod, factAttribute);
             var methodDisplay = discoveryOptions.MethodDisplayOrDefault();
 
             if (testMethod.Method.GetParameters().Count() != 1) {

--- a/src/UnitTests/Core/Impl/XUnit/TestForTypesParameters.cs
+++ b/src/UnitTests/Core/Impl/XUnit/TestForTypesParameters.cs
@@ -10,7 +10,7 @@ namespace Microsoft.UnitTests.Core.XUnit
     [ExcludeFromCodeCoverage]
     public class TestForTypesParameters : TestParameters
     {
-        public TestForTypesParameters(IAttributeInfo factAttribute) : base(factAttribute)
+        public TestForTypesParameters(ITestMethod testMethod, IAttributeInfo factAttribute) : base(testMethod, factAttribute)
         {
             Types = factAttribute.GetNamedArgument<Type[]>("Types");
         }

--- a/src/UnitTests/Core/Impl/XUnit/TestParameters.cs
+++ b/src/UnitTests/Core/Impl/XUnit/TestParameters.cs
@@ -2,16 +2,27 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Xunit.Abstractions;
 
 namespace Microsoft.UnitTests.Core.XUnit {
     [ExcludeFromCodeCoverage]
     public class TestParameters {
-        public TestParameters(IAttributeInfo factAttribute) {
+        public TestParameters(ITestMethod testMethod, IAttributeInfo factAttribute) {
             SkipReason = factAttribute.GetNamedArgument<string>(nameof(TestAttribute.Skip));
             ThreadType = factAttribute.GetNamedArgument<ThreadType>(nameof(TestAttribute.ThreadType));
             ShowWindow = factAttribute.GetNamedArgument<bool>(nameof(TestAttribute.ShowWindow));
+
+            if (ThreadType == ThreadType.Default) {
+                var classThreadTypeAttribute = GetClassAttribute<ThreadTypeAttribute>(testMethod);
+                if (classThreadTypeAttribute != null) {
+                    ThreadType = classThreadTypeAttribute.GetNamedArgument<ThreadType>(nameof(TestAttribute.ThreadType));
+                }
+            }
         }
+
+        private IAttributeInfo GetClassAttribute<T>(ITestMethod testMethod) 
+            => testMethod.TestClass.Class.GetCustomAttributes(typeof(T)).FirstOrDefault();
 
         public bool ShowWindow { get; }
         public ThreadType ThreadType { get; }

--- a/src/UnitTests/Core/Impl/XUnit/ThreadTypeAttribute.cs
+++ b/src/UnitTests/Core/Impl/XUnit/ThreadTypeAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.UnitTests.Core.XUnit {
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ThreadTypeAttribute : Attribute {
+        public ThreadTypeAttribute(ThreadType threadType) {
+            ThreadType = threadType;
+        }
+
+        public ThreadType ThreadType { get; set; }
+    }
+}


### PR DESCRIPTION
This is an attempt to reduce ambiguity in REPL/RSessionProvider operation.
Previously, `SwitchBrokerToLastConnection` was scheduled into UI thread to run at some point after `RInteractiveWorkflow` completes initialization. That could happen before or after REPL becomes visible, which itself was scheduled to show up during first broker switch. But because of the locks, it couldn't show up at the time the switch is happening.

With this change, behavior is determined:
- While REPL isn't visible and user haven't chosen workspace explicitly, no connection is established
- When user opens REPL (explicitly or by opening a project or by opening R or RMD file), it first checks if it can start local broker and only after that shows the window. 
- When user switches to the connection with closed REPL, `ConnectionManager` will first try to connect and then will open the REPL. Both operations will happen under progress bar.