### PR TITLE
Remove UI thread-dependent code from `ConnectionManager` constructor.

### DIFF
--- a/src/Package/Impl/Repl/VsRInteractiveWorkflowProvider.cs
+++ b/src/Package/Impl/Repl/VsRInteractiveWorkflowProvider.cs
@@ -48,6 +48,12 @@ namespace Microsoft.VisualStudio.R.Package.Repl {
             _debuggerModeTracker = debuggerModeTracker;
             _shell = shell;
             _settings = settings;
+
+            _shell.Terminating += OnApplicationTerminating;
+        }
+
+        private void OnApplicationTerminating(object sender, EventArgs e) {
+            Dispose();
         }
 
         public void Dispose() {


### PR DESCRIPTION
`ConnectionManager` constructor is called directly from `RInteractiveWorkflow` constructor. `IRInteractiveWorkflowProvider.GetOrCreate` is accessed from many MEF importing constructors, so there is no guarantee that `ConnectionManager` instance will be created from UI.

Logic to show `Resources.NoLocalR` and launch R Client setup is moved to the `RInteractiveWorkflow.CreateVisualComponentAsync`. It is guaranteed to be called from UI thread and before REPL becomes visible, so there will be no false error messages.

@MikhailArkhipov , can you please take a look at the change?