### PR TITLE
Fix #2810: Switching workspaces during a long-running operation gets stuck

### DIFF
--- a/src/Host/Client/Impl/Definitions/IObjectViewer.cs
+++ b/src/Host/Client/Impl/Definitions/IObjectViewer.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Client {
     public interface IObjectViewer {
         Task ViewObjectDetails(IRSession session, string environmentExpression, string expression, string title);
-        Task ViewFile(string fileName, string tabName, bool deleteFile);
+        Task ViewFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken);
     }
 }

--- a/src/Host/Client/Impl/Definitions/IRCallbacks.cs
+++ b/src/Host/Client/Impl/Definitions/IRCallbacks.cs
@@ -77,7 +77,7 @@ namespace Microsoft.R.Host.Client {
         /// <summary>
         /// Invoked when R calls 'pager'
         /// </summary>
-        Task ShowFile(string fileName, string tabName, bool deleteFile);
+        Task ShowFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken);
 
         /// <summary>
         /// Called when working directory has changed in R.

--- a/src/Host/Client/Impl/Definitions/IRSessionCallback.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionCallback.cs
@@ -74,7 +74,7 @@ namespace Microsoft.R.Host.Client {
         /// <summary>
         /// Presents file content
         /// </summary>
-        Task ViewFile(string fileName, string tabName, bool deleteFile);
+        Task ViewFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Saves data to file sent from RHost.

--- a/src/Host/Client/Impl/Host/NullRCallbacks.cs
+++ b/src/Host/Client/Impl/Host/NullRCallbacks.cs
@@ -33,7 +33,7 @@ namespace Microsoft.R.Host.Client.Host {
         public Task PlotDeviceDestroy(Guid deviceId, CancellationToken ct) => Task.CompletedTask;
         public Task WebBrowser(string url, CancellationToken ct) => Task.CompletedTask;
         public Task ViewLibrary(CancellationToken cancellationToken) => Task.CompletedTask;
-        public Task ShowFile(string fileName, string tabName, bool deleteFile) => Task.CompletedTask;
+        public Task ShowFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) => Task.CompletedTask;
         public void DirectoryChanged() { }
         public void ViewObject(string expression, string title) { }
         public void PackagesInstalled() { }

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -149,62 +149,55 @@ namespace Microsoft.R.Host.Client {
 
         private void CancelAll() {
             var tcs = Volatile.Read(ref _cancelAllTcs);
-            if (tcs != null) {
-                Volatile.Write(ref _cancelAllCts, new CancellationTokenSource());
-                tcs.TrySetResult(true);
-            }
+            tcs?.TrySetResult(true);
         }
 
         private async Task ShowDialog(Message request, MessageButtons buttons, CancellationToken ct) {
             TaskUtilities.AssertIsOnBackgroundThread();
-            using (CancellationTokenUtilities.Link(ref ct, _cancelAllCts.Token)) {
-                request.ExpectArguments(2);
-                var contexts = GetContexts(request);
-                var s = request.GetString(1, "s", allowNull: true);
+            request.ExpectArguments(2);
+            var contexts = GetContexts(request);
+            var s = request.GetString(1, "s", allowNull: true);
 
-                MessageButtons input = await _callbacks.ShowDialog(contexts, s, buttons, ct);
-                ct.ThrowIfCancellationRequested();
+            MessageButtons input = await _callbacks.ShowDialog(contexts, s, buttons, ct);
+            ct.ThrowIfCancellationRequested();
 
-                string response;
-                switch (input) {
-                    case MessageButtons.No:
-                        response = "N";
-                        break;
-                    case MessageButtons.Cancel:
-                        response = "C";
-                        break;
-                    case MessageButtons.Yes:
-                        response = "Y";
-                        break;
-                    default: {
-                        FormattableString error = $"YesNoCancel: callback returned an invalid value: {input}";
-                        Trace.Fail(Invariant(error));
-                        throw new InvalidOperationException(Invariant(error));
-                    }
+            string response;
+            switch (input) {
+                case MessageButtons.No:
+                    response = "N";
+                    break;
+                case MessageButtons.Cancel:
+                    response = "C";
+                    break;
+                case MessageButtons.Yes:
+                    response = "Y";
+                    break;
+                default: {
+                    FormattableString error = $"YesNoCancel: callback returned an invalid value: {input}";
+                    Trace.Fail(Invariant(error));
+                    throw new InvalidOperationException(Invariant(error));
                 }
-
-                await RespondAsync(request, ct, response);
             }
+
+            await RespondAsync(request, ct, response);
         }
 
         private async Task ReadConsole(Message request, CancellationToken ct) {
             TaskUtilities.AssertIsOnBackgroundThread();
 
-            using (CancellationTokenUtilities.Link(ref ct, _cancelAllCts.Token)) {
-                request.ExpectArguments(5);
+            request.ExpectArguments(5);
 
-                var contexts = GetContexts(request);
-                var len = request.GetInt32(1, "len");
-                var addToHistory = request.GetBoolean(2, "addToHistory");
-                var retryReason = request.GetString(3, "retry_reason", allowNull: true);
-                var prompt = request.GetString(4, "prompt", allowNull: true);
+            var contexts = GetContexts(request);
+            var len = request.GetInt32(1, "len");
+            var addToHistory = request.GetBoolean(2, "addToHistory");
+            var retryReason = request.GetString(3, "retry_reason", allowNull: true);
+            var prompt = request.GetString(4, "prompt", allowNull: true);
 
-                string input = await _callbacks.ReadConsole(contexts, prompt, len, addToHistory, ct);
-                ct.ThrowIfCancellationRequested();
+            string input = await _callbacks.ReadConsole(contexts, prompt, len, addToHistory, ct);
+            ct.ThrowIfCancellationRequested();
 
-                input = input.Replace("\r\n", "\n");
-                await RespondAsync(request, ct, input);
-            }
+            input = input.Replace("\r\n", "\n");
+            await RespondAsync(request, ct, input);
         }
 
         public Task<ulong> CreateBlobAsync(CancellationToken cancellationToken) {
@@ -364,6 +357,8 @@ namespace Microsoft.R.Host.Client {
                 return;
             }
 
+            var cancellationRegistration = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+
             try {
                 // Cancel any pending callbacks
                 _cancelAllCts.Cancel();
@@ -380,6 +375,7 @@ namespace Microsoft.R.Host.Client {
 
                 await tcs.Task;
             } finally {
+                cancellationRegistration.Dispose();
                 Volatile.Write(ref _cancelAllTcs, null);
             }
         }
@@ -422,13 +418,14 @@ namespace Microsoft.R.Host.Client {
             }
         }
 
-        private async Task<Message> RunLoop(CancellationToken ct) {
+        private async Task<Message> RunLoop(CancellationToken loopCt) {
             TaskUtilities.AssertIsOnBackgroundThread();
-
+            var cancelAllCtsLink = CancellationTokenSource.CreateLinkedTokenSource(loopCt, _cancelAllCts.Token);
+            var ct = cancelAllCtsLink.Token;
             try {
                 _log.EnterRLoop(_rLoopDepth++);
-                while (!ct.IsCancellationRequested) {
-                    var message = await ReceiveMessageAsync(ct);
+                while (!loopCt.IsCancellationRequested) {
+                    var message = await ReceiveMessageAsync(loopCt);
                     if (message == null) {
                         return null;
                     } else if (message.IsResponse) {
@@ -512,7 +509,8 @@ namespace Microsoft.R.Host.Client {
                                 await _callbacks.ShowFile(
                                     message.GetString(0, "file"),
                                     message.GetString(1, "tabName"),
-                                    message.GetBoolean(2, "delete.file"));
+                                    message.GetBoolean(2, "delete.file"),
+                                    ct);
                                 break;
 
                             case "!View":
@@ -567,15 +565,28 @@ namespace Microsoft.R.Host.Client {
                             default:
                                 throw ProtocolError($"Unrecognized host message name:", message);
                         }
-                    } catch (OperationCanceledException) when (!ct.IsCancellationRequested) {
-                        // Canceled via _cancelAllCts - just move onto the next message.
+
+                        if (_cancelAllCts.IsCancellationRequested) {
+                            ct = UpdateCancelAllCtsLink(ref cancelAllCtsLink, loopCt);
+                        }
+                    } catch (OperationCanceledException) when (_cancelAllCts.IsCancellationRequested) {
+                        // Canceled via _cancelAllCts - update cancelAllCtsLink and move on
+                        ct = UpdateCancelAllCtsLink(ref cancelAllCtsLink, loopCt);
                     }
                 }
             } finally {
+                cancelAllCtsLink.Dispose();
                 _log.ExitRLoop(--_rLoopDepth);
             }
 
             return null;
+        }
+
+        private CancellationToken UpdateCancelAllCtsLink(ref CancellationTokenSource cancelAllCtsLink, CancellationToken loopCt) {
+            cancelAllCtsLink.Dispose();
+            Interlocked.Exchange(ref _cancelAllCts, new CancellationTokenSource());
+            cancelAllCtsLink = CancellationTokenSource.CreateLinkedTokenSource(loopCt, _cancelAllCts.Token);
+            return cancelAllCtsLink.Token;
         }
 
         private async Task RunWorker(CancellationToken ct) {

--- a/src/Host/Client/Impl/Program.cs
+++ b/src/Host/Client/Impl/Program.cs
@@ -125,7 +125,7 @@ namespace Microsoft.R.Host.Client {
             await Console.Error.WriteLineAsync("ViewLibrary");
         }
 
-        public async Task ShowFile(string fileName, string tabName, bool deleteFile) {
+        public async Task ShowFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) {
             await Console.Error.WriteAsync(Invariant($"ShowFile({fileName}, {tabName}, {deleteFile})"));
         }
 

--- a/src/Host/Client/Test/Script/RHostClientTestApp.cs
+++ b/src/Host/Client/Test/Script/RHostClientTestApp.cs
@@ -50,7 +50,7 @@ namespace Microsoft.R.Host.Client.Test.Script {
             return Task.CompletedTask;
         }
 
-        public Task ViewFile(string fileName, string tabName, bool deleteFile) {
+        public Task ViewFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) {
             return Task.CompletedTask;
         }
 

--- a/src/Host/Client/Test/Session/RSessionTest.CancelAll.cs
+++ b/src/Host/Client/Test/Session/RSessionTest.CancelAll.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Common.Core.Threading;
 using Microsoft.R.Host.Client.Host;
 using Microsoft.R.Host.Client.Session;
+using Microsoft.R.Host.Client.Test.Stubs;
+using Microsoft.UnitTests.Core.FluentAssertions;
 using Microsoft.UnitTests.Core.Threading;
 using Microsoft.UnitTests.Core.XUnit;
 using Microsoft.UnitTests.Core.XUnit.MethodFixtures;
@@ -19,18 +22,20 @@ namespace Microsoft.R.Host.Client.Test.Session {
             private readonly MethodInfo _testMethod;
             private readonly IBrokerClient _brokerClient;
             private readonly RSession _session;
+            private readonly RSessionCallbackStub _callback;
 
             public CancelAll(TestMethodFixture testMethod, TaskObserverMethodFixture taskObserver) {
                 _taskObserver = taskObserver;
                 _testMethod = testMethod.MethodInfo;
                 _brokerClient = CreateLocalBrokerClient(nameof(RSessionTest) + nameof(CancelAll));
+                _callback = new RSessionCallbackStub();
                 _session = new RSession(0, _brokerClient, new AsyncReaderWriterLock().CreateExclusiveReaderLock(), () => {});
             }
 
             public async Task InitializeAsync() {
                 await _session.StartHostAsync(new RHostStartupInfo {
                     Name = _testMethod.Name
-                }, null, 50000);
+                }, _callback, 50000);
 
                 _taskObserver.ObserveTaskFailure(_session.RHost.GetRHostRunTask());
             }
@@ -53,6 +58,60 @@ namespace Microsoft.R.Host.Client.Test.Session {
 
                 _session.IsHostRunning.Should().BeTrue();
                 responceTask.Status.Should().Be(TaskStatus.Canceled);
+            }
+
+            [Test]
+            [Category.R.Session]
+            public async Task CancelAll_HandingLoop() {
+                var testMrs = new AsyncManualResetEvent();
+                var plotMrs = new AsyncManualResetEvent();
+                _callback.PlotHandler = (message, ct) => {
+                    testMrs.Set();
+                    return plotMrs.WaitAsync(ct);
+                };
+
+                Task responceTask;
+                using (var interaction = await _session.BeginInteractionAsync()) {
+                    responceTask = interaction.RespondAsync("plot(1)\n");
+                }
+
+                await testMrs.WaitAsync().Should().BeCompletedAsync();
+
+                await _session.CancelAllAsync().Should().BeCompletedAsync();
+
+                _session.IsHostRunning.Should().BeTrue();
+                responceTask.Should().BeCanceled();
+            }
+
+            [Test]
+            [Category.R.Session]
+            public async Task CancelAll_Cancel() {
+                var testMrs = new AsyncManualResetEvent();
+                var plotMrs = new AsyncManualResetEvent();
+                _callback.PlotHandler = (message, ct) => {
+                    testMrs.Set();
+                    // ct is ignored on purpose
+                    return plotMrs.WaitAsync();
+                };
+
+                var cancelAllCts = new CancellationTokenSource();
+                Task responceTask;
+                using (var interaction = await _session.BeginInteractionAsync()) {
+                    responceTask = interaction.RespondAsync("plot(1)\n");
+                }
+
+                await testMrs.WaitAsync().Should().BeCompletedAsync();
+                var cancelAllAsyncTask = _session.CancelAllAsync(cancelAllCts.Token);
+
+                await cancelAllAsyncTask.Should().NotBeCompletedAsync();
+
+                cancelAllCts.Cancel();
+                await cancelAllAsyncTask.Should().BeCanceledAsync();
+
+                _session.IsHostRunning.Should().BeTrue();
+                plotMrs.Set();
+
+                await responceTask.Should().BeCanceledAsync();
             }
         }
     }

--- a/src/Host/Client/Test/Session/RSessionTest.CancelAll.cs
+++ b/src/Host/Client/Test/Session/RSessionTest.CancelAll.cs
@@ -62,7 +62,7 @@ namespace Microsoft.R.Host.Client.Test.Session {
 
             [Test]
             [Category.R.Session]
-            public async Task CancelAll_HandingLoop() {
+            public async Task CancelAll_HangingLoop() {
                 var testMrs = new AsyncManualResetEvent();
                 var plotMrs = new AsyncManualResetEvent();
                 _callback.PlotHandler = (message, ct) => {

--- a/src/Host/Client/Test/Stubs/RSessionCallbackStub.cs
+++ b/src/Host/Client/Test/Stubs/RSessionCallbackStub.cs
@@ -27,6 +27,7 @@ namespace Microsoft.R.Host.Client.Test.Stubs {
             (m, b) => Task.FromResult(b.HasFlag(MessageButtons.Yes) ? MessageButtons.Yes : MessageButtons.OK);
 
         public Func<string, int, CancellationToken, Task<string>> ReadUserInputHandler { get; set; } = (m, l, ct) => Task.FromResult("\n");
+        public Func<PlotMessage, CancellationToken, Task> PlotHandler { get; set; } = (deviceId, ct) => Task.CompletedTask;
         public Func<Guid, CancellationToken, Task<LocatorResult>> LocatorHandler { get; set; } = (deviceId, ct) => Task.FromResult(LocatorResult.CreateNotClicked());
         public Func<Guid, CancellationToken, Task<PlotDeviceProperties>> PlotDeviceCreateHandler { get; set; } = (deviceId, ct) => Task.FromResult(PlotDeviceProperties.Default);
         public Func<Guid, CancellationToken, Task> PlotDeviceDestroyHandler { get; set; } = (deviceId, ct) => Task.CompletedTask;
@@ -54,7 +55,7 @@ namespace Microsoft.R.Host.Client.Test.Stubs {
 
         public Task Plot(PlotMessage plot, CancellationToken ct) {
             PlotCalls.Add(new Tuple<PlotMessage, CancellationToken>(plot, ct));
-            return Task.CompletedTask;
+            return PlotHandler != null ? PlotHandler(plot, ct) : Task.CompletedTask;
         }
 
         public Task<LocatorResult> Locator(Guid deviceId, CancellationToken ct) {
@@ -93,7 +94,7 @@ namespace Microsoft.R.Host.Client.Test.Stubs {
             return Task.CompletedTask;
         }
 
-        public Task ViewFile(string fileName, string tabName, bool deleteFile) {
+        public Task ViewFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) {
             ShowFileCalls.Add(new Tuple<string, string, bool>(fileName, tabName, deleteFile));
             ShowFileHandler?.Invoke(fileName, tabName, deleteFile);
             return Task.CompletedTask;

--- a/src/Package/Impl/DataInspect/Viewers/ObjectDetailsViewerProvider.cs
+++ b/src/Package/Impl/DataInspect/Viewers/ObjectDetailsViewerProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel.Composition;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.Common.Core.Shell;
@@ -28,8 +29,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
             }
         }
 
-        public async Task ViewFile(string fileName, string tabName, bool deleteFile) {
-            await VsAppShell.Current.SwitchToMainThreadAsync();
+        public async Task ViewFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) {
+            await VsAppShell.Current.SwitchToMainThreadAsync(cancellationToken);
 
             FileViewer.ViewFile(fileName, tabName);
             try {

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RSessionCallback.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RSessionCallback.cs
@@ -105,9 +105,9 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             _workflow.Packages.GetOrCreateVisualComponent(containerFactory).Container.Show(focus: true, immediate: false);
         }
 
-        public Task ViewFile(string fileName, string tabName, bool deleteFile) {
+        public Task ViewFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken = default(CancellationToken)) {
             var viewer = _coreShell.ExportProvider.GetExportedValue<IObjectViewer>();
-            return viewer?.ViewFile(fileName, tabName, deleteFile);
+            return viewer?.ViewFile(fileName, tabName, deleteFile, cancellationToken);
         }
 
         public Task<string> SaveFileAsync(string filename, byte[] data) {

--- a/src/R/Components/Impl/Plots/IRPlotDeviceVisualComponent.cs
+++ b/src/R/Components/Impl/Plots/IRPlotDeviceVisualComponent.cs
@@ -10,8 +10,8 @@ using Microsoft.R.Host.Client;
 namespace Microsoft.R.Components.Plots {
     public interface IRPlotDeviceVisualComponent : IVisualComponent {
         PlotDeviceProperties GetDeviceProperties();
-        Task AssignAsync(IRPlotDevice device);
-        Task UnassignAsync();
+        void Assign(IRPlotDevice device);
+        void Unassign();
         int InstanceId { get; }
         bool HasPlot { get; }
         bool LocatorMode { get; }

--- a/src/R/Components/Impl/Plots/Implementation/RPlotDeviceVisualComponent.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotDeviceVisualComponent.cs
@@ -125,13 +125,13 @@ namespace Microsoft.R.Components.Plots.Implementation {
             }
         }
 
-        public async Task AssignAsync(IRPlotDevice device) {
-            await _viewModel.AssignAsync(device);
+        public void Assign(IRPlotDevice device) {
+            _viewModel.Assign(device);
             Container.UpdateCommandStatus(false);
         }
 
-        public async Task UnassignAsync() {
-            await _viewModel.UnassignAsync();
+        public void Unassign() {
+             _viewModel.Unassign();
             Container.UpdateCommandStatus(false);
         }
 

--- a/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
@@ -113,7 +113,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
 
             IRPlotDeviceVisualComponent component;
             if (_assignedVisualComponents.TryGetValue(deviceId, out component)) {
-                await component.UnassignAsync();
+                component.Unassign();
                 _assignedVisualComponents.Remove(deviceId);
                 _unassignedVisualComponents.Add(component);
             } else {
@@ -148,7 +148,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
                 device.AddOrUpdate(plot.PlotId, null);
             }
 
-            var visualComponent = await GetVisualComponentForDevice(plot.DeviceId);
+            var visualComponent = GetVisualComponentForDevice(plot.DeviceId);
             if (visualComponent != null) {
                 visualComponent.Container.Show(focus: false, immediate: false);
                 visualComponent.Container.UpdateCommandStatus(false);
@@ -163,7 +163,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
 
             PlotDeviceProperties props;
 
-            var visualComponent = await GetVisualComponentForDevice(deviceId);
+            var visualComponent = GetVisualComponentForDevice(deviceId);
             if (visualComponent != null) {
                 visualComponent.Container.Show(focus: false, immediate: true);
                 props = visualComponent.GetDeviceProperties();
@@ -184,7 +184,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
         public async Task<LocatorResult> StartLocatorModeAsync(Guid deviceId, CancellationToken cancellationToken) {
             await _shell.SwitchToMainThreadAsync(cancellationToken);
 
-            var visualComponent = await GetVisualComponentForDevice(deviceId);
+            var visualComponent = GetVisualComponentForDevice(deviceId);
             if (visualComponent == null) {
                 return default(LocatorResult);
             }
@@ -307,7 +307,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
 
                     // Removing that plot may activate the device from the removed plot,
                     // which would hide this device. So we re-show it.
-                    await ShowDeviceAsync(targetDevice);
+                    ShowDevice(targetDevice);
                 }
             }
         }
@@ -334,13 +334,11 @@ namespace Microsoft.R.Components.Plots.Implementation {
             }
         }
 
-        private async Task ShowDeviceAsync(IRPlotDevice device) {
+        private void ShowDevice(IRPlotDevice device) {
             InteractiveWorkflow.Shell.AssertIsOnMainThread();
 
-            var visualComponent = await GetVisualComponentForDevice(device.DeviceId);
-            if (visualComponent != null) {
-                visualComponent.Container.Show(focus: false, immediate: false);
-            }
+            var visualComponent = GetVisualComponentForDevice(device.DeviceId);
+            visualComponent?.Container.Show(focus: false, immediate: false);
         }
 
         private async Task ExportAsync(string outputFilePath, Task<ulong> exportTask) {
@@ -356,7 +354,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
             }
         }
 
-        private async Task<IRPlotDeviceVisualComponent> GetVisualComponentForDevice(Guid deviceId) {
+        private IRPlotDeviceVisualComponent GetVisualComponentForDevice(Guid deviceId) {
             InteractiveWorkflow.Shell.AssertIsOnMainThread();
 
             // If we've already assigned a plot window, reuse it
@@ -369,7 +367,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
             component = GetOrCreatePlotDeviceVisualComponent();
 
             var device = FindDevice(deviceId);
-            await component.AssignAsync(device);
+            component.Assign(device);
 
             _assignedVisualComponents[deviceId] = component;
 
@@ -520,7 +518,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
             RemoveAllDevices();
 
             foreach (var visualComponent in _assignedVisualComponents.Values) {
-                await visualComponent.UnassignAsync();
+                visualComponent.Unassign();
                 _unassignedVisualComponents.Add(visualComponent);
             }
             _assignedVisualComponents.Clear();

--- a/src/R/Components/Impl/Plots/Implementation/ViewModel/RPlotDeviceViewModel.cs
+++ b/src/R/Components/Impl/Plots/Implementation/ViewModel/RPlotDeviceViewModel.cs
@@ -85,7 +85,7 @@ namespace Microsoft.R.Components.Plots.Implementation.ViewModel {
             get { return _device != null && _device == _plotManager.ActiveDevice; }
         }
 
-        public Task AssignAsync(IRPlotDevice device) {
+        public void Assign(IRPlotDevice device) {
             _shell.AssertIsOnMainThread();
 
             _device = device;
@@ -94,11 +94,9 @@ namespace Microsoft.R.Components.Plots.Implementation.ViewModel {
             _device.DeviceNumChanged += DeviceNumChanged;
 
             Refresh(_device.ActivePlot);
-
-            return Task.CompletedTask;
         }
 
-        public Task UnassignAsync() {
+        public void Unassign() {
             _shell.AssertIsOnMainThread();
 
             if (_device != null) {
@@ -109,8 +107,6 @@ namespace Microsoft.R.Components.Plots.Implementation.ViewModel {
 
             _device = null;
             Refresh(null);
-
-            return Task.CompletedTask;
         }
 
         public async Task ResizePlotAsync(int pixelWidth, int pixelHeight, int resolution) {

--- a/src/R/Components/Impl/Plots/ViewModel/IRPlotDeviceViewModel.cs
+++ b/src/R/Components/Impl/Plots/ViewModel/IRPlotDeviceViewModel.cs
@@ -67,12 +67,12 @@ namespace Microsoft.R.Components.Plots.ViewModel {
         /// Initialize this view model for the specified device.
         /// </summary>
         /// <param name="device">Device to set.</param>
-        Task AssignAsync(IRPlotDevice device);
+        void Assign(IRPlotDevice device);
 
         /// <summary>
         /// Cleanup this view model so it can be reused later for a different device.
         /// </summary>
-        Task UnassignAsync();
+        void Unassign();
 
         /// <summary>
         /// Resize the plot.


### PR DESCRIPTION
- `_cancelAllCts` now affects all requests in the loop
- `CompleteSwitchingBrokerAsync` waits for cancellation only 10 seconds, after that host will be terminated
- `RHost.CancelAllAsync` can be canceled even when message loop is stuck
- Couple of tests added