### PR TITLE
Fix #2838: Collection-typed cells are formatted improperly in data grid

### DIFF
--- a/src/Host/Client/Impl/rtvs/R/grid.R
+++ b/src/Host/Client/Impl/rtvs/R/grid.R
@@ -68,7 +68,11 @@ grid_data <- function(x, rows, cols, row_selector) {
             # If that also fails, give up and display the value as <?>.
             if (!is.character(s) || length(s) != 1) {
                 s <- tryCatch({
-                    paste0(format(s, trim = TRUE, justify = "none"), collapse = '')
+                    # Preserve the behavior of format() for list elements, documented as follows:
+                    # If x is a list, the result is a character vector obtained by applying format.default(x, ...)
+                    # to each element of the list (after unlisting elements which are themselves lists), and then
+                    # collapsing the result for each element with paste(collapse = ", ").
+                    paste(format.default(unlist(s), trim = TRUE, justify = "none"), collapse = ', ')
                 }, error = function(e) {
                     tryCatch({
                         make_repr_str(max_length = 100)(s) 

--- a/src/Package/Test/DataInspect/EvaluationWrapperTest.cs
+++ b/src/Package/Test/DataInspect/EvaluationWrapperTest.cs
@@ -375,7 +375,7 @@ namespace Microsoft.VisualStudio.R.Package.Test.DataInspect {
             grid.Grid[1, 2].Should().Be("6");
         }
 
-        [Test(Skip = "https://github.com/Microsoft/RTVS/issues/2838")]
+        [Test]
         [Category.Variable.Explorer]
         public async Task MatrixLargeCellTest() {
             var script = "matrix.largecell <- matrix(list(as.double(1:5000), 2, 3, 4), nrow = 2, ncol = 2);";


### PR DESCRIPTION
When performing cell-by-cell formatting because column-level format() was unapplicable, duplicate the behavior of the latter.