### PR TITLE
#2792, #2808, #2817, #2826

### DIFF
--- a/src/Common/Core/Impl/Shell/ICoreShell.cs
+++ b/src/Common/Core/Impl/Shell/ICoreShell.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Common.Core.Shell {
         Thread MainThread { get; }
 
         /// <summary>
+        /// Fires when host application has completed it's startup sequence
+        /// </summary>
+        event EventHandler<EventArgs> Started;
+
+        /// <summary>
         /// Fires when host application enters idle state.
         /// </summary>
         event EventHandler<EventArgs> Idle;

--- a/src/Common/Core/Test/Fakes/Shell/TestCoreShell.cs
+++ b/src/Common/Core/Test/Fakes/Shell/TestCoreShell.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Common.Core.Test.Fakes.Shell {
         public Thread MainThread => UIThreadHelper.Instance.Thread;
 
 #pragma warning disable 67
+        public event EventHandler<EventArgs> Started;
         public event EventHandler<EventArgs> Idle;
         public event EventHandler<EventArgs> Terminating;
 

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -20,7 +20,7 @@ using static System.FormattableString;
 
 namespace Microsoft.R.Host.Client.Session {
     internal sealed class RSession : IRSession, IRCallbacks {
-        private static readonly string RemotePromptPrefix = "\u26ab";
+        private static readonly string RemotePromptPrefix = "\u26b9";
         private static readonly string DefaultPrompt = "> ";
 
         private static readonly Task<IRSessionEvaluation> CanceledBeginEvaluationTask;

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -20,7 +20,7 @@ using static System.FormattableString;
 
 namespace Microsoft.R.Host.Client.Session {
     internal sealed class RSession : IRSession, IRCallbacks {
-        private static readonly string RemotePromptPrefix = "*";
+        private static readonly string RemotePromptPrefix = "\u26ab";
         private static readonly string DefaultPrompt = "> ";
 
         private static readonly Task<IRSessionEvaluation> CanceledBeginEvaluationTask;

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -106,7 +106,7 @@ namespace Microsoft.R.Host.Client.Session {
             if (string.IsNullOrEmpty(requestedPrompt)) {
                 requestedPrompt = DefaultPrompt;
             }
-            return IsRemote ? RemotePromptPrefix + DefaultPrompt : DefaultPrompt;
+            return IsRemote ? RemotePromptPrefix + requestedPrompt : requestedPrompt;
         }
 
         private void OnMutated() {
@@ -539,7 +539,7 @@ if (rtvs:::version != {rtvsPackageVersion}) {{
             var currentRequest = Interlocked.Exchange(ref _currentRequestSource, null);
 
             _contexts = contexts;
-            Prompt = IsRemote ? "*" + prompt : prompt;
+            Prompt = GetDefaultPrompt(prompt);
             MaxLength = len;
 
             var requestEventArgs = new RBeforeRequestEventArgs(contexts, Prompt, len, addToHistory);

--- a/src/Languages/Editor/Test/Fakes/Shell/TestEditorShell.cs
+++ b/src/Languages/Editor/Test/Fakes/Shell/TestEditorShell.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Languages.Editor.Test.Fakes.Shell {
         public Thread MainThread => UIThreadHelper.Instance.Thread;
 
 #pragma warning disable 67
+        public event EventHandler<EventArgs> Started;
         public event EventHandler<EventArgs> Idle;
         public event EventHandler<EventArgs> Terminating;
 

--- a/src/Languages/Editor/Test/Shell/TestShellBase.cs
+++ b/src/Languages/Editor/Test/Shell/TestShellBase.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Languages.Editor.Test.Shell {
 
         public event EventHandler<EventArgs> Idle;
 #pragma warning disable 0067
+        public event EventHandler<EventArgs> Started;
         public event EventHandler<EventArgs> Terminating;
 #pragma warning restore 0067
 

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
@@ -38,7 +38,6 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
         private readonly ISecurityService _securityService;
 
         private bool _showWindowAtStartup;
-        private bool _applicationStarted;
 
         public bool IsConnected { get; private set; }
         public IConnection ActiveConnection { get; private set; }
@@ -78,8 +77,6 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
         }
 
         private void OnApplicationStarted(object sender, EventArgs e) {
-            _shell.Started -= OnApplicationStarted;
-            _applicationStarted = true;
             if (_showWindowAtStartup) {
                 GetOrCreateVisualComponent().Container.Show(focus: true, immediate: false);
             }
@@ -263,7 +260,8 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
                         var installer = _shell.ExportProvider.GetExportedValue<IMicrosoftRClientInstaller>();
                         installer.LaunchRClientSetup(_shell);
                     } else {
-                        ShowWorkspacesWindow();
+                        // If VS is still stating delay until complete.
+                        _showWindowAtStartup = true;
                     }
                     return connections;
                 }
@@ -281,11 +279,6 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
             }
 
             return connections;
-        }
-
-        private void ShowWorkspacesWindow() {
-            // If VS is still stating delay until complete.
-            _showWindowAtStartup = true;
         }
 
         private bool IsValidLocalConnection(string name, string path) {

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
@@ -140,9 +140,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
         public async Task ConnectAsync(IConnectionInfo connection, CancellationToken cancellationToken = default(CancellationToken)) {
             if (ActiveConnection == null || !ActiveConnection.Path.PathEquals(connection.Path) || string.IsNullOrEmpty(_sessionProvider.Broker.Name)) {
                 await TrySwitchBrokerAsync(connection, cancellationToken);
-                await _shell.SwitchToMainThreadAsync();
-                var interactiveWindow = await _interactiveWorkflow.GetOrCreateVisualComponentAsync();
-                interactiveWindow.Container.Show(focus: false, immediate: false);
+                await ShowConnectionsWindowAsync();
             }
         }
         
@@ -207,6 +205,12 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
                 .ToArray();
         }
 
+        private async Task ShowConnectionsWindowAsync() {
+            await _shell.SwitchToMainThreadAsync();
+            var interactiveWindow = await _interactiveWorkflow.GetOrCreateVisualComponentAsync();
+            interactiveWindow.Container.Show(focus: false, immediate: false);
+        }
+
         private void UpdateRecentConnections(bool save = true) {
             RecentConnections = new ReadOnlyCollection<IConnection>(_userConnections.Values.OrderByDescending(c => c.LastUsed).ToList());
             if (save) {
@@ -249,6 +253,8 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
                         var installer = _shell.ExportProvider.GetExportedValue<IMicrosoftRClientInstaller>();
                         installer.LaunchRClientSetup(_shell);
                         return connections;
+                    } else {
+                        ShowConnectionsWindowAsync().DoNotWait();
                     }
                 }
                 // No connections, may be first use or connections were removed.

--- a/src/R/Components/Impl/InteractiveWorkflow/Commands/SessionInformationCommand.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Commands/SessionInformationCommand.cs
@@ -80,9 +80,19 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Commands {
                 window.WriteErrorLine("\t" + Resources.ProcessorCount.FormatInvariant(aboutHost.ProcessorCount));
                 window.WriteErrorLine("\t" + Resources.PhysicalMemory.FormatInvariant(aboutHost.TotalPhysicalMemory, aboutHost.FreePhysicalMemory));
                 window.WriteErrorLine("\t" + Resources.VirtualMemory.FormatInvariant(aboutHost.TotalVirtualMemory, aboutHost.FreeVirtualMemory));
-                window.WriteErrorLine("\t" + Resources.VideoCardName.FormatInvariant(aboutHost.VideoCardName));
-                window.WriteErrorLine("\t" + Resources.VideoProcessor.FormatInvariant(aboutHost.VideoProcessor));
-                window.WriteErrorLine("\t" + Resources.VideoRAM.FormatInvariant(aboutHost.VideoRAM));
+
+                if (!string.IsNullOrEmpty(aboutHost.VideoCardName)) {
+                    window.WriteErrorLine("\t" + Resources.VideoCardName.FormatInvariant(aboutHost.VideoCardName));
+                }
+
+                if (!string.IsNullOrEmpty(aboutHost.VideoProcessor)) {
+                    window.WriteErrorLine("\t" + Resources.VideoProcessor.FormatInvariant(aboutHost.VideoProcessor));
+                }
+
+                if (aboutHost.VideoRAM > 0) {
+                    window.WriteErrorLine("\t" + Resources.VideoRAM.FormatInvariant(aboutHost.VideoRAM));
+                }
+
                 window.WriteErrorLine("\t" + Resources.ConnectedUserCount.FormatInvariant(aboutHost.ConnectedUserCount));
                 window.WriteErrorLine(string.Empty);
             }
@@ -94,6 +104,8 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Commands {
                     services.Telemetry.ReportEvent(TelemetryArea.Configuration, "Remote OS", aboutHost.OS.VersionString);
                     services.Telemetry.ReportEvent(TelemetryArea.Configuration, "Remote CPUs", aboutHost.ProcessorCount);
                     services.Telemetry.ReportEvent(TelemetryArea.Configuration, "Remote RAM", aboutHost.TotalPhysicalMemory);
+                    services.Telemetry.ReportEvent(TelemetryArea.Configuration, "Remote Video Card", aboutHost.VideoCardName);
+                    services.Telemetry.ReportEvent(TelemetryArea.Configuration, "Remote GPU", aboutHost.VideoProcessor);
                 }
             }
         }

--- a/src/R/Components/Impl/PackageManager/IRPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/IRPackageManager.cs
@@ -135,5 +135,10 @@ namespace Microsoft.R.Components.PackageManager {
         /// <param name="libraryPath">Library path (in any format).</param>
         /// <returns>Lock state.</returns>
         Task<PackageLockState> GetPackageLockStateAsync(string name, string libraryPath);
+
+        /// <summary>
+        /// Indicates if the current session is remote
+        /// </summary>
+        bool IsRemoteSession { get; }
     }
 }

--- a/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/RPackageManager.cs
@@ -46,6 +46,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation {
 
         public IRPackageManagerVisualComponent VisualComponent { get; private set; }
 
+        public bool IsRemoteSession => _session.IsRemote;
+
         public RPackageManager(IRSettings settings, IRInteractiveWorkflow interactiveWorkflow, Action dispose) {
             _session = interactiveWorkflow.RSessions.GetOrCreate(SessionGuids.PackageManagerRSessionGuid);
             _settings = settings;

--- a/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageManagerViewModel.cs
@@ -23,10 +23,10 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View.DesignTime {
         public bool HasMultipleErrors => false;
         public bool IsRemoteSession => false;
 
-        public Task SwitchToAvailablePackagesAsync() => Task.CompletedTask;
-        public Task SwitchToInstalledPackagesAsync() => Task.CompletedTask;
-        public Task SwitchToLoadedPackagesAsync() => Task.CompletedTask;
-        public Task ReloadCurrentTabAsync() => Task.CompletedTask;
+        public Task SwitchToAvailablePackagesAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task SwitchToInstalledPackagesAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task SwitchToLoadedPackagesAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task ReloadCurrentTabAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public void SelectPackage(IRPackageViewModel package) { }
         public Task InstallAsync(IRPackageViewModel package, CancellationToken cancellationToken) => Task.CompletedTask;
         public Task UpdateAsync(IRPackageViewModel package, CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageManagerViewModel.cs
@@ -21,7 +21,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View.DesignTime {
 
         public string FirstError => null;
         public bool HasMultipleErrors => false;
-
+        public bool IsRemoteSession => false;
         public Task SwitchToAvailablePackagesAsync() => Task.CompletedTask;
         public Task SwitchToInstalledPackagesAsync() => Task.CompletedTask;
         public Task SwitchToLoadedPackagesAsync() => Task.CompletedTask;

--- a/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/DesignTime/DesignTimeRPackageViewModel.cs
@@ -73,7 +73,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View.DesignTime {
         public bool IsLoaded { get; set; }
         public bool CanBeUninstalled { get; set; }
         public bool IsChanging { get; set; }
-
+        public bool IsRemoteSession { get; set; }
         public bool IsUpdateAvailable { get; }
         public bool HasDetails { get; }
         public bool IsChecked { get; set; }

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
@@ -198,7 +198,9 @@
                             Visibility="{Binding Path=LibraryPath, Converter={x:Static wpf:Converters.NullIsCollapsed}}" />
                 <TextBlock Grid.Row="9" Grid.Column="1" Margin="8,8,0,0" 
                             Visibility="{Binding Path=LibraryPath, Converter={x:Static wpf:Converters.NullIsCollapsed}}">
-                    <Hyperlink NavigateUri="{Binding Path=LibraryPath}" Style="{StaticResource HyperlinkStyle}" RequestNavigate="LibraryPath_RequestNavigate">
+                    <Hyperlink NavigateUri="{Binding Path=LibraryPath}" Style="{StaticResource HyperlinkStyle}" 
+                               RequestNavigate="LibraryPath_RequestNavigate" 
+                               IsEnabled="{Binding Path=IsRemoteSession, Converter={x:Static wpf:Converters.Not}}">
                         <Run Text="{Binding Mode=OneTime, Path=LibraryPath}" />
                     </Hyperlink>
                 </TextBlock>

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
@@ -140,7 +140,7 @@
                            Visibility="{Binding Path=Title, Converter={x:Static wpf:Converters.NullIsCollapsed}}" />
                 <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Path=Title}" Margin="8,8,0,0" 
                            Visibility="{Binding Path=Title, Converter={x:Static wpf:Converters.NullIsCollapsed}}" />
-                
+
                 <!-- descriptions -->
                 <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,8,0,0" Text="{x:Static local:Resources.Package_Description}" FontWeight="Bold" 
                            Visibility="{Binding Path=Description, Converter={x:Static wpf:Converters.NullIsCollapsed}}" />
@@ -196,14 +196,16 @@
                 <!--Library -->
                 <TextBlock Grid.Row="9" Grid.Column="0" FontWeight="Bold" Margin="0,8,0,0" Text="{x:Static local:Resources.Package_LibraryPath}"
                             Visibility="{Binding Path=LibraryPath, Converter={x:Static wpf:Converters.NullIsCollapsed}}" />
-                <TextBlock Grid.Row="9" Grid.Column="1" Margin="8,8,0,0" 
-                            Visibility="{Binding Path=LibraryPath, Converter={x:Static wpf:Converters.NullIsCollapsed}}">
-                    <Hyperlink NavigateUri="{Binding Path=LibraryPath}" Style="{StaticResource HyperlinkStyle}" 
-                               RequestNavigate="LibraryPath_RequestNavigate" 
-                               IsEnabled="{Binding Path=IsRemoteSession, Converter={x:Static wpf:Converters.Not}}">
-                        <Run Text="{Binding Mode=OneTime, Path=LibraryPath}" />
-                    </Hyperlink>
-                </TextBlock>
+                <StackPanel Grid.Row="9" Grid.Column="1" Margin="8,8,0,0"
+                            Visibility="{Binding Path=RepositoryUri, Converter={x:Static wpf:Converters.NullIsCollapsed}}">
+                    <TextBlock Visibility="{Binding Path=IsRemoteSession, Converter={x:Static wpf:Converters.TrueIsNotCollapsed}}" 
+                                   Text="{Binding Mode=OneTime, Path=LibraryPath}" />
+                    <TextBlock Visibility="{Binding Path=IsRemoteSession, Converter={x:Static wpf:Converters.TrueIsCollapsed}}">
+                        <Hyperlink NavigateUri="{Binding Path=LibraryPath}" Style="{StaticResource HyperlinkStyle}" RequestNavigate="LibraryPath_RequestNavigate">
+                            <Run Text="{Binding Mode=OneTime, Path=LibraryPath}" />
+                        </Hyperlink>
+                    </TextBlock>
+                </StackPanel>
 
                 <!--Repository -->
                 <TextBlock Grid.Row="10" Grid.Column="0" FontWeight="Bold" Margin="0,8,0,0" Text="{x:Static local:Resources.Package_Repository}"

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Navigation;
@@ -23,7 +25,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View {
         private void ButtonInstall_Click(object sender, RoutedEventArgs e) {
             Model?.InstallAsync().DoNotWait();
         }
-        
+
         private void ButtonUninstall_Click(object sender, RoutedEventArgs e) {
             Model?.UninstallAsync().DoNotWait();
         }
@@ -37,7 +39,12 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View {
         }
 
         private void LibraryPath_RequestNavigate(object sender, RequestNavigateEventArgs e) {
-            Process.Start(e.Uri.ToString().Replace('/', '\\'));
+            var path = e.Uri.ToString().Replace('/', '\\');
+            if (File.Exists(path)) {
+                try {
+                    Process.Start(path);
+                } catch (Win32Exception) { }
+            }
         }
 
         private void Urls_RequestNavigate(object sender, RequestNavigateEventArgs e) {

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml.cs
@@ -40,7 +40,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.View {
 
         private void LibraryPath_RequestNavigate(object sender, RequestNavigateEventArgs e) {
             var path = e.Uri.ToString().Replace('/', '\\');
-            if (File.Exists(path)) {
+            if (Directory.Exists(path)) {
                 try {
                     Process.Start(path);
                 } catch (Win32Exception) { }

--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageManagerViewModel.cs
@@ -62,6 +62,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
 
         public ReadOnlyObservableCollection<object> Items { get; }
 
+        public bool IsRemoteSession => _packageManager.IsRemoteSession;
+
         public IRPackageViewModel SelectedPackage {
             get { return _selectedPackage; }
             private set { SetProperty(ref _selectedPackage, value); }

--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageViewModel.cs
@@ -26,6 +26,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
         private string _built;
         private bool _isUpdateAvailable;
         private bool _canBeUninstalled;
+        private bool _isRemoteSession;
 
         public static RPackageViewModel CreateAvailable(RPackage package, IRPackageManagerViewModel owner) {
             Uri repositoryUri;
@@ -40,6 +41,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                 NeedsCompilation = package.NeedsCompilation != null && !package.NeedsCompilation.EqualsIgnoreCase("no"),
                 RepositoryUri = repositoryUri,
                 RepositoryText = repositoryUri != null ? null : package.Repository,
+                IsRemoteSession = owner.IsRemoteSession,
                 Title = package.Title.NormalizeWhitespace(),
                 Description = package.Description.NormalizeWhitespace(),
                 Built = package.Built,
@@ -64,6 +66,7 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
                     .ToArray() ?? new string[0],
                 NeedsCompilation = package.NeedsCompilation != null && !package.NeedsCompilation.EqualsIgnoreCase("no"),
                 LibraryPath = package.LibPath,
+                IsRemoteSession = owner.IsRemoteSession,
                 RepositoryUri = repositoryUri,
                 RepositoryText = repositoryUri != null ? null : package.Repository,
                 Description = package.Description.NormalizeWhitespace(),
@@ -114,8 +117,10 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
 
         public bool NeedsCompilation { get; private set; }
 
-        public bool IsRemoteSession => _owner.IsRemoteSession;
-
+        public bool IsRemoteSession {
+            get { return _isRemoteSession; }
+            private set { SetProperty(ref _isRemoteSession, value); }
+        }
         public string LibraryPath {
             get { return _libraryPath; }
             private set { SetProperty(ref _libraryPath, value); }

--- a/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/Implementation/ViewModel/RPackageViewModel.cs
@@ -114,6 +114,8 @@ namespace Microsoft.R.Components.PackageManager.Implementation.ViewModel {
 
         public bool NeedsCompilation { get; private set; }
 
+        public bool IsRemoteSession => _owner.IsRemoteSession;
+
         public string LibraryPath {
             get { return _libraryPath; }
             private set { SetProperty(ref _libraryPath, value); }

--- a/src/R/Components/Impl/PackageManager/ViewModel/IRPackageManagerViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/ViewModel/IRPackageManagerViewModel.cs
@@ -15,6 +15,7 @@ namespace Microsoft.R.Components.PackageManager.ViewModel {
 
         string FirstError { get; }
         bool HasMultipleErrors { get; }
+        bool IsRemoteSession { get; }
 
         Task SwitchToAvailablePackagesAsync();
         Task SwitchToInstalledPackagesAsync();

--- a/src/R/Components/Impl/PackageManager/ViewModel/IRPackageViewModel.cs
+++ b/src/R/Components/Impl/PackageManager/ViewModel/IRPackageViewModel.cs
@@ -33,6 +33,7 @@ namespace Microsoft.R.Components.PackageManager.ViewModel {
         bool HasDetails { get; }
         bool IsChecked { get; set; }
         bool IsChanging { get; set; }
+        bool IsRemoteSession { get; }
 
         void AddDetails(RPackage package, bool isInstalled);
         void UpdateAvailablePackageDetails(RPackage package);

--- a/src/R/Components/Impl/Resources.Designer.cs
+++ b/src/R/Components/Impl/Resources.Designer.cs
@@ -1298,7 +1298,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Video processor: {0}.
+        ///   Looks up a localized string similar to GPU: {0}.
         /// </summary>
         public static string VideoProcessor {
             get {

--- a/src/R/Components/Impl/Resources.resx
+++ b/src/R/Components/Impl/Resources.resx
@@ -541,7 +541,7 @@ Are you sure you want to terminate R session?</value>
     <value>Video controller: {0}</value>
   </data>
   <data name="VideoProcessor" xml:space="preserve">
-    <value>Video processor: {0}</value>
+    <value>GPU: {0}</value>
   </data>
   <data name="VideoRAM" xml:space="preserve">
     <value>Video memory: {0} MB</value>

--- a/src/Setup/VsToolsAssemblies.wxi
+++ b/src/Setup/VsToolsAssemblies.wxi
@@ -10,9 +10,6 @@
   <File Source="$(var.BinDir)\Microsoft.R.Editor.dll" />
   <File Source="$(var.BinDir)\Microsoft.R.Host.Client.dll" />
   <File Source="$(var.BinDir)\Microsoft.R.Support.dll" />
-  <File Source="$(var.BinDir)\Microsoft.Data.ConnectionUI.dll" />
-  <File Source="$(var.BinDir)\Microsoft.Data.ConnectionUI.Dialog.dll" />
-  <File Source="$(var.BinDir)\Microsoft.SqlServer.Types.dll" />
   <File Source="$(var.BinDir)\Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring.dll" />
   <File Source="$(var.BinDir)\Microsoft.VisualStudio.R.Package.dll" />
   <File Source="$(var.BinDir)\Microsoft.VisualStudio.R.Package.pkgdef" />


### PR DESCRIPTION
#2826 When no R present, show option to connect to remote
 - show WS window when user says NO to install MRC

#2808 Clicking on library link in package manager in remote case
 - make plain text when session is remote. Add check for folder existence

#2792 Microsoft.Data.ConnectionUI binaries are unsigned
- remove binaries since VS ships them and install even without SQL tools

#2817 Different prompt for remote 

![image](https://cloud.githubusercontent.com/assets/12820357/20907388/c5ed3ca6-bb02-11e6-940e-922ea7a3118b.png)
