### PR TITLE
#2361 and #2908

### DIFF
--- a/src/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionViewModel.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionViewModel.cs
@@ -261,19 +261,27 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.ViewModel {
             } catch (InvalidOperationException) { } catch (ArgumentException) { } catch (UriFormatException) { }
 
             if (uri == null || !(uri.IsFile || string.IsNullOrEmpty(uri.Host))) {
-                bool hasScheme = uri != null && !string.IsNullOrEmpty(uri.Scheme);
-                bool hasPort = uri != null && uri.Port >= 0;
+                var hasScheme = uri != null && !string.IsNullOrEmpty(uri.Scheme);
+                var hasPort = uri != null && uri.Port >= 0;
+                var hasPathOrQuery = uri != null && !string.IsNullOrEmpty(uri.PathAndQuery) && uri.PathAndQuery != "/";
 
                 if (hasScheme) {
+                    var components = UriComponents.Scheme | UriComponents.UserInfo | UriComponents.Host | UriComponents.Fragment;
+
+                    if (hasPathOrQuery) {
+                        components |= UriComponents.Path | UriComponents.Query;
+                    }
+
                     if (hasPort) {
-                        return Invariant($"{uri.Scheme}{Uri.SchemeDelimiter}{uri.Host}:{uri.Port}");
+                        components |= UriComponents.StrongPort;
                     }
-                    return Invariant($"{uri.Scheme}{Uri.SchemeDelimiter}{uri.Host}");
-                } else {
-                    if (Uri.CheckHostName(path) != UriHostNameType.Unknown) {
-                        var port = hasPort ? uri.Port : DefaultPort;
-                        return Invariant($"{Uri.UriSchemeHttps}{Uri.SchemeDelimiter}{path.ToLower()}:{port}");
-                    }
+
+                    return uri.GetComponents(components, UriFormat.UriEscaped);
+                }
+
+                if (Uri.CheckHostName(path) != UriHostNameType.Unknown) {
+                    var port = hasPort ? uri.Port : DefaultPort;
+                    return Invariant($"{Uri.UriSchemeHttps}{Uri.SchemeDelimiter}{path.ToLower()}:{port}");
                 }
             }
             return path;

--- a/src/R/Components/Test/ConnectionManager/ConnectionManagerViewModelTest.cs
+++ b/src/R/Components/Test/ConnectionManager/ConnectionManagerViewModelTest.cs
@@ -9,10 +9,12 @@ using FluentAssertions;
 using Microsoft.R.Components.ConnectionManager;
 using Microsoft.R.Components.ConnectionManager.Implementation.ViewModel;
 using Microsoft.R.Components.InteractiveWorkflow;
+using Microsoft.R.Host.Client;
 using Microsoft.UnitTests.Core.FluentAssertions;
 using Microsoft.UnitTests.Core.Mef;
 using Microsoft.UnitTests.Core.Threading;
 using Microsoft.UnitTests.Core.XUnit;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.R.Components.Test.ConnectionManager {
@@ -36,12 +38,15 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
             _exportProvider.Dispose();
         }
 
-        [Test(ThreadType.UI)]
-        public void Connect() {
+        [CompositeTest(ThreadType.UI)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Connect(bool connectToEdited) {
             var connection = _cmvm.LocalConnections.First();
-            _cmvm.Connect(connection, true);
+            _cmvm.Connect(connection, connectToEdited);
 
-            _cmvm.LocalConnections.Should().ContainSingle(c => c.Name == connection.Name)
+            _cmvm.LocalConnections.Should().ContainSingle(c => c.IsConnected)
+                .And.ContainSingle(c => c.Name == connection.Name)
                 .Which.IsConnected.Should().BeTrue();
         }
 
@@ -80,7 +85,6 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
             conn.IsRunning.Should().BeTrue();
         }
 
-
         [CompositeTest(ThreadType.UI)]
         [InlineData(true)]
         [InlineData(false)]
@@ -99,6 +103,29 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
         }
 
         [Test(ThreadType.UI)]
