### PR TITLE
Fix #2801: Simplify MEF dependencies in CoreServices

### DIFF
--- a/src/Common/Core/Impl/Logging/Implementation/LoggingPermissions.cs
+++ b/src/Common/Core/Impl/Logging/Implementation/LoggingPermissions.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Common.Core.Logging {
     ///        in the interactive window.
     ///     c. Admin can limit level of logging and disable feedback sending even if app telemetry is on.
     /// </remarks>
-    [Export(typeof(ILoggingPermissions))]
-    internal sealed class LoggingPermissions : ILoggingPermissions {
+    public sealed class LoggingPermissions : ILoggingPermissions {
         internal const string LogVerbosityValueName = "LogVerbosity";
         internal const string FeedbackValueName = "Feedback";
 
@@ -36,11 +35,10 @@ namespace Microsoft.Common.Core.Logging {
         private LogVerbosity? _registryVerbosity;
         private int? _registryFeedbackSetting;
 
-        [ImportingConstructor]
-        public LoggingPermissions(IApplicationConstants appConstants, ITelemetryService telemetryService, [Import(AllowDefault = true)] IRegistry registry) {
+        public LoggingPermissions(IApplicationConstants appConstants, ITelemetryService telemetryService, IRegistry registry) {
             _appConstants = appConstants;
             _telemetryService = telemetryService;
-            _registry = registry ?? new RegistryImpl();
+            _registry = registry;
 
             _registryVerbosity = GetLogLevelFromRegistry();
             _registryFeedbackSetting = GetFeedbackFromRegistry();

--- a/src/Common/Core/Impl/Logging/Implementation/LoggingServices.cs
+++ b/src/Common/Core/Impl/Logging/Implementation/LoggingServices.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.ComponentModel.Composition;
 using System.Threading;
 using Microsoft.Common.Core.Shell;
 
 namespace Microsoft.Common.Core.Logging.Implementation {
     internal sealed class LoggingServices : ILoggingServices {
-        private static Logger _instance;
         private readonly IApplicationConstants _appConstants;
+        private Logger _instance;
 
         public LoggingServices(ILoggingPermissions permissions, IApplicationConstants appConstants) {
             Permissions = permissions;

--- a/src/Common/Core/Impl/Security/SecurityService.cs
+++ b/src/Common/Core/Impl/Security/SecurityService.cs
@@ -12,7 +12,7 @@ using Microsoft.Common.Core.Shell;
 using static Microsoft.Common.Core.NativeMethods;
 
 namespace Microsoft.Common.Core.Security {
-    internal class SecurityService : ISecurityService {
+    public class SecurityService : ISecurityService {
         private readonly ICoreShell _coreShell;
 
         public SecurityService(ICoreShell coreShell) {

--- a/src/Common/Core/Impl/Services/CoreServices.cs
+++ b/src/Common/Core/Impl/Services/CoreServices.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Common.Core.Services {
             , ISettingsStorage settings
             , ITaskService tasks
             , IMainThread mainThread
-            , ICoreShell coreShell) {
+            , ISecurityService security) {
             Telemetry = telemetry;
             Registry = new RegistryImpl();
-            Security = new SecurityService(coreShell);
+            Security = security;
             LoggingServices = new LoggingServices(new LoggingPermissions(appConstants, telemetry, Registry), appConstants);
             Tasks = tasks;
 

--- a/src/Common/Core/Impl/Services/CoreServices.cs
+++ b/src/Common/Core/Impl/Services/CoreServices.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.ComponentModel.Composition;
 using Microsoft.Common.Core.IO;
 using Microsoft.Common.Core.Logging;
 using Microsoft.Common.Core.Logging.Implementation;
@@ -14,43 +12,54 @@ using Microsoft.Common.Core.Telemetry;
 using Microsoft.Common.Core.Threading;
 
 namespace Microsoft.Common.Core.Services {
-    [Export(typeof(ICoreServices))]
     public sealed class CoreServices : ICoreServices {
-        private readonly IApplicationConstants _appConstants;
-        private readonly Lazy<IMainThread> _mainThread;
-        private IActionLog _log;
+        public CoreServices(IApplicationConstants appConstants
+            , ITelemetryService telemetry
+            , ISettingsStorage settings
+            , ITaskService tasks
+            , IMainThread mainThread
+            , ICoreShell coreShell) {
+            Telemetry = telemetry;
+            Registry = new RegistryImpl();
+            Security = new SecurityService(coreShell);
+            LoggingServices = new LoggingServices(new LoggingPermissions(appConstants, telemetry, Registry), appConstants);
+            Tasks = tasks;
 
-        [ImportingConstructor]
-        public CoreServices(
-              IApplicationConstants appConstants
+            ProcessServices = new ProcessServices();
+            FileSystem = new FileSystem();
+            Settings = settings;
+            MainThread = mainThread;
+
+            Log = LoggingServices.GetOrCreateLog(appConstants.ApplicationName);
+        }
+
+        public CoreServices(IApplicationConstants appConstants
             , ITelemetryService telemetry
             , ILoggingPermissions permissions
             , ISecurityService security
             , ITaskService tasks
             , ISettingsStorage settings
-            , Lazy<IMainThread> mainThread
-            , [Import(AllowDefault = true)] IActionLog log = null
-            , [Import(AllowDefault = true)] IFileSystem fs = null
-            , [Import(AllowDefault = true)] IRegistry registry = null
-            , [Import(AllowDefault = true)] IProcessServices ps = null) {
+            , IMainThread mainThread
+            , IActionLog log
+            , IFileSystem fs
+            , IRegistry registry
+            , IProcessServices ps) {
 
             LoggingServices = new LoggingServices(permissions, appConstants);
-            _appConstants = appConstants;
-            _log = log;
+            Log = log;
 
             Telemetry = telemetry;
             Security = security;
             Tasks = tasks;
 
-            ProcessServices = ps ?? new ProcessServices();
-            Registry = registry ?? new RegistryImpl();
-            FileSystem = fs ?? new FileSystem();
+            ProcessServices = ps;
+            Registry = registry;
+            FileSystem = fs;
             Settings = settings;
-            _mainThread = mainThread;
+            MainThread = mainThread;
         }
 
-        public IActionLog Log => _log ?? (_log = LoggingServices.GetOrCreateLog(_appConstants.ApplicationName));
-
+        public IActionLog Log { get; }
         public IFileSystem FileSystem { get; } 
         public IProcessServices ProcessServices { get; }
         public IRegistry Registry { get; } 
@@ -59,6 +68,6 @@ namespace Microsoft.Common.Core.Services {
         public ITaskService Tasks { get; }
         public ILoggingServices LoggingServices { get; }
         public ISettingsStorage Settings { get; }
-        public IMainThread MainThread => _mainThread.Value;
+        public IMainThread MainThread { get; }
     }
 }

--- a/src/Common/Core/Impl/Shell/IApplicationConstants.cs
+++ b/src/Common/Core/Impl/Shell/IApplicationConstants.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Common.Core.Shell {
     /// Implemented by the host application. Imported via MEF.
     /// </summary>
     public interface IApplicationConstants {
-        void Initialize();
         /// <summary>
         /// Application name to use in log, system events, etc.
         /// </summary>

--- a/src/Common/Core/Test/Fakes/Shell/TestCoreServices.cs
+++ b/src/Common/Core/Test/Fakes/Shell/TestCoreServices.cs
@@ -18,15 +18,15 @@ using NSubstitute;
 namespace Microsoft.Common.Core.Test.Fakes.Shell {
     [ExcludeFromCodeCoverage]
     public static class TestCoreServices {
-        public static ICoreServices CreateSubstitute(IFileSystem fs = null, IRegistry registry = null, IProcessServices ps = null) {
+        public static ICoreServices CreateSubstitute(ILoggingPermissions loggingPermissions = null, IFileSystem fs = null, IRegistry registry = null, IProcessServices ps = null) {
             return new CoreServices(
                 Substitute.For<IApplicationConstants>(),
                 Substitute.For<ITelemetryService>(),
-                null,
+                loggingPermissions,
                 Substitute.For<ISecurityService>(),
                 Substitute.For<ITaskService>(),
                 Substitute.For<ISettingsStorage>(),
-                new Lazy<IMainThread>(() => new TestMainThread()),
+                new TestMainThread(),
                 Substitute.For<IActionLog>(),
                 fs ?? Substitute.For<IFileSystem>(),
                 registry ?? Substitute.For<IRegistry>(),
@@ -41,7 +41,7 @@ namespace Microsoft.Common.Core.Test.Fakes.Shell {
                 Substitute.For<ISecurityService>(),
                 new TestTaskService(),
                 Substitute.For<ISettingsStorage>(),
-                new Lazy<IMainThread>(() => new TestMainThread()),
+                new TestMainThread(),
                 Substitute.For<IActionLog>(),
                 new FileSystem(),
                 new RegistryImpl(),

--- a/src/Host/Client/Impl/Program.cs
+++ b/src/Host/Client/Impl/Program.cs
@@ -23,7 +23,7 @@ namespace Microsoft.R.Host.Client {
             Console.CancelKeyPress += Console_CancelKeyPress;
 
             using (var logger = new Logger("Program", new MaxLoggingPermissions(), FileLogWriter.InTempFolder("Microsoft.R.Host.Client.Program"))) {
-                var services = new CoreServices(new AppConstants(), null, null, null, null, null, Lazy.Create<IMainThread>(() => null));
+                var services = new CoreServices(new AppConstants(), null, new MaxLoggingPermissions(), null, null, null, null, null, null, null, null);
                 var localConnector = new LocalBrokerClient("Program", args[0], services, new NullConsole());
                 var host = localConnector.ConnectAsync(new BrokerConnectionInfo("Program", new Program())).GetAwaiter().GetResult();
                 _evaluator = host;

--- a/src/Package/Impl/Feedback/ReportIssueCommand.cs
+++ b/src/Package/Impl/Feedback/ReportIssueCommand.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using Microsoft.Common.Core.Logging;
 using Microsoft.Common.Core.OS;
+using Microsoft.Common.Core.Services;
 using Microsoft.VisualStudio.R.Package.Commands;
 using Microsoft.VisualStudio.R.Package.Logging;
 using Microsoft.VisualStudio.R.Packages.R;
@@ -17,10 +18,10 @@ namespace Microsoft.VisualStudio.R.Package.Feedback {
         private readonly ILoggingPermissions _permissions;
         private readonly IProcessServices _pss;
 
-        public ReportIssueCommand(ILoggingPermissions permissions, IProcessServices pss)
+        public ReportIssueCommand(ICoreServices services)
             : base(RGuidList.RCmdSetGuid, RPackageCommandId.icmdReportIssue) {
-            _permissions = permissions;
-            _pss = pss;
+            _permissions = services.LoggingServices.Permissions;
+            _pss = services.ProcessServices;
         }
 
         protected override void SetStatus() {

--- a/src/Package/Impl/Feedback/SendFrownCommand.cs
+++ b/src/Package/Impl/Feedback/SendFrownCommand.cs
@@ -12,8 +12,8 @@ using Microsoft.VisualStudio.R.Packages.R;
 
 namespace Microsoft.VisualStudio.R.Package.Feedback {
     internal sealed class SendFrownCommand : SendMailCommand {
-        public SendFrownCommand(ILoggingPermissions permissions, ICoreServices services) :
-            base(RGuidList.RCmdSetGuid, RPackageCommandId.icmdSendFrown, permissions, services) {
+        public SendFrownCommand(ICoreServices services) :
+            base(RGuidList.RCmdSetGuid, RPackageCommandId.icmdSendFrown, services) {
         }
 
         protected override void Handle() {

--- a/src/Package/Impl/Feedback/SendMailCommand.cs
+++ b/src/Package/Impl/Feedback/SendMailCommand.cs
@@ -13,17 +13,15 @@ using Microsoft.VisualStudio.R.Package.Interop;
 
 namespace Microsoft.VisualStudio.R.Package.Feedback {
     internal class SendMailCommand : PackageCommand {
-        private readonly ILoggingPermissions _permissions;
         protected ICoreServices Services { get; }
 
-        public SendMailCommand(Guid group, int id, ILoggingPermissions permissions, ICoreServices services) :
+        public SendMailCommand(Guid group, int id, ICoreServices services) :
             base(group, id) {
-            _permissions = permissions;
             Services = services;
         }
 
         protected override void SetStatus() {
-            Enabled = Visible = _permissions.IsFeedbackPermitted;
+            Enabled = Visible = Services.LoggingServices.Permissions.IsFeedbackPermitted;
         }
 
         protected void SendMail(string body, string subject, string attachmentFile) {

--- a/src/Package/Impl/Feedback/SendSmileCommand.cs
+++ b/src/Package/Impl/Feedback/SendSmileCommand.cs
@@ -8,8 +8,8 @@ using Microsoft.VisualStudio.R.Packages.R;
 
 namespace Microsoft.VisualStudio.R.Package.Feedback {
     internal sealed class SendSmileCommand : SendMailCommand {
-        public SendSmileCommand(ILoggingPermissions permissions, ICoreServices services) :
-            base(RGuidList.RCmdSetGuid, RPackageCommandId.icmdSendSmile, permissions, services) {
+        public SendSmileCommand(ICoreServices services) :
+            base(RGuidList.RCmdSetGuid, RPackageCommandId.icmdSendSmile, services) {
         }
 
         protected override void Handle() {

--- a/src/Package/Impl/Options/R/Tools/LogLevelTypeConverter.cs
+++ b/src/Package/Impl/Options/R/Tools/LogLevelTypeConverter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.R.Package.Options.R.Tools {
         private readonly int _maxLogLevel;
 
         public LogLevelTypeConverter() {
-            var permissions = VsAppShell.Current.ExportProvider.GetExportedValue<ILoggingPermissions>();
+            var permissions = VsAppShell.Current.Services.LoggingServices.Permissions;
             _maxLogLevel = (int)permissions.MaxVerbosity;
         }
 

--- a/src/Package/Impl/Options/R/Tools/RToolsSettingsImplementation.cs
+++ b/src/Package/Impl/Options/R/Tools/RToolsSettingsImplementation.cs
@@ -55,9 +55,9 @@ namespace Microsoft.VisualStudio.R.Package.Options.R {
         private LogVerbosity _logLevel = LogVerbosity.Normal;
 
         [ImportingConstructor]
-        public RToolsSettingsImplementation(ISettingsStorage settings, ILoggingPermissions loggingPermissions) {
+        public RToolsSettingsImplementation(ISettingsStorage settings, ICoreShell coreShell) {
             _settings = settings;
-            _loggingPermissions = loggingPermissions;
+            _loggingPermissions = coreShell.Services.LoggingServices.Permissions;
             _workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
         }
 

--- a/src/Package/Impl/Packages/R/PackageCommands.cs
+++ b/src/Package/Impl/Packages/R/PackageCommands.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.R.Packages.R {
             var pcsp = exportProvider.GetExportedValue<IProjectConfigurationSettingsProvider>();
             var dbcs = exportProvider.GetExportedValue<IDbConnectionService>();
             var settings = exportProvider.GetExportedValue<IRToolsSettings>();
-            var logPerms = exportProvider.GetExportedValue<ILoggingPermissions>();
+            var logPerms = appShell.Services.LoggingServices.Permissions;
 
             return new List<MenuCommand> {
                 new GoToOptionsCommand(),
@@ -62,9 +62,9 @@ namespace Microsoft.VisualStudio.R.Packages.R {
                 new SurveyNewsCommand(appShell),
                 new SetupRemoteCommand(),
 
-                new ReportIssueCommand(logPerms, appShell.Services.ProcessServices),
-                new SendSmileCommand(logPerms, appShell.Services),
-                new SendFrownCommand(logPerms, appShell.Services),
+                new ReportIssueCommand(appShell.Services),
+                new SendSmileCommand(appShell.Services),
+                new SendFrownCommand(appShell.Services),
 
                 CreateRCmdSetCommand(RPackageCommandId.icmdRDocsIntroToR, new OpenDocumentationCommand(interactiveWorkflow, OnlineDocumentationUrls.CranIntro, LocalDocumentationPaths.CranIntro)),
                 CreateRCmdSetCommand(RPackageCommandId.icmdRDocsDataImportExport, new OpenDocumentationCommand(interactiveWorkflow, OnlineDocumentationUrls.CranData, LocalDocumentationPaths.CranData)),

--- a/src/Package/Impl/Repl/VsRInteractiveWorkflowProvider.cs
+++ b/src/Package/Impl/Repl/VsRInteractiveWorkflowProvider.cs
@@ -4,11 +4,7 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Common.Core;
 using Microsoft.Common.Core.Disposables;
-using Microsoft.Common.Core.Services;
-using Microsoft.Common.Core.Shell;
 using Microsoft.R.Components.ConnectionManager;
 using Microsoft.R.Components.History;
 using Microsoft.R.Components.InteractiveWorkflow;
@@ -16,12 +12,7 @@ using Microsoft.R.Components.InteractiveWorkflow.Implementation;
 using Microsoft.R.Components.PackageManager;
 using Microsoft.R.Components.Plots;
 using Microsoft.R.Components.Settings;
-using Microsoft.R.Components.Workspace;
-using Microsoft.R.Host.Client;
-using Microsoft.R.Host.Client.Session;
-using Microsoft.VisualStudio.R.Package.Commands;
 using Microsoft.VisualStudio.R.Package.Shell;
-using Microsoft.VisualStudio.R.Packages.R;
 
 namespace Microsoft.VisualStudio.R.Package.Repl {
     [Export(typeof(IRInteractiveWorkflowProvider))]
@@ -35,9 +26,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
         private readonly IActiveWpfTextViewTracker _activeTextViewTracker;
         private readonly IDebuggerModeTracker _debuggerModeTracker;
         private readonly IApplicationShell _shell;
-        private readonly IWorkspaceServices _wss;
         private readonly IRSettings _settings;
-        private readonly ICoreServices _services;
 
         private Lazy<IRInteractiveWorkflow> _instanceLazy;
 
@@ -49,9 +38,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
             , IActiveWpfTextViewTracker activeTextViewTracker
             , IDebuggerModeTracker debuggerModeTracker
             , IApplicationShell shell
-            , IWorkspaceServices wss
-            , IRSettings settings
-            , ICoreServices services) {
+            , IRSettings settings) {
 
             _connectionsProvider = connectionsProvider;
             _historyProvider = historyProvider;
@@ -60,9 +47,7 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
             _activeTextViewTracker = activeTextViewTracker;
             _debuggerModeTracker = debuggerModeTracker;
             _shell = shell;
-            _wss = wss;
             _settings = settings;
-            _services = services;
         }
 
         public void Dispose() {

--- a/src/Package/Impl/Shell/ApplicationConstants.cs
+++ b/src/Package/Impl/Shell/ApplicationConstants.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.ComponentModel.Composition;
 using Microsoft.Common.Core.Shell;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.R.Package.Shell {
-    [Export(typeof(IApplicationConstants))]
     public sealed class ApplicationConstants : IApplicationConstants {
         /// <summary>
         /// Application name to use in log, system events, etc.

--- a/src/Package/Impl/Shell/VsAppShell.cs
+++ b/src/Package/Impl/Shell/VsAppShell.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.R.Package.Shell {
             ProgressDialog = new VsProgressDialog(this);
             FileDialog = new VsFileDialog(this);
 
-            _coreServices = new CoreServices(_appConstants, telemetryService, settingsStorage, new VsTaskService(), this, this);
+            _coreServices = new CoreServices(_appConstants, telemetryService, settingsStorage, new VsTaskService(), this, new SecurityService(this));
         }
 
         public static void EnsureInitialized() {

--- a/src/Package/Impl/Shell/VsTaskService.cs
+++ b/src/Package/Impl/Shell/VsTaskService.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.ComponentModel.Composition;
 using System.Threading;
 using Microsoft.Common.Core.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.R.Package.Shell {
-    [Export(typeof(ITaskService))]
     internal class VsTaskService : ITaskService {
         public bool Wait(Task task, CancellationToken cancellationToken = default(CancellationToken), int ms = Timeout.Infinite) 
             => UIThreadReentrancyScope.WaitOnTaskComplete(task, cancellationToken, ms);

--- a/src/Package/Impl/source.extension.14.0.vsixmanifest
+++ b/src/Package/Impl/source.extension.14.0.vsixmanifest
@@ -14,6 +14,7 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="websocket-sharp.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Newtonsoft.Json.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.R.Host.exe" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.R.Common.Core.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Languages.Core.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.R.Core.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.R.Debugger.dll" />
@@ -24,7 +25,6 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Data.ConnectionUI.Dialog.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.R.Debugger.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.R.Host.Client.dll" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.R.Common.Core.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.R.Components.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.Languages.Editor.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.R.Editor.dll" />

--- a/src/Package/Impl/source.extension.15.0.vsixmanifest
+++ b/src/Package/Impl/source.extension.15.0.vsixmanifest
@@ -23,6 +23,7 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="websocket-sharp.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Newtonsoft.Json.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.R.Host.exe" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.R.Common.Core.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Languages.Core.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.R.Core.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.R.Debugger.dll" />
@@ -33,7 +34,6 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Data.ConnectionUI.Dialog.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.R.Debugger.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.R.Host.Client.dll" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.R.Common.Core.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.R.Components.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.Languages.Editor.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.R.Editor.dll" />

--- a/src/Package/Test/Feedback/FeedbackCommandTest.cs
+++ b/src/Package/Test/Feedback/FeedbackCommandTest.cs
@@ -20,24 +20,24 @@ namespace Microsoft.VisualStudio.R.Package.Test.Commands {
 
         public FeedbackCommandTest() {
             _lp = Substitute.For<ILoggingPermissions>();
-            _services = TestCoreServices.CreateSubstitute();
+            _services = TestCoreServices.CreateSubstitute(_lp);
         }
 
         [Test]
         public void ReportIssue() {
-            var cmd = new ReportIssueCommand(_lp, _services.ProcessServices);
+            var cmd = new ReportIssueCommand(_services);
             TestStatus(cmd);
         }
 
         [Test]
         public void SendFrown() {
-            var cmd = new SendFrownCommand(_lp, _services);
+            var cmd = new SendFrownCommand(_services);
             TestStatus(cmd);
         }
 
         [Test]
         public void SendSmile() {
-            var cmd = new SendSmileCommand(_lp, _services);
+            var cmd = new SendSmileCommand(_services);
             TestStatus(cmd);
         }
 

--- a/src/Package/Test/Fixtures/DisposeRInteractiveWorkflowFixture.cs
+++ b/src/Package/Test/Fixtures/DisposeRInteractiveWorkflowFixture.cs
@@ -14,7 +14,8 @@ namespace Microsoft.VisualStudio.R.Package.Test.Fixtures {
         private readonly IRInteractiveWorkflow _workflow;
 
         public DisposeRInteractiveWorkflowFixture() {
-            _workflow = VsAppShell.Current.ExportProvider.GetExportedValue<IRInteractiveWorkflowProvider>().GetOrCreate();
+            var exportProvider = VsAppShell.Current.ExportProvider;
+            _workflow = exportProvider.GetExportedValue<IRInteractiveWorkflowProvider>().GetOrCreate();
         }
         
         public async Task InitializeAsync() {

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
@@ -51,7 +51,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
             _settings = settings;
             _interactiveWorkflow = interactiveWorkflow;
             _shell = interactiveWorkflow.Shell;
-            _securityService = _shell.ExportProvider.GetExportedValue<ISecurityService>();
+            _securityService = _shell.Services.Security;
 
             _statusBarViewModel = new ConnectionStatusBarViewModel(this, interactiveWorkflow.Shell);
             _hostLoadIndicatorViewModel = new HostLoadIndicatorViewModel(_sessionProvider, interactiveWorkflow.Shell);


### PR DESCRIPTION
- CoreServices is no longer a MEF export, and is available through `ICoreShell.Services` property only
- Common.Core is added to vsix manifest as assembly