### PR TITLE
Fixes the issue where sent to remote did not apply the filter.

### DIFF
--- a/src/Common/Core/Impl/Extensions/MatcherExtensions.cs
+++ b/src/Common/Core/Impl/Extensions/MatcherExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.FileSystemGlobbing;
+
+namespace Microsoft.Common.Core {
+    public static class MatcherExtensions {
+        public static IEnumerable<string> GetMatchedFiles(this Matcher matcher,  IEnumerable<string> dirPaths) {
+            List<string> files = new List<string>();
+            foreach(string dir in dirPaths) {
+                files.AddRange(matcher.GetResultsInFullPath(dir));
+            }
+
+            return files.Distinct();
+        }
+    }
+}

--- a/src/Common/Core/Impl/Microsoft.Common.Core.csproj
+++ b/src/Common/Core/Impl/Microsoft.Common.Core.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Extensions\ArraySegmentExtensions.cs" />
     <Compile Include="Extensions\ClipboardExtensions.cs" />
     <Compile Include="Exceptions\CriticalException.cs" />
+    <Compile Include="Extensions\MatcherExtensions.cs" />
     <Compile Include="Extensions\MathExtensions.cs" />
     <Compile Include="Extensions\ReflectionExtensions.cs" />
     <Compile Include="Extensions\SettingsExtensions.cs" />

--- a/src/Package/Impl/ProjectSystem/Commands/SendToRemoteCommand.cs
+++ b/src/Package/Impl/ProjectSystem/Commands/SendToRemoteCommand.cs
@@ -58,19 +58,14 @@ namespace Microsoft.VisualStudio.R.Package.ProjectSystem.Commands {
             string projectDir = Path.GetDirectoryName(_configuredProject.UnconfiguredProject.FullPath);
 
             string fileFilterString = await properties.GetFileFilterAsync();
-            Matcher matcher = new Matcher(StringComparison.InvariantCultureIgnoreCase);
+            Matcher matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
             matcher.AddIncludePatterns(fileFilterString.Split(new string[] { ";" }, StringSplitOptions.RemoveEmptyEntries));
 
             List<string> filteredFiles = new List<string>();
             filteredFiles.AddRange(matcher.GetMatchedFiles(nodes.GetAllFolderPaths(_configuredProject.UnconfiguredProject)));
 
-            foreach (IProjectTree node in nodes) {
-                if (node.IsFile()) {
-                    // Add any file that user specifically selected. 
-                    // This can contain a file ignored by the filter.
-                    filteredFiles.Add(node.FilePath);
-                } 
-            }
+            // Add any file that user specifically selected. This can contain a file ignored by the filter.
+            filteredFiles.AddRange(nodes.Where(n => n.IsFile()).Select(n => n.FilePath));
 
             string projectName = properties.GetProjectName();
             string remotePath = await properties.GetRemoteProjectPathAsync();

--- a/src/Package/Impl/ProjectSystem/ProjectProperties.cs
+++ b/src/Package/Impl/ProjectSystem/ProjectProperties.cs
@@ -134,7 +134,8 @@ namespace Microsoft.VisualStudio.R.Package {
         /// Gets the filter string that selects files to be sent to remote host.
         /// </summary>
         /// <remarks>
-        /// Default filter string is ".r;.rmd;". This selects all R script files, R markdown files.
+        /// Default filter string is ".r;.rmd;.sql;.md;.cpp;". This selects all R script files, 
+        /// R markdown files.
         /// </remarks>
         public async Task<string> GetFileFilterAsync() {
             var runProps = await GetConfigurationRunPropertiesAsync();
@@ -149,7 +150,8 @@ namespace Microsoft.VisualStudio.R.Package {
         /// Gets the filter string that selects files to be sent to remote host.
         /// </summary>
         /// <remarks>
-        /// Default filter string is ".r;.rmd;". This selects all R script files, R markdown files.
+        /// Default filter string is ".r;.rmd;.sql;.md;.cpp;". This selects all R script files, 
+        /// R markdown files.
         /// </remarks>
         public async Task SetFileFilterAsync(string fileTransferFilter) {
             var runProps = await GetConfigurationRunPropertiesAsync();

--- a/src/ProjectSystem/Impl/Extensions/ProjectTreeExtensions.cs
+++ b/src/ProjectSystem/Impl/Extensions/ProjectTreeExtensions.cs
@@ -85,5 +85,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.FileSystemMirroring {
             }
             return string.Empty;
         }
+
+        public static IEnumerable<string> GetAllFolderPaths(this IEnumerable<IProjectTree> nodes, UnconfiguredProject unconfiguredProject) {
+            List<string> paths = new List<string>();
+            foreach (IProjectTree node in nodes) {
+                if (node.IsRoot()) {
+                    paths.Add(Path.GetDirectoryName(unconfiguredProject.FullPath));
+                    paths.AddRange(node.Children.GetAllFolderPaths(unconfiguredProject));
+                } else if (node.IsFolder || node.Children.Count > 0) {
+                    if (Directory.Exists(node.FilePath)) {
+                        paths.Add(node.FilePath);
+                        paths.AddRange(node.Children.GetAllFolderPaths(unconfiguredProject));
+                    }
+                }
+            }
+            return paths.Distinct();
+        }
+
+        public static bool IsFile(this IProjectTree node) {
+            return (node != null) && !node.IsFolder && (node.Root != node);
+        }
     }
 }


### PR DESCRIPTION
Applies file filter while sending files using "send to remote" command. Exception to this rule is when the user selects file(s) to be sent, then that/those file(s) will be sent always.