+        public async Task AddLocalWithCommandLine() {
+            var connection = _cmvm.LocalConnections.First();
+            _cmvm.Connect(connection, false);
+
+            connection = _cmvm.LocalConnections.First(c => c.IsConnected);
+            var name = connection.Name + Guid.NewGuid();
+
+            _cmvm.EditNew();
+            _cmvm.EditedConnection.Name = name;
+            _cmvm.EditedConnection.Path = connection.Path;
+            _cmvm.EditedConnection.UpdatePath();
+            _cmvm.EditedConnection.RCommandLineArguments = "--args 5";
+            _cmvm.Save(_cmvm.EditedConnection);
+
+            connection = _cmvm.LocalConnections.First(c => c.Name == name);
+            _cmvm.Connect(connection, false);
+
+            var result = await _workflow.RSession.EvaluateAsync<JValue>("commandArgs(trailingOnly = TRUE)", REvaluationKind.Normal);
+
+            result.Value.Should().Be("5");
+        }
+
+        [Test(ThreadType.UI)]
         public void AddRemote_Edit_NoChanges() {
             _cmvm.EditNew();
 
@@ -112,6 +139,25 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
 
             _cmvm.RemoteConnections.Should().ContainSingle(c => ReferenceEquals(c, connection))
                 .Which.HasChanges.Should().BeFalse();
+        }
+
+        [Test(ThreadType.UI)]
+        public void AddTwoRemotesWithFragments() {
+            _cmvm.EditNew();
+            _cmvm.EditedConnection.Path = "https://machine#123";
+            _cmvm.EditedConnection.UpdatePath();
+            _cmvm.Save(_cmvm.EditedConnection);
+
+            _cmvm.EditNew();
+            _cmvm.EditedConnection.Name = "machine2";
+            _cmvm.EditedConnection.Path = "https://machine#456";
+            _cmvm.EditedConnection.UpdatePath();
+            _cmvm.Save(_cmvm.EditedConnection);
+
+            _cmvm.RemoteConnections.Should().ContainSingle(c => c.Name == "machine")
+                .Which.Path.Should().Be("https://machine:443#123");
+            _cmvm.RemoteConnections.Should().ContainSingle(c => c.Name == "machine2")
+                .Which.Path.Should().Be("https://machine:443#456");
         }
 
         [CompositeTest(ThreadType.UI)]

--- a/src/R/Components/Test/ConnectionManager/ConnectionViewModelTest.cs
+++ b/src/R/Components/Test/ConnectionManager/ConnectionViewModelTest.cs
@@ -134,14 +134,24 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
         [CompositeTest]
         [InlineData("http://host", "http://host:80")]
         [InlineData("http://HOST", "http://host:80")]
+        [InlineData("http://host#1234", "http://host:80#1234")]
+        [InlineData("http://HOST#1234", "http://host:80#1234")]
         [InlineData("https://host", "https://host:443")]
+        [InlineData("https://host#1234", "https://host:443#1234")]
+        [InlineData("https://host/path", "https://host:443/path")]
+        [InlineData("https://host/path#1234", "https://host:443/path#1234")]
         [InlineData("http://host:5000", "http://host:5000")]
+        [InlineData("http://host:5000#1234", "http://host:5000#1234")]
         [InlineData("https://host:5100", "https://host:5100")]
         [InlineData("https://HOST:5100", "https://host:5100")]
+        [InlineData("https://host:5100#1234", "https://host:5100#1234")]
+        [InlineData("https://HOST:5100#1234", "https://host:5100#1234")]
         [InlineData("HOST", "https://host:5444")]
         [InlineData("host", "https://host:5444")]
         [InlineData("host:4000", "host:4000")] // host == scheme in this case and 4000 is actually a host name
         [InlineData("HOST:4000", "HOST:4000")] // host == scheme in this case and 4000 is actually a host name
