### PR TITLE
Fix #2671: Interrupt R is disabled but REPL is busy

### DIFF
--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -203,14 +203,13 @@ namespace Microsoft.R.Host.Client.Session {
 
         public async Task CancelAllAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             using (_disposeToken.Link(ref cancellationToken)) {
-                var cancelTask = _host.CancelAllAsync(cancellationToken);
+                await _host.CancelAllAsync(cancellationToken);
 
                 var currentRequest = Interlocked.Exchange(ref _currentRequestSource, null);
                 var exception = new OperationCanceledException();
                 currentRequest?.TryCancel(exception);
-                ClearPendingRequests(exception);
 
-                await cancelTask;
+                ClearPendingRequests(exception);
             }
         }
 

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -203,13 +203,13 @@ namespace Microsoft.R.Host.Client.Session {
 
         public async Task CancelAllAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             using (_disposeToken.Link(ref cancellationToken)) {
+                var exception = new OperationCanceledException();
+                ClearPendingRequests(exception);
+
                 await _host.CancelAllAsync(cancellationToken);
 
                 var currentRequest = Interlocked.Exchange(ref _currentRequestSource, null);
-                var exception = new OperationCanceledException();
                 currentRequest?.TryCancel(exception);
-
-                ClearPendingRequests(exception);
             }
         }
 

--- a/src/R/Components/Impl/InteractiveWorkflow/Commands/InterruptRCommand.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Commands/InterruptRCommand.cs
@@ -48,9 +48,9 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Commands {
 
         public async Task<CommandResult> InvokeAsync() {
             if (_enabled) {
+                _enabled = false;
                 _interactiveWorkflow.Operations.ClearPendingInputs();
                 await _session.CancelAllAsync();
-                _enabled = false;
                 return CommandResult.Executed;
             }
 

--- a/src/R/Components/Test/InteractiveWorkflow/RInteractiveWorkflowCommandTest.cs
+++ b/src/R/Components/Test/InteractiveWorkflow/RInteractiveWorkflowCommandTest.cs
@@ -106,6 +106,7 @@ namespace Microsoft.R.Components.Test.InteractiveWorkflow {
             command.Should().BeInvisibleAndDisabled();
 
             using (await UIThreadHelper.Instance.Invoke(() => _workflow.GetOrCreateVisualComponentAsync())) {
+                using (await _workflow.RSession.BeginInteractionAsync()) { }
                 command.Should().BeVisibleAndDisabled();
 
                 await _workflow.RSessions.TrySwitchBrokerAsync(nameof(RInteractiveWorkflowCommandTest));


### PR DESCRIPTION
When interrupting R, do not cancel the current interaction request task until R confirms completion.

Disable "Interrupt R" command while it's running to prevent re-entrancy.

Fix interrupt test to wait for prompt before first checking command status.