### PR TITLE
- Fix #2825: Vefiry all SwitchToMainThreadAsync calls for CancellationToken usage

### DIFF
--- a/src/Host/Client/Impl/Definitions/IConsole.cs
+++ b/src/Host/Client/Impl/Definitions/IConsole.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Client {
     public interface IConsole {
         void Write(string text);
-        Task<bool> PromptYesNoAsync(string text);
+        Task<bool> PromptYesNoAsync(string text, CancellationToken cancellationToken);
     }
 }

--- a/src/Host/Client/Impl/Definitions/IObjectViewer.cs
+++ b/src/Host/Client/Impl/Definitions/IObjectViewer.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Client {
     public interface IObjectViewer {
-        Task ViewObjectDetails(IRSession session, string environmentExpression, string expression, string title);
+        Task ViewObjectDetails(IRSession session, string environmentExpression, string expression, string title, CancellationToken cancellationToken = default(CancellationToken));
         Task ViewFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken);
     }
 }

--- a/src/Host/Client/Impl/Definitions/IRCallbacks.cs
+++ b/src/Host/Client/Impl/Definitions/IRCallbacks.cs
@@ -88,7 +88,7 @@ namespace Microsoft.R.Host.Client {
         /// Called when used invoked View(obj) in R.
         /// </summary>
         /// <returns></returns>
-        void ViewObject(string expression, string title);
+        Task ViewObject(string expression, string title, CancellationToken cancellationToken);
 
         void PackagesInstalled();
         void PackagesRemoved();

--- a/src/Host/Client/Impl/Definitions/IRSessionCallback.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionCallback.cs
@@ -63,7 +63,7 @@ namespace Microsoft.R.Host.Client {
         /// Opens viewer for the given object
         /// </summary>
         /// <returns></returns>
-        void ViewObject(string expression, string title);
+        Task ViewObjectAsync(string expression, string title, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Present package list or package manager

--- a/src/Host/Client/Impl/Host/BrokerClient.cs
+++ b/src/Host/Client/Impl/Host/BrokerClient.cs
@@ -102,7 +102,7 @@ namespace Microsoft.R.Host.Client.Host {
             try {
                 var sessionExists = connectionInfo.PreserveSessionData && await IsSessionRunningAsync(connectionInfo.Name, cancellationToken);
                 if (sessionExists) {
-                    var terminateRDataSave = await _console.PromptYesNoAsync(Resources.AbortRDataAutosave);
+                    var terminateRDataSave = await _console.PromptYesNoAsync(Resources.AbortRDataAutosave, cancellationToken);
                     if (!terminateRDataSave) {
                         while (await IsSessionRunningAsync(connectionInfo.Name, cancellationToken)) {
                             await Task.Delay(500, cancellationToken);

--- a/src/Host/Client/Impl/Host/NullRCallbacks.cs
+++ b/src/Host/Client/Impl/Host/NullRCallbacks.cs
@@ -35,7 +35,7 @@ namespace Microsoft.R.Host.Client.Host {
         public Task ViewLibrary(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task ShowFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) => Task.CompletedTask;
         public void DirectoryChanged() { }
-        public void ViewObject(string expression, string title) { }
+        public Task ViewObject(string expression, string title, CancellationToken cancellationToken) => Task.CompletedTask;
         public void PackagesInstalled() { }
         public void PackagesRemoved() {}
         public Task<string> SaveFileAsync(string filename, byte[] data) => Task.FromResult(filename);

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -514,7 +514,7 @@ namespace Microsoft.R.Host.Client {
 
                             case "!View":
                                 message.ExpectArguments(2);
-                                _callbacks.ViewObject(message.GetString(0, "x"), message.GetString(1, "title"));
+                                await _callbacks.ViewObject(message.GetString(0, "x"), message.GetString(1, "title"), ct);
                                 break;
 
                             case "!Plot":
@@ -574,6 +574,8 @@ namespace Microsoft.R.Host.Client {
                     }
                 }
             } finally {
+                // asyncronously-running handlers like ReadConsole and ShowDialog that were started in the loop should be canceled
+                cancelAllCtsLink.Cancel();
                 cancelAllCtsLink.Dispose();
                 _log.ExitRLoop(--_rLoopDepth);
             }

--- a/src/Host/Client/Impl/Program.cs
+++ b/src/Host/Client/Impl/Program.cs
@@ -109,25 +109,20 @@ namespace Microsoft.R.Host.Client {
             await Console.Error.WriteLineAsync(plot.FilePath);
         }
 
-        public async Task WebBrowser(string url, CancellationToken ct) {
-            await Console.Error.WriteLineAsync("Browser: " + url);
-        }
+        public async Task WebBrowser(string url, CancellationToken ct) 
+            => await Console.Error.WriteLineAsync("Browser: " + url);
 
-        public async void DirectoryChanged() {
-            await Console.Error.WriteLineAsync("Directory changed.");
-        }
+        public async void DirectoryChanged() 
+            => await Console.Error.WriteLineAsync("Directory changed.");
 
-        public void ViewObject(string x, string title) {
-            Console.Error.WriteLineAsync(Invariant($"ViewObject({title}): {x}"));
-        }
+        public Task ViewObject(string x, string title, CancellationToken cancellationToken) 
+            => Console.Error.WriteLineAsync(Invariant($"ViewObjectAsync({title}): {x}"));
 
-        public async Task ViewLibrary(CancellationToken cancellationToken) {
-            await Console.Error.WriteLineAsync("ViewLibrary");
-        }
+        public async Task ViewLibrary(CancellationToken cancellationToken) 
+            => await Console.Error.WriteLineAsync("ViewLibrary");
 
-        public async Task ShowFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) {
-            await Console.Error.WriteAsync(Invariant($"ShowFile({fileName}, {tabName}, {deleteFile})"));
-        }
+        public async Task ShowFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) 
+            => await Console.Error.WriteAsync(Invariant($"ShowFile({fileName}, {tabName}, {deleteFile})"));
 
         public void PackagesInstalled() {
             Console.Error.WriteLineAsync("PackagesInstalled").DoNotWait();

--- a/src/Host/Client/Impl/Session/NullConsole.cs
+++ b/src/Host/Client/Impl/Session/NullConsole.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.R.Host.Client.Session {
     internal class NullConsole : IConsole {
         public void Write(string text) {}
-        public Task<bool> PromptYesNoAsync(string text) => Task.FromResult(true);
+        public Task<bool> PromptYesNoAsync(string text, CancellationToken cancellationToken) => Task.FromResult(true);
     }
 }

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -736,9 +736,9 @@ if (rtvs:::version != {rtvsPackageVersion}) {{
             DirectoryChanged?.Invoke(this, EventArgs.Empty);
         }
 
-        void IRCallbacks.ViewObject(string obj, string title) {
+        Task IRCallbacks.ViewObject(string obj, string title, CancellationToken cancellationToken) {
             var callback = _callback;
-            callback?.ViewObject(obj, title);
+            return callback?.ViewObjectAsync(obj, title, cancellationToken) ?? Task.CompletedTask;
         }
 
         void IRCallbacks.PackagesInstalled() {

--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -17,8 +17,8 @@ namespace Microsoft.R.Host.Client.Session {
         public static Task QuitAsync(this IRExpressionEvaluator eval) =>
             eval.ExecuteAsync("q()", REvaluationKind.Normal);
 
-        public static async Task<string> GetRUserDirectoryAsync(this IRExpressionEvaluator evaluation) {
-            var result = await evaluation.EvaluateAsync<string>("Sys.getenv('R_USER')", REvaluationKind.Normal);
+        public static async Task<string> GetRUserDirectoryAsync(this IRExpressionEvaluator evaluation, CancellationToken cancellationToken = default(CancellationToken)) {
+            var result = await evaluation.EvaluateAsync<string>("Sys.getenv('R_USER')", REvaluationKind.Normal, cancellationToken);
             return result.Replace('/', '\\');
         }
 
@@ -162,14 +162,14 @@ grDevices::deviceIsInteractive('ide')
             return evaluation.EvaluateAsync<JArray>(script, REvaluationKind.Reentrant);
         }
 
-        public static Task<JArray> LoadedPackagesAsync(this IRExpressionEvaluator evaluation) {
+        public static Task<JArray> LoadedPackagesAsync(this IRExpressionEvaluator evaluation, CancellationToken cancellationToken = default(CancellationToken)) {
             var script = @"rtvs:::packages.loaded()";
-            return evaluation.EvaluateAsync<JArray>(script, REvaluationKind.Normal);
+            return evaluation.EvaluateAsync<JArray>(script, REvaluationKind.Normal, cancellationToken);
         }
 
-        public static Task<string[]> LibraryPathsAsync(this IRExpressionEvaluator evaluation) {
+        public static Task<string[]> LibraryPathsAsync(this IRExpressionEvaluator evaluation, CancellationToken cancellationToken = default(CancellationToken)) {
             var script = @"rtvs:::packages.libpaths()";
-            return evaluation.EvaluateAsync<string[]>(script, REvaluationKind.Normal);
+            return evaluation.EvaluateAsync<string[]>(script, REvaluationKind.Normal, cancellationToken);
         }
         public static Task<ulong> ExportPlotToBitmapAsync(this IRExpressionEvaluator evaluation, Guid deviceId, Guid plotId, string deviceName, string outputFilePath, int widthInPixels, int heightInPixels, int resolution) {
             string script = Invariant($"rtvs:::export_to_image({deviceId.ToString().ToRStringLiteral()}, {plotId.ToString().ToRStringLiteral()}, {deviceName}, {widthInPixels}, {heightInPixels}, {resolution})");

--- a/src/Host/Client/Impl/Session/RSessionExtensions.cs
+++ b/src/Host/Client/Impl/Session/RSessionExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.IO;
@@ -24,29 +25,28 @@ namespace Microsoft.R.Host.Client.Session {
             return null;
         }
 
-        public static async Task<string> GetRUserDirectoryAsync(this IRSession session) {
+        public static async Task<string> GetRUserDirectoryAsync(this IRSession session, CancellationToken cancellationToken = default(CancellationToken)) {
             if (session.IsHostRunning) {
                 await TaskUtilities.SwitchToBackgroundThread();
                 try {
-                    return await RSessionEvaluationCommands.GetRUserDirectoryAsync(session);
+                    return await RSessionEvaluationCommands.GetRUserDirectoryAsync(session, cancellationToken);
                 } catch (RException) {
                 } catch (OperationCanceledException) { }
             }
             return null;
         }
 
-        public static async Task<string> MakeRelativeToRUserDirectoryAsync(this IRSession session, string name) {
-            var userDirectory = await session.GetRUserDirectoryAsync();
+        public static async Task<string> MakeRelativeToRUserDirectoryAsync(this IRSession session, string name, CancellationToken cancellationToken = default(CancellationToken)) {
+            var userDirectory = await session.GetRUserDirectoryAsync(cancellationToken);
             return name.MakeRRelativePath(userDirectory);
         }
 
-        public static async Task<IEnumerable<string>> MakeRelativeToRUserDirectoryAsync(this IRSession session, IEnumerable<string> names) {
-            var userDirectory = await session.GetRUserDirectoryAsync();
+        public static async Task<IEnumerable<string>> MakeRelativeToRUserDirectoryAsync(this IRSession session, IEnumerable<string> names, CancellationToken cancellationToken = default(CancellationToken)) {
+            var userDirectory = await session.GetRUserDirectoryAsync(cancellationToken);
             return names.Select(n => n.MakeRRelativePath(userDirectory));
         }
 
-        public static Task<string> GetFunctionCodeAsync(this IRSession session, string functionName) {
-            return session.EvaluateAsync<string>(Invariant($"paste0(deparse({functionName}), collapse='\n')"), REvaluationKind.Normal);
-        }
+        public static Task<string> GetFunctionCodeAsync(this IRSession session, string functionName, CancellationToken cancellationToken = default(CancellationToken)) 
+            => session.EvaluateAsync<string>(Invariant($"paste0(deparse({functionName}), collapse='\n')"), REvaluationKind.Normal, cancellationToken);
     }
 }

--- a/src/Host/Client/Test/Script/RHostClientTestApp.cs
+++ b/src/Host/Client/Test/Script/RHostClientTestApp.cs
@@ -44,11 +44,9 @@ namespace Microsoft.R.Host.Client.Test.Script {
             return Task.FromResult("\n");
         }
 
-        public void ViewObject(string expression, string title) { }
+        public Task ViewObjectAsync(string expression, string title, CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task ViewLibraryAsync(CancellationToken cancellationToken) {
-            return Task.CompletedTask;
-        }
+        public Task ViewLibraryAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task ViewFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) {
             return Task.CompletedTask;

--- a/src/Host/Client/Test/Session/RSessionTest.InteractionEvaluation.cs
+++ b/src/Host/Client/Test/Session/RSessionTest.InteractionEvaluation.cs
@@ -166,6 +166,18 @@ namespace Microsoft.R.Host.Client.Test.Session {
                 cts.CancelAfter(100);
                 await assertion;
             } 
+            
+            [Test]
+            public async Task EvaluateAsync_Stop_Start_EvaluateAsync() {
+                await _session.EvaluateAsync("x <- 1").Should().BeCompletedAsync();
+
+                await _session.StopHostAsync().Should().BeCompletedAsync();
+                await _session.StartHostAsync(new RHostStartupInfo {
+                    Name = _testMethod.Name
+                }, null, 10000).Should().BeCompletedAsync();
+
+                await _session.EvaluateAsync("x <- 1").Should().BeCompletedAsync();
+            }
 
             [Test]
             public async Task BeginEvaluationAsync_DisconnectedFromTheStart() {

--- a/src/Host/Client/Test/Stubs/RSessionCallbackStub.cs
+++ b/src/Host/Client/Test/Stubs/RSessionCallbackStub.cs
@@ -83,9 +83,10 @@ namespace Microsoft.R.Host.Client.Test.Stubs {
             return CranUrlFromNameHandler != null ? CranUrlFromNameHandler(name) : string.Empty;
         }
 
-        public void ViewObject(string expression, string title) {
+        public Task ViewObjectAsync(string expression, string title, CancellationToken cancellationToken) {
             ViewObjectCalls.Add(new Tuple<string, string>(expression, title));
             ViewObjectHandler?.Invoke(expression, title);
+            return Task.CompletedTask;
         }
 
         public Task ViewLibraryAsync(CancellationToken cancellationToken) {

--- a/src/Languages/Editor/Test/Shell/TestEditorShell.cs
+++ b/src/Languages/Editor/Test/Shell/TestEditorShell.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Languages.Editor.Test.Shell {
     internal sealed class TestEditorShell : TestShellBase, IEditorShell {
         private static TestEditorShell _instance;
 
-        private TestEditorShell(ICompositionCatalog catalog) {
+        private TestEditorShell(ICompositionCatalog catalog, Thread mainThread) {
             CompositionService = catalog.CompositionService;
             ExportProvider = catalog.ExportProvider;
-            MainThread = Thread.CurrentThread;
+            MainThread = mainThread;
         }
 
         /// <summary>
@@ -32,10 +32,8 @@ namespace Microsoft.Languages.Editor.Test.Shell {
             // Called via reflection in test cases. Creates instance
             // of the test shell that editor code can access during
             // test run.
-            UIThreadHelper.Instance.Invoke(() => {
-                _instance = new TestEditorShell(EditorTestCompositionCatalog.Current);
-                EditorShell.Current = (IEditorShell)(object)_instance;
-            });
+            _instance = new TestEditorShell(EditorTestCompositionCatalog.Current, UIThreadHelper.Instance.Thread);
+            EditorShell.Current = _instance;
         }
 
         #region ICompositionCatalog

--- a/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml.cs
+++ b/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml.cs
@@ -141,10 +141,10 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
             FilePathBox.ScrollToEnd();
 
             VariableNameBox.Text = name ?? Path.GetFileNameWithoutExtension(filePath);
-            PreviewContent();
+            PreviewContentAsync().DoNotWait();
         }
 
-        private async void PreviewContent() {
+        private async Task PreviewContentAsync() {
             if (string.IsNullOrEmpty(FilePathBox.Text)) {
                 return;
             }
@@ -244,11 +244,11 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
         }
 
         private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e) {
-            PreviewContent();
+            PreviewContentAsync().DoNotWait();
         }
 
         private void HeaderCheckBox_Changed(object sender, RoutedEventArgs e) {
-            PreviewContent();
+            PreviewContentAsync().DoNotWait();
         }
 
         private void PreviewFileContent(string file, int codePage) {

--- a/src/Package/Impl/DataInspect/Definitions/IDebugObjectEvaluator.cs
+++ b/src/Package/Impl/DataInspect/Definitions/IDebugObjectEvaluator.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.R.DataInspection;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect {
     public interface IDataObjectEvaluator {
-       Task<IREvaluationResultInfo> EvaluateAsync(string expression, REvaluationResultProperties fields, string repr);
+       Task<IREvaluationResultInfo> EvaluateAsync(string expression, REvaluationResultProperties fields, string repr, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Package/Impl/DataInspect/Definitions/IObjectDetailsViewer.cs
+++ b/src/Package/Impl/DataInspect/Definitions/IObjectDetailsViewer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.R.DataInspection;
 
@@ -10,6 +11,6 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         bool CanView(IRValueInfo evaluation);
 
-        Task ViewAsync(string expression, string title);
+        Task ViewAsync(string expression, string title, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Package/Impl/DataInspect/Definitions/ObjectDetailsViewerAggregatorExtensions.cs
+++ b/src/Package/Impl/DataInspect/Definitions/ObjectDetailsViewerAggregatorExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.R.DataInspection;
 using Microsoft.R.Host.Client;
@@ -8,8 +9,8 @@ using static Microsoft.R.DataInspection.REvaluationResultProperties;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect {
     public static class ObjectDetailsViewerAggregatorExtensions {
-        public static async Task<IObjectDetailsViewer> GetViewer(this IObjectDetailsViewerAggregator aggregator, IRSession session, string environmentExpression, string expression) {
-            var preliminary = await session.TryEvaluateAndDescribeAsync(expression, TypeNameProperty | ClassesProperty | DimProperty | LengthProperty, null) as IRValueInfo;
+        public static async Task<IObjectDetailsViewer> GetViewer(this IObjectDetailsViewerAggregator aggregator, IRSession session, string environmentExpression, string expression, CancellationToken cancellationToken = default(CancellationToken)) {
+            var preliminary = await session.TryEvaluateAndDescribeAsync(expression, TypeNameProperty | ClassesProperty | DimProperty | LengthProperty, null, cancellationToken) as IRValueInfo;
             return preliminary != null ? aggregator.GetViewer(preliminary) : null;
         }
     }

--- a/src/Package/Impl/DataInspect/Viewers/GridViewerBase.cs
+++ b/src/Package/Impl/DataInspect/Viewers/GridViewerBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.Common.Core.Shell;
@@ -29,12 +30,12 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
         #region IObjectDetailsViewer
         public ViewerCapabilities Capabilities => ViewerCapabilities.List | ViewerCapabilities.Table;
 
-        abstract public bool CanView(IRValueInfo evaluation);
+        public abstract bool CanView(IRValueInfo evaluation);
 
-        public async Task ViewAsync(string expression, string title) {
-            var evaluation = await EvaluateAsync(expression, _properties, RValueRepresentations.Str()) as IRValueInfo;
+        public async Task ViewAsync(string expression, string title, CancellationToken cancellationToken = default(CancellationToken)) {
+            var evaluation = await EvaluateAsync(expression, _properties, RValueRepresentations.Str(), cancellationToken);
             if (evaluation != null) {
-                await VsAppShell.Current.SwitchToMainThreadAsync();
+                await VsAppShell.Current.SwitchToMainThreadAsync(cancellationToken);
                 var id = Math.Abs(_toolWindowIdBase + expression.GetHashCode() % (Int32.MaxValue - _toolWindowIdBase));
 
                 var existingPane = ToolWindowUtilities.FindWindowPane<VariableGridWindowPane>(id);

--- a/src/Package/Impl/DataInspect/Viewers/ObjectDetailsViewerProvider.cs
+++ b/src/Package/Impl/DataInspect/Viewers/ObjectDetailsViewerProvider.cs
@@ -22,10 +22,10 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
             _aggregator = aggregator;
         }
 
-        public async Task ViewObjectDetails(IRSession session, string environmentExpression, string expression, string title) {
-            var viewer = await _aggregator.GetViewer(session, environmentExpression, expression);
+        public async Task ViewObjectDetails(IRSession session, string environmentExpression, string expression, string title, CancellationToken cancellationToken) {
+            var viewer = await _aggregator.GetViewer(session, environmentExpression, expression, cancellationToken);
             if (viewer != null) {
-                await viewer?.ViewAsync(expression, title);
+                await viewer.ViewAsync(expression, title, cancellationToken);
             }
         }
 

--- a/src/Package/Impl/DataInspect/Viewers/ViewerBase.cs
+++ b/src/Package/Impl/DataInspect/Viewers/ViewerBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core.Shell;
 using Microsoft.R.DataInspection;
@@ -14,11 +15,11 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
              Evaluator = evaluator;
         }
 
-        protected async Task<IRValueInfo> EvaluateAsync(string expression, REvaluationResultProperties fields, string repr) {
-            var result = await Evaluator.EvaluateAsync(expression, fields, repr);
+        protected async Task<IRValueInfo> EvaluateAsync(string expression, REvaluationResultProperties fields, string repr, CancellationToken cancellationToken) {
+            var result = await Evaluator.EvaluateAsync(expression, fields, repr, cancellationToken);
             var error = result as IRErrorInfo;
             if (error != null) {
-                await VsAppShell.Current.SwitchToMainThreadAsync();
+                await VsAppShell.Current.SwitchToMainThreadAsync(cancellationToken);
                 VsAppShell.Current.ShowErrorMessage(error.ErrorText);
                 return null;
             }

--- a/src/Package/Test/DataInspect/ViewersTest.cs
+++ b/src/Package/Test/DataInspect/ViewersTest.cs
@@ -55,13 +55,13 @@ namespace Microsoft.VisualStudio.R.Package.Test.DataInspect {
         [Category.Viewers]
         public async Task ViewDataTest01() {
             var cb = Substitute.For<IRSessionCallback>();
-            cb.When(x => x.ViewObject(Arg.Any<string>(), Arg.Any<string>())).Do(x => { });
+            cb.When(x => x.ViewObjectAsync(Arg.Any<string>(), Arg.Any<string>())).Do(x => { });
             using (var hostScript = new RHostScript(_workflow.RSessions, cb)) {
                 using (var inter = await hostScript.Session.BeginInteractionAsync()) {
                     await inter.RespondAsync("View(mtcars)" + Environment.NewLine);
                 }
             }
-            cb.Received().ViewObject("mtcars", "mtcars");
+            cb.Received().ViewObjectAsync("mtcars", "mtcars");
         }
 
         [Test]

--- a/src/Package/TestApp/Data/VariableGridTest.cs
+++ b/src/Package/TestApp/Data/VariableGridTest.cs
@@ -25,7 +25,6 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Data {
 
         public VariableGridTest(TestFilesFixture files) {
             _files = files;
-            var workflow = VsAppShell.Current.ExportProvider.GetExportedValue<IRInteractiveWorkflowProvider>().GetOrCreate();
             _hostScript = new VariableRHostScript(SessionProvider);
         }
 

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
@@ -140,7 +140,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
         public async Task ConnectAsync(IConnectionInfo connection, CancellationToken cancellationToken = default(CancellationToken)) {
             if (ActiveConnection == null || !ActiveConnection.Path.PathEquals(connection.Path) || string.IsNullOrEmpty(_sessionProvider.Broker.Name)) {
                 await TrySwitchBrokerAsync(connection, cancellationToken);
-                await _shell.SwitchToMainThreadAsync();
+                await _shell.SwitchToMainThreadAsync(cancellationToken);
                 var interactiveWindow = await _interactiveWorkflow.GetOrCreateVisualComponentAsync();
                 interactiveWindow.Container.Show(focus: false, immediate: false);
             }

--- a/src/R/Components/Impl/InteractiveWorkflow/IRInteractiveWorkflowOperations.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/IRInteractiveWorkflowOperations.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.Text;
@@ -35,7 +36,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow {
 
         void SourceFiles(IEnumerable<string> files, bool echo);
 
-        Task SourceFileAsync(string file, bool echo, Encoding encoding = null);
+        Task SourceFileAsync(string file, bool echo, Encoding encoding = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Attempts to launch Shiny app. Invokes 'library(shiny)'

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/InteractiveWindowConsole.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/InteractiveWindowConsole.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core.Shell;
 using Microsoft.R.Host.Client;
@@ -18,8 +19,8 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             _workflow.Shell.DispatchOnUIThread(() => _workflow.ActiveWindow?.InteractiveWindow?.WriteErrorLine(text));
         }
 
-        public async Task<bool> PromptYesNoAsync(string text) {
-            var result = await _workflow.Shell.ShowMessageAsync(text, MessageButtons.YesNo);
+        public async Task<bool> PromptYesNoAsync(string text, CancellationToken cancellationToken) {
+            var result = await _workflow.Shell.ShowMessageAsync(text, MessageButtons.YesNo, cancellationToken);
             return result == MessageButtons.Yes;
         }
     }

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflowOperations.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflowOperations.cs
@@ -174,10 +174,10 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
             });
         }
 
-        public async Task SourceFileAsync(string file, bool echo, Encoding encoding = null) {
+        public async Task SourceFileAsync(string file, bool echo, Encoding encoding = null, CancellationToken cancellationToken = default(CancellationToken)) {
             await TaskUtilities.SwitchToBackgroundThread();
-            file = await _workflow.RSession.MakeRelativeToRUserDirectoryAsync(file);
-            await _coreShell.SwitchToMainThreadAsync();
+            file = await _workflow.RSession.MakeRelativeToRUserDirectoryAsync(file, cancellationToken);
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
             ExecuteExpression(GetSourceExpression(file, echo, encoding));
         }
 

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RSessionCallback.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RSessionCallback.cs
@@ -43,7 +43,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
         /// <summary>
         /// Displays message with specified buttons in a host-specific UI
         /// </summary>
-        public Task<MessageButtons> ShowMessageAsync(string message, MessageButtons buttons, CancellationToken cancellationToken) => _coreShell.ShowMessageAsync(message, buttons);
+        public Task<MessageButtons> ShowMessageAsync(string message, MessageButtons buttons, CancellationToken cancellationToken) => _coreShell.ShowMessageAsync(message, buttons, cancellationToken);
             
         /// <summary>
         /// Displays R help URL in a browser on in the host app-provided window
@@ -62,17 +62,14 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
         /// <summary>
         /// Displays R plot in the host app-provided window
         /// </summary>
-        public async Task Plot(PlotMessage plot, CancellationToken ct) {
-            await _workflow.Plots.LoadPlotAsync(plot, ct);
-        }
+        public Task Plot(PlotMessage plot, CancellationToken ct) 
+            => _workflow.Plots.LoadPlotAsync(plot, ct);
 
-        public async Task<LocatorResult> Locator(Guid deviceId, CancellationToken ct) {
-            return await _workflow.Plots.StartLocatorModeAsync(deviceId, ct);
-        }
+        public Task<LocatorResult> Locator(Guid deviceId, CancellationToken ct) 
+            => _workflow.Plots.StartLocatorModeAsync(deviceId, ct);
 
-        public async Task<PlotDeviceProperties> PlotDeviceCreate(Guid deviceId, CancellationToken ct) {
-            return await _workflow.Plots.DeviceCreatedAsync(deviceId, ct);
-        }
+        public Task<PlotDeviceProperties> PlotDeviceCreate(Guid deviceId, CancellationToken ct) 
+            => _workflow.Plots.DeviceCreatedAsync(deviceId, ct);
 
         public async Task PlotDeviceDestroy(Guid deviceId, CancellationToken ct) {
             await _workflow.Plots.DeviceDestroyedAsync(deviceId, ct);
@@ -94,9 +91,9 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             return CranMirrorList.UrlFromName(mirrorName);
         }
 
-        public void ViewObject(string expression, string title) {
+        public Task ViewObjectAsync(string expression, string title, CancellationToken cancellationToken = default(CancellationToken)) {
             var viewer = _coreShell.ExportProvider.GetExportedValue<IObjectViewer>();
-            viewer?.ViewObjectDetails(_session, REnvironments.GlobalEnv, expression, title);
+            return viewer?.ViewObjectDetails(_session, REnvironments.GlobalEnv, expression, title, cancellationToken) ?? Task.CompletedTask;
         }
 
         public async Task ViewLibraryAsync(CancellationToken cancellationToken = default(CancellationToken)) {

--- a/src/R/Components/Impl/PackageManager/IRPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/IRPackageManager.cs
@@ -55,7 +55,8 @@ namespace Microsoft.R.Components.PackageManager {
         ///     Optional library path (in any format). Pass null to use the default
         ///     for the session ie. the first one in .libPaths().
         /// </param>
-        Task InstallPackageAsync(string name, string libraryPath);
+        /// <param name="cancellationToken"></param>
+        Task InstallPackageAsync(string name, string libraryPath, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Uninstall a package by evaluating rtvs:::package_uninstall.
@@ -65,13 +66,14 @@ namespace Microsoft.R.Components.PackageManager {
         ///     Optional library path (in any format) where the package is installed.
         ///     Pass null to use the defaults for the session ie. in .libPaths().
         /// </param>
+        /// <param name="cancellationToken"></param>
         /// <returns>
         /// <see cref="PackageLockState.Unlocked"/>  if the package was successfully 
         /// installed. <see cref="PackageLockState.LockedByRSession"/> or <see cref="PackageLockState.LockedByOther"/> 
         /// if the package was found to be installed and loaded in the REPL or 
         /// loaded by another process.
         /// </returns>
-        Task<PackageLockState> UninstallPackageAsync(string name, string libraryPath);
+        Task<PackageLockState> UninstallPackageAsync(string name, string libraryPath, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Uninstall and Install a package by evaluating rtvs:::package_update.
@@ -81,13 +83,14 @@ namespace Microsoft.R.Components.PackageManager {
         ///     Optional library path (in any format) where the package is installed.
         ///     Pass null to use the defaults for the session ie. in .libPaths().
         /// </param>
+        /// <param name="cancellationToken"></param>
         /// <returns>
         /// <see cref="PackageLockState.Unlocked"/>  if the package was successfully 
         /// installed. <see cref="PackageLockState.LockedByRSession"/> or <see cref="PackageLockState.LockedByOther"/> 
         /// if the package was found to be installed and loaded in the REPL or 
         /// loaded by another process.
         /// </returns>
-        Task<PackageLockState> UpdatePackageAsync(string name, string libraryPath);
+        Task<PackageLockState> UpdatePackageAsync(string name, string libraryPath, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Load a package by sending library() to the REPL.
@@ -97,13 +100,15 @@ namespace Microsoft.R.Components.PackageManager {
         ///     Optional library path (in any format). Pass null to use the defaults
         ///     for the session ie. in .libPaths().
         /// </param>
-        Task LoadPackageAsync(string name, string libraryPath);
+        /// <param name="cancellationToken"></param>
+        Task LoadPackageAsync(string name, string libraryPath, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Unload a package by sending detach() to the REPL.
         /// </summary>
         /// <param name="name">Package name.</param>
-        Task UnloadPackageAsync(string name);
+        /// <param name="cancellationToken"></param>
+        Task UnloadPackageAsync(string name, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Package names that are currently loaded.
@@ -114,7 +119,7 @@ namespace Microsoft.R.Components.PackageManager {
         /// </exception>
         /// <exception cref="OperationCanceledException">
         /// </exception>
-        Task<string[]> GetLoadedPackagesAsync();
+        Task<string[]> GetLoadedPackagesAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Path of selected library folder, as returned .libPaths().
@@ -125,7 +130,7 @@ namespace Microsoft.R.Components.PackageManager {
         /// </exception>
         /// <exception cref="OperationCanceledException">
         /// </exception>
-        Task<string> GetLibraryPathAsync();
+        Task<string> GetLibraryPathAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Check if the dll for the specified package is locked by the REPL
@@ -133,7 +138,8 @@ namespace Microsoft.R.Components.PackageManager {
         /// </summary>
         /// <param name="name">Package name.</param>
         /// <param name="libraryPath">Library path (in any format).</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>Lock state.</returns>
-        Task<PackageLockState> GetPackageLockStateAsync(string name, string libraryPath);
+        Task<PackageLockState> GetPackageLockStateAsync(string name, string libraryPath, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -85,8 +85,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             return await GetPackagesAsync(_session.AvailablePackagesAsync, cancellationToken);
         }
 
-        public async Task InstallPackageAsync(string name, string libraryPath) {
-            using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync()) {
+        public async Task InstallPackageAsync(string name, string libraryPath, CancellationToken cancellationToken = default(CancellationToken)) {
+            using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync(cancellationToken:cancellationToken)) {
                 if (string.IsNullOrEmpty(libraryPath)) {
                     await request.InstallPackageAsync(name);
                 } else {
@@ -95,16 +95,16 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             }
         }
 
-        public Task<PackageLockState> UninstallPackageAsync(string name, string libraryPath) => 
+        public Task<PackageLockState> UninstallPackageAsync(string name, string libraryPath, CancellationToken cancellationToken = default(CancellationToken)) => 
             _interactiveWorkflow.RSession.EvaluateAsync<PackageLockState>(
-                Invariant($"rtvs:::package_uninstall({name.ToRStringLiteral()}, {libraryPath.ToRStringLiteral()})"), REvaluationKind.Normal);
+                Invariant($"rtvs:::package_uninstall({name.ToRStringLiteral()}, {libraryPath.ToRStringLiteral()})"), REvaluationKind.Normal, cancellationToken);
 
-        public Task<PackageLockState> UpdatePackageAsync(string name, string libraryPath) => 
+        public Task<PackageLockState> UpdatePackageAsync(string name, string libraryPath, CancellationToken cancellationToken = default(CancellationToken)) => 
             _interactiveWorkflow.RSession.EvaluateAsync<PackageLockState>(
-                Invariant($"rtvs:::package_update({name.ToRStringLiteral()}, {libraryPath.ToRStringLiteral()})"), REvaluationKind.Normal);
+                Invariant($"rtvs:::package_update({name.ToRStringLiteral()}, {libraryPath.ToRStringLiteral()})"), REvaluationKind.Normal, cancellationToken);
 
-        public async Task LoadPackageAsync(string name, string libraryPath) {
-            using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync()) {
+        public async Task LoadPackageAsync(string name, string libraryPath, CancellationToken cancellationToken = default(CancellationToken)) {
+            using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync(cancellationToken: cancellationToken)) {
                 if (string.IsNullOrEmpty(libraryPath)) {
                     await request.LoadPackageAsync(name);
                 } else {
@@ -113,26 +113,26 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
             }
         }
 
-        public async Task UnloadPackageAsync(string name) {
-            using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync()) {
+        public async Task UnloadPackageAsync(string name, CancellationToken cancellationToken = default(CancellationToken)) {
+            using (var request = await _interactiveWorkflow.RSession.BeginInteractionAsync(cancellationToken: cancellationToken)) {
                 await request.UnloadPackageAsync(name);
             }
         }
 
-        public async Task<string[]> GetLoadedPackagesAsync() {
+        public async Task<string[]> GetLoadedPackagesAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             _loadedPackagesEvent.Reset();
-            var result = await WrapRException(_interactiveWorkflow.RSession.LoadedPackagesAsync());
+            var result = await WrapRException(_interactiveWorkflow.RSession.LoadedPackagesAsync(cancellationToken));
             return result.Select(p => (string)((JValue)p).Value).ToArray();
         }
 
-        public async Task<string> GetLibraryPathAsync() {
-            var result = await WrapRException(_interactiveWorkflow.RSession.LibraryPathsAsync());
+        public async Task<string> GetLibraryPathAsync(CancellationToken cancellationToken = default(CancellationToken)) {
+            var result = await WrapRException(_interactiveWorkflow.RSession.LibraryPathsAsync(cancellationToken));
             return result.Select(p => p.ToRPath()).FirstOrDefault();
         }
 
-        public Task<PackageLockState> GetPackageLockStateAsync(string name, string libraryPath) 
+        public Task<PackageLockState> GetPackageLockStateAsync(string name, string libraryPath, CancellationToken cancellationToken = default(CancellationToken)) 
             => _interactiveWorkflow.RSession.EvaluateAsync<PackageLockState>(
-                 Invariant($"rtvs:::package_lock_state({name.ToRStringLiteral()}, {libraryPath.ToRStringLiteral()})"), REvaluationKind.Normal);
+                 Invariant($"rtvs:::package_lock_state({name.ToRStringLiteral()}, {libraryPath.ToRStringLiteral()})"), REvaluationKind.Normal, cancellationToken);
 
         private async Task<IReadOnlyList<RPackage>> GetPackagesAsync(Func<Task<JArray>> queryFunc, CancellationToken cancellationToken) {
             // Fetching of installed and available packages is done in a

--- a/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageManagerViewModel.cs
@@ -22,17 +22,17 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View.DesignTime {
         public string FirstError => null;
         public bool HasMultipleErrors => false;
 
-        public Task SwitchToAvailablePackagesAsync() => Task.CompletedTask;
-        public Task SwitchToInstalledPackagesAsync() => Task.CompletedTask;
-        public Task SwitchToLoadedPackagesAsync() => Task.CompletedTask;
-        public Task ReloadCurrentTabAsync() => Task.CompletedTask;
+        public Task SwitchToAvailablePackagesAsync(CancellationToken cancellationToken = default(CancellationToken)) => Task.CompletedTask;
+        public Task SwitchToInstalledPackagesAsync(CancellationToken cancellationToken = default(CancellationToken)) => Task.CompletedTask;
+        public Task SwitchToLoadedPackagesAsync(CancellationToken cancellationToken = default(CancellationToken)) => Task.CompletedTask;
+        public Task ReloadCurrentTabAsync(CancellationToken cancellationToken = default(CancellationToken)) => Task.CompletedTask;
         public void SelectPackage(IRPackageViewModel package) { }
-        public Task InstallAsync(IRPackageViewModel package) => Task.CompletedTask;
-        public Task UpdateAsync(IRPackageViewModel package) => Task.CompletedTask;
-        public Task UninstallAsync(IRPackageViewModel package) => Task.CompletedTask;
-        public Task LoadAsync(IRPackageViewModel package) => Task.CompletedTask;
-        public Task UnloadAsync(IRPackageViewModel package) => Task.CompletedTask;
-        public Task DefaultActionAsync() => Task.CompletedTask;
+        public Task InstallAsync(IRPackageViewModel package, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task UpdateAsync(IRPackageViewModel package, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task UninstallAsync(IRPackageViewModel package, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task LoadAsync(IRPackageViewModel package, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task UnloadAsync(IRPackageViewModel package, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task DefaultActionAsync(CancellationToken cancellationToken = default(CancellationToken)) => Task.CompletedTask;
 
         public void DismissErrorMessage() {
         }

--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
@@ -90,9 +90,9 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
         }
 
-        public async Task ReloadCurrentTabAsync() {
-            await _coreShell.SwitchToMainThreadAsync();
-            await ReloadTabContentAsync(_selectedTab);
+        public async Task ReloadCurrentTabAsync(CancellationToken cancellationToken = default(CancellationToken)) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
+            await ReloadTabContentAsync(_selectedTab, cancellationToken);
         }
 
         public void SelectPackage(IRPackageViewModel package) {
@@ -104,8 +104,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             SelectedPackage = package;
         }
 
-        public async Task DefaultActionAsync() {
-            await _coreShell.SwitchToMainThreadAsync();
+        public async Task DefaultActionAsync(CancellationToken cancellationToken = default(CancellationToken)) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
             if (SelectedPackage == null) {
                 return;
             }
@@ -113,14 +113,14 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             // Available => Installed => Loaded
             var package = SelectedPackage;
             if (!package.IsInstalled) {
-                await InstallAsync(package);
+                await InstallAsync(package, cancellationToken);
             } else if (!package.IsLoaded) {
-                await LoadAsync(package);
+                await LoadAsync(package, cancellationToken);
             }
         }
 
-        public async Task InstallAsync(IRPackageViewModel package) {
-            await _coreShell.SwitchToMainThreadAsync();
+        public async Task InstallAsync(IRPackageViewModel package, CancellationToken cancellationToken = default(CancellationToken)) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
             if (package.IsInstalled || package.IsChanging) {
                 return;
             }
@@ -129,20 +129,20 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             var startingTab = _selectedTab;
 
             try {
-                var libPath = await _packageManager.GetLibraryPathAsync();
-                await _packageManager.InstallPackageAsync(package.Name, libPath);
+                var libPath = await _packageManager.GetLibraryPathAsync(cancellationToken);
+                await _packageManager.InstallPackageAsync(package.Name, libPath, cancellationToken);
             } catch (RHostDisconnectedException) {
                 _errorMessages.Add(Resources.PackageManager_CantInstallPackageNoRSession.FormatCurrent(package.Name), ErrorMessageType.PackageOperations);
             } catch (RPackageManagerException ex) {
                 _errorMessages.Add(ex.Message, ErrorMessageType.PackageOperations);
             }
 
-            await EnsureInstalledAndLoadedPackagesAsync(true);
-            await AfterLoadUnloadAsync(package, startingTab);
+            await EnsureInstalledAndLoadedPackagesAsync(true, cancellationToken);
+            await AfterLoadUnloadAsync(package, startingTab, cancellationToken);
         }
 
-        public async Task UpdateAsync(IRPackageViewModel package) {
-            await _coreShell.SwitchToMainThreadAsync();
+        public async Task UpdateAsync(IRPackageViewModel package, CancellationToken cancellationToken = default(CancellationToken)) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
             if (!package.IsInstalled || package.IsChanging) {
                 return;
             }
@@ -155,46 +155,46 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             var startingTab = _selectedTab;
             BeforeLoadUnload(package);
 
-            await UpdateImplAsync(package);
-            await AfterLoadUnloadAsync(package, startingTab);
+            await UpdateImplAsync(package, cancellationToken);
+            await AfterLoadUnloadAsync(package, startingTab, cancellationToken);
         }
 
-        private async Task ReplaceItemsAsync(Tab startingTab) {
+        private async Task ReplaceItemsAsync(Tab startingTab, CancellationToken cancellationToken) {
             if (startingTab == _selectedTab) {
                 switch (_selectedTab) {
                     case Tab.AvailablePackages:
-                        await ReplaceItemsAsync(_availablePackages);
+                        await ReplaceItemsAsync(_availablePackages, cancellationToken);
                         break;
                     case Tab.InstalledPackages:
-                        await ReplaceItemsAsync(_installedPackages);
+                        await ReplaceItemsAsync(_installedPackages, cancellationToken);
                         break;
                     case Tab.LoadedPackages:
-                        await ReplaceItemsAsync(_loadedPackages);
+                        await ReplaceItemsAsync(_loadedPackages, cancellationToken);
                         break;
                 }
                 IsLoading = false;
             }
         }
 
-        private async Task UpdateImplAsync(IRPackageViewModel package) {
-            await _coreShell.SwitchToMainThreadAsync();
+        private async Task UpdateImplAsync(IRPackageViewModel package, CancellationToken cancellationToken) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
 
             if (package.IsLoaded) {
                 try {
-                    await _packageManager.UnloadPackageAsync(package.Name);
+                    await _packageManager.UnloadPackageAsync(package.Name, cancellationToken);
                 } catch (RHostDisconnectedException) {
                     _errorMessages.Add(Resources.PackageManager_CantUnloadPackageNoRSession.FormatCurrent(package.Name), ErrorMessageType.PackageOperations);
                 } catch (RPackageManagerException ex) {
                     _errorMessages.Add(ex.Message, ErrorMessageType.PackageOperations);
                 }
-                await ReloadLoadedPackagesAsync();
+                await ReloadLoadedPackagesAsync(cancellationToken);
             }
 
             if (!package.IsLoaded) {
                 try {
                     var libPath = package.LibraryPath.ToRPath();
                     try {
-                        var packageLockState = await _packageManager.UpdatePackageAsync(package.Name, libPath);
+                        var packageLockState = await _packageManager.UpdatePackageAsync(package.Name, libPath, cancellationToken);
                         if (packageLockState != PackageLockState.Unlocked) {
                             ShowPackageLockedMessage(packageLockState, package.Name);
                         }
@@ -206,11 +206,11 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                 }
             }
 
-            await EnsureInstalledAndLoadedPackagesAsync(true);
+            await EnsureInstalledAndLoadedPackagesAsync(true, cancellationToken);
         }
 
-        public async Task UninstallAsync(IRPackageViewModel package) {
-            await _coreShell.SwitchToMainThreadAsync();
+        public async Task UninstallAsync(IRPackageViewModel package, CancellationToken cancellationToken = default(CancellationToken)) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
             if (!package.IsInstalled || package.IsChanging) {
                 return;
             }
@@ -225,19 +225,19 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
 
             if (package.IsLoaded) {
                 try {
-                    await _packageManager.UnloadPackageAsync(package.Name);
+                    await _packageManager.UnloadPackageAsync(package.Name, cancellationToken);
                 } catch (RHostDisconnectedException) {
                     _errorMessages.Add(Resources.PackageManager_CantUnloadPackageNoRSession.FormatCurrent(package.Name), ErrorMessageType.PackageOperations);
                 } catch (RPackageManagerException ex) {
                     _errorMessages.Add(ex.Message, ErrorMessageType.PackageOperations);
                 }
-                await ReloadLoadedPackagesAsync();
+                await ReloadLoadedPackagesAsync(cancellationToken);
             }
 
             if (!package.IsLoaded) {
                 try {
                     var libPath = package.LibraryPath.ToRPath();
-                    var packageLockState = await _packageManager.UninstallPackageAsync(package.Name, libPath);
+                    var packageLockState = await _packageManager.UninstallPackageAsync(package.Name, libPath, cancellationToken);
                     if (packageLockState != PackageLockState.Unlocked) {
                         ShowPackageLockedMessage(packageLockState, package.Name);
                     }
@@ -247,14 +247,14 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                     _errorMessages.Add(ex.Message, ErrorMessageType.PackageOperations);
                 }
 
-                await EnsureInstalledAndLoadedPackagesAsync(true);
+                await EnsureInstalledAndLoadedPackagesAsync(true, cancellationToken);
             }
 
-            await AfterLoadUnloadAsync(package, startingTab);
+            await AfterLoadUnloadAsync(package, startingTab, cancellationToken);
         }
 
-        public async Task LoadAsync(IRPackageViewModel package) {
-            await _coreShell.SwitchToMainThreadAsync();
+        public async Task LoadAsync(IRPackageViewModel package, CancellationToken cancellationToken = default(CancellationToken)) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
             if (package.IsLoaded) {
                 return;
             }
@@ -263,19 +263,19 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             var startingTab = _selectedTab;
 
             try {
-                await _packageManager.LoadPackageAsync(package.Name, package.LibraryPath.ToRPath());
+                await _packageManager.LoadPackageAsync(package.Name, package.LibraryPath.ToRPath(), cancellationToken);
             } catch (RHostDisconnectedException) {
                 _errorMessages.Add(Resources.PackageManager_CantLoadPackageNoRSession.FormatCurrent(package.Name), ErrorMessageType.PackageOperations);
             } catch (RPackageManagerException ex) {
                 _errorMessages.Add(ex.Message, ErrorMessageType.PackageOperations);
             }
 
-            await ReloadLoadedPackagesAsync();
-            await AfterLoadUnloadAsync(package, startingTab);
+            await ReloadLoadedPackagesAsync(cancellationToken);
+            await AfterLoadUnloadAsync(package, startingTab, cancellationToken);
         }
 
-        public async Task UnloadAsync(IRPackageViewModel package) {
-            await _coreShell.SwitchToMainThreadAsync();
+        public async Task UnloadAsync(IRPackageViewModel package, CancellationToken cancellationToken = default(CancellationToken)) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
 
             if (!package.IsLoaded) {
                 return;
@@ -285,15 +285,15 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             var startingTab = _selectedTab;
 
             try {
-                await _packageManager.UnloadPackageAsync(package.Name);
+                await _packageManager.UnloadPackageAsync(package.Name, cancellationToken);
             } catch (RHostDisconnectedException) {
                 _errorMessages.Add(Resources.PackageManager_CantUnloadPackageNoRSession.FormatCurrent(package.Name), ErrorMessageType.PackageOperations);
             } catch (RPackageManagerException ex) {
                 _errorMessages.Add(ex.Message, ErrorMessageType.PackageOperations);
             }
 
-            await ReloadLoadedPackagesAsync();
-            await AfterLoadUnloadAsync(package, startingTab);
+            await ReloadLoadedPackagesAsync(cancellationToken);
+            await AfterLoadUnloadAsync(package, startingTab, cancellationToken);
         }
 
         private void BeforeLoadUnload(IRPackageViewModel package) {
@@ -303,8 +303,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             package.IsChanging = true;
         }
 
-        private async Task AfterLoadUnloadAsync(IRPackageViewModel package, Tab startingTab) {
-            await ReplaceItemsAsync(startingTab);
+        private async Task AfterLoadUnloadAsync(IRPackageViewModel package, Tab startingTab, CancellationToken cancellationToken) {
+            await ReplaceItemsAsync(startingTab, cancellationToken);
             package.IsChanging = false;
         }
 
@@ -327,18 +327,18 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
         }
         
-        public async Task SwitchToAvailablePackagesAsync() {
-            if (await SetTabAsync(Tab.AvailablePackages)) {
-                await EnsureAvailablePackagesLoadedAsync(false);
-                await ReplaceItemsAsync(Tab.AvailablePackages);
+        public async Task SwitchToAvailablePackagesAsync(CancellationToken cancellationToken = default(CancellationToken)) {
+            if (await SetTabAsync(Tab.AvailablePackages, cancellationToken)) {
+                await EnsureAvailablePackagesLoadedAsync(false, cancellationToken);
+                await ReplaceItemsAsync(Tab.AvailablePackages, cancellationToken);
             }
         }
 
-        private async Task EnsureAvailablePackagesLoadedAsync(bool reload) {
-            var lockToken = reload ? await _availableLock.ResetAsync() : await _availableLock.WaitAsync();
+        private async Task EnsureAvailablePackagesLoadedAsync(bool reload, CancellationToken cancellationToken) {
+            var lockToken = reload ? await _availableLock.ResetAsync(cancellationToken) : await _availableLock.WaitAsync(cancellationToken);
             try {
                 if (!lockToken.IsSet) {
-                    await LoadAvailablePackagesAsync();
+                    await LoadAvailablePackagesAsync(cancellationToken);
                     _errorMessages.Remove(ErrorMessageType.Connection);
                     lockToken.Set();
                 }
@@ -349,11 +349,11 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
         }
 
-        private async Task LoadAvailablePackagesAsync() {
+        private async Task LoadAvailablePackagesAsync(CancellationToken cancellationToken) {
             await TaskUtilities.SwitchToBackgroundThread();
 
             var vmAvailablePackages = new List<IRPackageViewModel>();
-            var availablePackages = await _packageManager.GetAvailablePackagesAsync();
+            var availablePackages = await _packageManager.GetAvailablePackagesAsync(cancellationToken);
 
             var installedPackages = _installedPackages.ToDictionary(p => p.Name, p => p);
             foreach (var package in availablePackages) {
@@ -369,15 +369,15 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             _availablePackages = vmAvailablePackages.OrderBy(p => p.Name).ToList();
         }
 
-        public async Task SwitchToInstalledPackagesAsync() {
-            if (await SetTabAsync(Tab.InstalledPackages)) {
-                await EnsureInstalledAndLoadedPackagesAsync(true);
-                await ReplaceItemsAsync(Tab.InstalledPackages);
+        public async Task SwitchToInstalledPackagesAsync(CancellationToken cancellationToken = default(CancellationToken)) {
+            if (await SetTabAsync(Tab.InstalledPackages, cancellationToken)) {
+                await EnsureInstalledAndLoadedPackagesAsync(true, cancellationToken);
+                await ReplaceItemsAsync(Tab.InstalledPackages, cancellationToken);
             }
         }
 
-        private async Task<bool> SetTabAsync(Tab tab) {
-            await _coreShell.SwitchToMainThreadAsync();
+        private async Task<bool> SetTabAsync(Tab tab, CancellationToken cancellationToken) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
             if (_selectedTab != tab) {
                 _selectedTab = tab;
                 IsLoading = true;
@@ -386,21 +386,21 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             return false;
         }
 
-        private async Task ReloadTabContentAsync(Tab tab) {
-            await _coreShell.SwitchToMainThreadAsync();
+        private async Task ReloadTabContentAsync(Tab tab, CancellationToken cancellationToken = default(CancellationToken)) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
             if (tab == _selectedTab) {
                 IsLoading = true;
             }
 
             switch (tab) {
                 case Tab.AvailablePackages:
-                    await EnsureAvailablePackagesLoadedAsync(true);
+                    await EnsureAvailablePackagesLoadedAsync(true, cancellationToken);
                     break;
                 case Tab.InstalledPackages:
-                    await EnsureInstalledAndLoadedPackagesAsync(true);
+                    await EnsureInstalledAndLoadedPackagesAsync(true, cancellationToken);
                     break;
                 case Tab.LoadedPackages:
-                    await ReloadLoadedPackagesAsync();
+                    await ReloadLoadedPackagesAsync(cancellationToken);
                     break;
                 case Tab.None:
                     return;
@@ -408,17 +408,17 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                     throw new ArgumentOutOfRangeException();
             }
 
-            await ReplaceItemsAsync(tab);
+            await ReplaceItemsAsync(tab, cancellationToken);
         }
 
-        private async Task EnsureInstalledAndLoadedPackagesAsync(bool reload) {
+        private async Task EnsureInstalledAndLoadedPackagesAsync(bool reload, CancellationToken cancellationToken) {
             var lockToken = reload 
-                ? await _installedAndLoadedLock.ResetAsync()
-                : await _installedAndLoadedLock.WaitAsync();
+                ? await _installedAndLoadedLock.ResetAsync(cancellationToken)
+                : await _installedAndLoadedLock.WaitAsync(cancellationToken);
 
             if (!lockToken.IsSet) {
                 try {
-                    await LoadInstalledAndLoadedPackagesAsync(reload);
+                    await LoadInstalledAndLoadedPackagesAsync(reload, cancellationToken);
                     _errorMessages.Remove(ErrorMessageType.Connection);
                     lockToken.Set();
                 } catch (RPackageManagerException ex) {
@@ -429,16 +429,16 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
         }
 
-        private async Task LoadInstalledAndLoadedPackagesAsync(bool reload) {
+        private async Task LoadInstalledAndLoadedPackagesAsync(bool reload, CancellationToken cancellationToken) {
             await TaskUtilities.SwitchToBackgroundThread();
 
             IReadOnlyList<RPackage> installedPackages;
             if (reload) {
                 _installedPackages = new List<IRPackageViewModel>();
-                installedPackages = await _packageManager.GetInstalledPackagesAsync();
+                installedPackages = await _packageManager.GetInstalledPackagesAsync(cancellationToken);
             } else { 
-                var markUninstalledAndUnloadedTask = MarkUninstalledAndUnloaded();
-                var getInstalledPackagesTask = _packageManager.GetInstalledPackagesAsync();
+                var markUninstalledAndUnloadedTask = MarkUninstalledAndUnloaded(cancellationToken);
+                var getInstalledPackagesTask = _packageManager.GetInstalledPackagesAsync(cancellationToken);
                 await Task.WhenAll(markUninstalledAndUnloadedTask, getInstalledPackagesTask);
                 installedPackages = getInstalledPackagesTask.Result;
             }
@@ -451,10 +451,10 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
 
                 IdentifyRemovablePackages(vmInstalledPackages);
 
-                await UpdateLoadedPackages(vmInstalledPackages);
+                await UpdateLoadedPackages(vmInstalledPackages, null, cancellationToken);
                 _installedPackages = vmInstalledPackages;
 
-                EnsureAvailablePackagesLoadedAsync(false).DoNotWait();
+                EnsureAvailablePackagesLoadedAsync(false, cancellationToken).DoNotWait();
             } else {
                 var vmAvailablePackages = _availablePackages.ToDictionary(k => k.Name);
                 var vmInstalledPackages = new List<IRPackageViewModel>();
@@ -472,7 +472,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                 IdentifyRemovablePackages(vmInstalledPackages);
                 vmInstalledPackages = vmInstalledPackages.OrderBy(p => p.Name).ToList();
 
-                await UpdateLoadedPackages(vmInstalledPackages);
+                await UpdateLoadedPackages(vmInstalledPackages, null, cancellationToken);
                 _installedPackages = vmInstalledPackages;
             }
         }
@@ -488,14 +488,14 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
         }
 
-        private async Task ReloadLoadedPackagesAsync() {
+        private async Task ReloadLoadedPackagesAsync(CancellationToken cancellationToken) {
             await TaskUtilities.SwitchToBackgroundThread();
             try {
                 var currentLoadedPackages = _loadedPackages;
                 var currentInstalledPackages = _installedPackages;
                 List<string> loadedPackageNames;
                 try {
-                    loadedPackageNames = (await _packageManager.GetLoadedPackagesAsync()).OrderBy(n => n).ToList();
+                    loadedPackageNames = (await _packageManager.GetLoadedPackagesAsync(cancellationToken)).OrderBy(n => n).ToList();
                     _errorMessages.Remove(ErrorMessageType.NoRSession);
                 } catch (RHostDisconnectedException) {
                     _errorMessages.Add(Resources.PackageManager_NoLoadedPackagesNoRSession, ErrorMessageType.NoRSession);
@@ -506,16 +506,16 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                     return;
                 }
 
-                await UpdateLoadedPackages(currentInstalledPackages, loadedPackageNames);
+                await UpdateLoadedPackages(currentInstalledPackages, loadedPackageNames, cancellationToken);
                 _errorMessages.Remove(ErrorMessageType.Connection);
             } catch (RPackageManagerException ex) {
                 _errorMessages.Add(ex.Message, ErrorMessageType.Connection);
             }
         }
 
-        private async Task UpdateLoadedPackages(IList<IRPackageViewModel> installedPackages, IList<string> loadedPackageNames = null) {
+        private async Task UpdateLoadedPackages(IList<IRPackageViewModel> installedPackages, IList<string> loadedPackageNames, CancellationToken cancellationToken) {
             try {
-                loadedPackageNames = loadedPackageNames ?? await _packageManager.GetLoadedPackagesAsync();
+                loadedPackageNames = loadedPackageNames ?? await _packageManager.GetLoadedPackagesAsync(cancellationToken);
                 _errorMessages.Remove(ErrorMessageType.NoRSession);
             } catch (RHostDisconnectedException) {
                 _errorMessages.Add(Resources.PackageManager_NoLoadedPackagesNoRSession, ErrorMessageType.NoRSession);
@@ -533,8 +533,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             _loadedPackages = vmLoadedPackages;
         }
 
-        private async Task MarkUninstalledAndUnloaded() {
-            await _coreShell.SwitchToMainThreadAsync();
+        private async Task MarkUninstalledAndUnloaded(CancellationToken cancellationToken) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
 
             foreach (var package in _installedPackages) {
                 package.IsInstalled = false;
@@ -543,15 +543,15 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             }
         }
 
-        public async Task SwitchToLoadedPackagesAsync() {
-            if (await SetTabAsync(Tab.LoadedPackages)) {
-                await EnsureInstalledAndLoadedPackagesAsync(false);
-                await ReplaceItemsAsync(Tab.LoadedPackages);
+        public async Task SwitchToLoadedPackagesAsync(CancellationToken cancellationToken = default(CancellationToken)) {
+            if (await SetTabAsync(Tab.LoadedPackages, cancellationToken)) {
+                await EnsureInstalledAndLoadedPackagesAsync(false, cancellationToken);
+                await ReplaceItemsAsync(Tab.LoadedPackages, cancellationToken);
             }
         }
 
-        private async Task ReplaceItemsAsync(IList<IRPackageViewModel> packages) {
-            await _coreShell.SwitchToMainThreadAsync();
+        private async Task ReplaceItemsAsync(IList<IRPackageViewModel> packages, CancellationToken cancellationToken) {
+            await _coreShell.SwitchToMainThreadAsync(cancellationToken);
 
             if (string.IsNullOrEmpty(_searchString)) {
                 _items.ReplaceWith(packages);
@@ -582,10 +582,10 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
             _searchString = searchString;
             switch (_selectedTab) {
                 case Tab.AvailablePackages:
-                    await EnsureAvailablePackagesLoadedAsync(false);
+                    await EnsureAvailablePackagesLoadedAsync(false, cancellationToken);
                     return Search(_availablePackages, searchString, cancellationToken);
                 case Tab.InstalledPackages:
-                    await EnsureInstalledAndLoadedPackagesAsync(true);
+                    await EnsureInstalledAndLoadedPackagesAsync(true, cancellationToken);
                     return Search(_installedPackages, searchString, cancellationToken);
                 case Tab.LoadedPackages:
                     return Search(_loadedPackages, searchString, cancellationToken);

--- a/src/R/Components/Impl/PackageManager/ViewModel/IRPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/ViewModel/IRPackageManagerViewModel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.ObjectModel;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.R.Components.Search;
 
@@ -16,17 +17,17 @@ namespace Microsoft.R.Components.PackageManager.ViewModel {
         string FirstError { get; }
         bool HasMultipleErrors { get; }
 
-        Task SwitchToAvailablePackagesAsync();
-        Task SwitchToInstalledPackagesAsync();
-        Task SwitchToLoadedPackagesAsync();
-        Task ReloadCurrentTabAsync();
+        Task SwitchToAvailablePackagesAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task SwitchToInstalledPackagesAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task SwitchToLoadedPackagesAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task ReloadCurrentTabAsync(CancellationToken cancellationToken = default(CancellationToken));
         void SelectPackage(IRPackageViewModel package);
-        Task InstallAsync(IRPackageViewModel package);
-        Task UpdateAsync(IRPackageViewModel package);
-        Task UninstallAsync(IRPackageViewModel package);
-        Task LoadAsync(IRPackageViewModel package);
-        Task UnloadAsync(IRPackageViewModel package);
-        Task DefaultActionAsync();
+        Task InstallAsync(IRPackageViewModel package, CancellationToken cancellationToken = default(CancellationToken));
+        Task UpdateAsync(IRPackageViewModel package, CancellationToken cancellationToken = default(CancellationToken));
+        Task UninstallAsync(IRPackageViewModel package, CancellationToken cancellationToken = default(CancellationToken));
+        Task LoadAsync(IRPackageViewModel package, CancellationToken cancellationToken = default(CancellationToken));
+        Task UnloadAsync(IRPackageViewModel package, CancellationToken cancellationToken = default(CancellationToken));
+        Task DefaultActionAsync(CancellationToken cancellationToken = default(CancellationToken));
         void DismissErrorMessage();
         void DismissAllErrorMessages();
     }

--- a/src/R/Components/Test/InteractiveWorkflow/RInteractiveWorkflowCommandTest.cs
+++ b/src/R/Components/Test/InteractiveWorkflow/RInteractiveWorkflowCommandTest.cs
@@ -125,7 +125,7 @@ namespace Microsoft.R.Components.Test.InteractiveWorkflow {
                     await command.InvokeAsync();
                     command.Should().BeVisibleAndDisabled();
 
-                    await task.Should().BeCompletedAsync();
+                    await task.Should().BeCanceledAsync();
                 }
             }
 

--- a/src/UnitTests/Core/Impl/FluentAssertions/TaskAssertions.cs
+++ b/src/UnitTests/Core/Impl/FluentAssertions/TaskAssertions.cs
@@ -11,31 +11,31 @@ using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 
 namespace Microsoft.UnitTests.Core.FluentAssertions {
-    public sealed class TaskAssertions : ReferenceTypeAssertions<Task, TaskAssertions> {
-        public TaskAssertions(Task task) {
+    public sealed class TaskAssertions<T> : ReferenceTypeAssertions<T, TaskAssertions<T>> where T : Task {
+        public TaskAssertions(T task) {
             Subject = task;
         }
 
         protected override string Context { get; } = "System.Threading.Tasks.Task";
 
-        public AndConstraint<TaskAssertions> BeCompleted(string because = "", params object[] reasonArgs) {
+        public AndConstraint<TaskAssertions<T>> BeCompleted(string because = "", params object[] reasonArgs) {
             Subject.Should().NotBeNull();
 
             Execute.Assertion.ForCondition(Subject.IsCompleted)
                 .BecauseOf(because, reasonArgs)
                 .FailWith($"Expected task to be completed{{reason}}, but it is {Subject.Status}.");
 
-            return new AndConstraint<TaskAssertions>(this);
+            return new AndConstraint<TaskAssertions<T>>(this);
         }
 
-        public AndConstraint<TaskAssertions> NotBeCompleted(string because = "", params object[] reasonArgs) {
+        public AndConstraint<TaskAssertions<T>> NotBeCompleted(string because = "", params object[] reasonArgs) {
             Subject.Should().NotBeNull();
 
             Execute.Assertion.ForCondition(!Subject.IsCompleted)
                 .BecauseOf(because, reasonArgs)
                 .FailWith($"Expected task not to be completed{{reason}}, but {GetNotBeCompletedMessage()}.");
 
-            return new AndConstraint<TaskAssertions>(this);
+            return new AndConstraint<TaskAssertions<T>>(this);
         }
 
         private string GetNotBeCompletedMessage() { 
@@ -53,16 +53,16 @@ namespace Microsoft.UnitTests.Core.FluentAssertions {
             }
         }
         
-        public Task<AndConstraint<TaskAssertions>> BeCompletedAsync(int timeout = 10000, string because = "", params object[] reasonArgs)
+        public Task<AndConstraint<TaskAssertions<T>>> BeCompletedAsync(int timeout = 10000, string because = "", params object[] reasonArgs)
             => BeInTimeAsync(BeCompletedAsyncContinuation, timeout, because:because, reasonArgs:reasonArgs);
         
-        public Task<AndConstraint<TaskAssertions>> BeCanceledAsync(int timeout = 10000, string because = "", params object[] reasonArgs)
+        public Task<AndConstraint<TaskAssertions<T>>> BeCanceledAsync(int timeout = 10000, string because = "", params object[] reasonArgs)
             => BeInTimeAsync(BeCanceledAsyncContinuation, timeout, because: because, reasonArgs: reasonArgs);
         
-        public Task<AndConstraint<TaskAssertions>> NotBeCompletedAsync(int timeout = 1000, string because = "", params object[] reasonArgs) 
+        public Task<AndConstraint<TaskAssertions<T>>> NotBeCompletedAsync(int timeout = 1000, string because = "", params object[] reasonArgs) 
             => BeInTimeAsync(NotBeCompletedAsyncContinuation, timeout, 1000, because, reasonArgs);
 
-        private Task<AndConstraint<TaskAssertions>> BeInTimeAsync(Func<Task<Task>, object, AndConstraint<TaskAssertions>> continuation, int timeout = 10000, int debuggerTimeout = 100000, string because = "", params object[] reasonArgs) {
+        private Task<AndConstraint<TaskAssertions<T>>> BeInTimeAsync(Func<Task<Task>, object, AndConstraint<TaskAssertions<T>>> continuation, int timeout = 10000, int debuggerTimeout = 100000, string because = "", params object[] reasonArgs) {
             Subject.Should().NotBeNull();
             if (Debugger.IsAttached) {
                 timeout = Math.Max(debuggerTimeout, timeout);
@@ -74,55 +74,55 @@ namespace Microsoft.UnitTests.Core.FluentAssertions {
                 .ContinueWith(continuation, state, default(CancellationToken), TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         }
 
-        private AndConstraint<TaskAssertions> BeCompletedAsyncContinuation(Task<Task> task, object state) {
+        private AndConstraint<TaskAssertions<T>> BeCompletedAsyncContinuation(Task<Task> task, object state) {
             var data = (TimeoutContinuationState) state;
             AssertStatus(TaskStatus.RanToCompletion, true, data.Because, data.ReasonArgs,
                 "Expected task to be completed in {0} milliseconds{reason}, but it is {1}.", data.Timeout, Subject.Status);
-            return new AndConstraint<TaskAssertions>(this);
+            return new AndConstraint<TaskAssertions<T>>(this);
         }
 
-        private AndConstraint<TaskAssertions> BeCanceledAsyncContinuation(Task<Task> task, object state) {
+        private AndConstraint<TaskAssertions<T>> BeCanceledAsyncContinuation(Task<Task> task, object state) {
             var data = (TimeoutContinuationState) state;
             AssertStatus(TaskStatus.Canceled, true, data.Because, data.ReasonArgs,
                 "Expected task to be canceled in {0} milliseconds{reason}, but it is {1}.", data.Timeout, Subject.Status);
-            return new AndConstraint<TaskAssertions>(this);
+            return new AndConstraint<TaskAssertions<T>>(this);
         }
 
-        private AndConstraint<TaskAssertions> NotBeCompletedAsyncContinuation(Task<Task> task, object state) {
+        private AndConstraint<TaskAssertions<T>> NotBeCompletedAsyncContinuation(Task<Task> task, object state) {
             var data = (TimeoutContinuationState) state;
             Execute.Assertion.ForCondition(!Subject.IsCompleted)
                 .BecauseOf(data.Because, data.ReasonArgs)
                 .FailWith($"Expected task not to be completed in {data.Timeout} milliseconds{{reason}}, but {GetNotBeCompletedMessage()}.");
 
-            return new AndConstraint<TaskAssertions>(this);
+            return new AndConstraint<TaskAssertions<T>>(this);
         }
 
-        public AndConstraint<TaskAssertions> BeRanToCompletion(string because = "", params object[] reasonArgs) 
+        public AndConstraint<TaskAssertions<T>> BeRanToCompletion(string because = "", params object[] reasonArgs) 
             => AssertStatus(TaskStatus.RanToCompletion, true, because, reasonArgs, "Expected task to completed execution successfully{reason}, but it has status {0}.", Subject.Status);
 
-        public AndConstraint<TaskAssertions> BeCanceled(string because = "", params object[] reasonArgs) 
+        public AndConstraint<TaskAssertions<T>> BeCanceled(string because = "", params object[] reasonArgs) 
             => AssertStatus(TaskStatus.Canceled, true, because, reasonArgs, "Expected task to be canceled{reason}, but it has status {0}.", Subject.Status);
 
-        public AndConstraint<TaskAssertions> NotBeCanceled(string because = "", params object[] reasonArgs) 
+        public AndConstraint<TaskAssertions<T>> NotBeCanceled(string because = "", params object[] reasonArgs) 
             => AssertStatus(TaskStatus.Canceled, false, because, reasonArgs, "Expected task not to be canceled{reason}, but it has status {0}.", Subject.Status);
 
-        public AndConstraint<TaskAssertions> BeFaulted(string because = "", params object[] reasonArgs) 
+        public AndConstraint<TaskAssertions<T>> BeFaulted(string because = "", params object[] reasonArgs) 
             => AssertStatus(TaskStatus.Faulted, true, because, reasonArgs, "Expected task to be faulted{reason}, but it has status {0}.", Subject.Status);
 
-        public AndConstraint<TaskAssertions> BeFaulted<T>(string because = "", params object[] reasonArgs) where T : Exception
-            => AssertStatus(TaskStatus.Faulted, false, because, reasonArgs, "Expected task to be faulted with exception of type {0}{reason}, but it has status {1}.", typeof(T), Subject.Status);
+        public AndConstraint<TaskAssertions<T>> BeFaulted<TException>(string because = "", params object[] reasonArgs) where TException : Exception
+            => AssertStatus(TaskStatus.Faulted, false, because, reasonArgs, "Expected task to be faulted with exception of type {0}{reason}, but it has status {1}.", typeof(TException), Subject.Status);
 
-        public AndConstraint<TaskAssertions> NotBeFaulted(string because = "", params object[] reasonArgs) 
+        public AndConstraint<TaskAssertions<T>> NotBeFaulted(string because = "", params object[] reasonArgs) 
             => AssertStatus(TaskStatus.Faulted, false, because, reasonArgs, "Expected task not to be faulted{reason}, but it has status {0}.", Subject.Status);
 
-        private AndConstraint<TaskAssertions> AssertStatus(TaskStatus status, bool hasStatus, string because, object[] reasonArgs, string message, params object[] messageArgs) {
+        private AndConstraint<TaskAssertions<T>> AssertStatus(TaskStatus status, bool hasStatus, string because, object[] reasonArgs, string message, params object[] messageArgs) {
             Subject.Should().NotBeNull();
 
             Execute.Assertion.ForCondition(status == Subject.Status == hasStatus)
                 .BecauseOf(because, reasonArgs)
                 .FailWith(message, messageArgs);
 
-            return new AndConstraint<TaskAssertions>(this);
+            return new AndConstraint<TaskAssertions<T>>(this);
         }
 
         private class TimeoutContinuationState {

--- a/src/UnitTests/Core/Impl/FluentAssertions/TaskAssertionsExtensions.cs
+++ b/src/UnitTests/Core/Impl/FluentAssertions/TaskAssertionsExtensions.cs
@@ -7,8 +7,12 @@ using System.Threading.Tasks;
 namespace Microsoft.UnitTests.Core.FluentAssertions {
     [ExcludeFromCodeCoverage]
     public static class TaskAssertionsExtensions {
-        public static TaskAssertions Should(this Task task) {
-            return new TaskAssertions(task);
+        public static TaskAssertions<Task> Should(this Task task) {
+            return new TaskAssertions<Task>(task);
+        }
+
+        public static TaskAssertions<Task<TResult>> Should<TResult>(this Task<TResult> task) {
+            return new TaskAssertions<Task<TResult>>(task);
         }
     }
 }


### PR DESCRIPTION
Also:
- Fixed hanging in Microsoft.R.Editor tests caused by deadlock in TestEditorShell
- Fixed a bug that EvaluateAsync->Stop->Start->EvaluateAsync sequence handged until console input is executed