+        [InlineData("host#1234", "host#1234")]
+        [InlineData("HOST#1234", "HOST#1234")]
         [InlineData("c:\\", "c:\\")]
         public void CompletePath(string original, string expected) {
             ConnectionViewModel.GetCompletePath(original).Should().Be(expected);

--- a/src/R/Interpreters/Test/Install/RInstallationTest.cs
+++ b/src/R/Interpreters/Test/Install/RInstallationTest.cs
@@ -78,18 +78,15 @@ namespace Microsoft.R.Interpreters.Test {
         }
 
         private RegistryKeyMock[] SimulateRegistry01() {
-            return new RegistryKeyMock[] {
-                new RegistryKeyMock(
-                     @"SOFTWARE\R-core\R",
-                     new RegistryKeyMock[] {
-                            new RegistryKeyMock(
-                                 @"SOFTWARE\R-core\R\3.2.3",
-                                 new RegistryKeyMock[0],
-                                 new string[] {"InstallPath"},
-                                 new string[] { @"C:\Program Files\MRO\R-3.2.3" }),
-                            new RegistryKeyMock("3.2.2"),
-                            new RegistryKeyMock("8.0.3")
-                     }),
+            return new[] {
+                new RegistryKeyMock(@"SOFTWARE\R-core\R64",
+                    new RegistryKeyMock(@"3.2.3",
+                            new RegistryKeyMock[0],
+                            new[] {"InstallPath"},
+                            new[] { @"C:\Program Files\MRO\R-3.2.3" }),
+                    new RegistryKeyMock("3.2.2"),
+                    new RegistryKeyMock("8.0.3")
+                )
             };
         }
 
@@ -238,10 +235,10 @@ namespace Microsoft.R.Interpreters.Test {
         private RegistryKeyMock[] SimulateRegistry02() {
             return new RegistryKeyMock[] {
                 new RegistryKeyMock(
-                     @"SOFTWARE\R-core\R",
+                     @"SOFTWARE\R-core\R64",
                      new RegistryKeyMock[] {
                             new RegistryKeyMock(
-                                 @"SOFTWARE\R-core\R\3.1.3",
+                                 @"3.1.3",
                                  new RegistryKeyMock[0],
                                  new string[] {"InstallPath"},
                                  new string[] { @"C:\Program Files\R\R-3.1.3" }),
@@ -250,22 +247,17 @@ namespace Microsoft.R.Interpreters.Test {
         }
 
         private RegistryKeyMock[] SimulateDuplicates() {
-            return new RegistryKeyMock[] {
+            return new[] {
                 new RegistryKeyMock(
-                     @"SOFTWARE\R-core\R",
-                     new RegistryKeyMock[] {
-                            new RegistryKeyMock(
-                                 @"SOFTWARE\R-core\R\3.2.2.803",
-                                 new RegistryKeyMock[0],
-                                 new string[] {"InstallPath"},
-                                 new string[] { @"C:\Program Files\Microsoft\R Client\R_SERVER\" }),
-
-                            new RegistryKeyMock(
-                                 @"SOFTWARE\R-core\R\3.2.2.803 Microsoft R Client",
-                                 new RegistryKeyMock[0],
-                                 new string[] {"InstallPath"},
-                                 new string[] { @"C:\Program Files\Microsoft\R Client\R_SERVER" }),
-                     }),
+                     @"SOFTWARE\R-core\R64", 
+                     new RegistryKeyMock(@"3.2.2.803",
+                         new RegistryKeyMock[0],
+                         new[] {"InstallPath"},
+                         new[] { @"C:\Program Files\Microsoft\R Client\R_SERVER\" }),
+                     new RegistryKeyMock(@"3.2.2.803 Microsoft R Client",
+                         new RegistryKeyMock[0],
+                         new[] {"InstallPath"},
+                         new[] { @"C:\Program Files\Microsoft\R Client\R_SERVER" })),
             };
         }
 


### PR DESCRIPTION
- Fix #2908: Any # added to the server URL is immediately removed when you save
- Fix #2361: Workspaces window doesn't allow multiple connections that differ only by URL fragment
- Fix `RInstallationTest`
- More tests for `ConnectionViewModel` and `ConnectionManagerViewModel`