### PR TITLE
#2954 Can't connect to custom local interpreter

### DIFF
--- a/src/Languages/Editor/Impl/project.15.0.json
+++ b/src/Languages/Editor/Impl/project.15.0.json
@@ -11,7 +11,6 @@
     "Microsoft.VisualStudio.Text.Data": "15.0.25901-RC",
     "Microsoft.VisualStudio.Text.Logic": "15.0.25901-RC",
     "Microsoft.VisualStudio.Text.UI": "15.0.25901-RC",
-    "Microsoft.VisualStudio.Text.UI.Wpf": "15.0.25901-RC",
     "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
     "Microsoft.VisualStudio.TextManager.Interop.8.0": "8.0.50727"
   },

--- a/src/Mocks/VisualStudio/project.15.0.json
+++ b/src/Mocks/VisualStudio/project.15.0.json
@@ -5,7 +5,7 @@
     "Microsoft.VisualStudio.Editor": "15.0.25824-RC",
     "Microsoft.VisualStudio.ImageCatalog": "15.0.25824-RC",
     "Microsoft.VisualStudio.ProjectSystem": "15.0.594-pre",
-    "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.3.25407",
+    "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "15.0.25726-Preview5",
     "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime": "15.0.25726-Preview5",
     "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "14.1.4",
     "Microsoft.VisualStudio.Text.Data": "15.0.25901-RC",

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
@@ -136,7 +136,9 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
 
                 // Credentials are saved by URI. Delete the credentials if there are no other connections using it.
                 if (_connections.All(kvp => kvp.Value.Uri != connection.Uri)) {
-                    _securityService.DeleteUserCredentials(connection.Uri.ToCredentialAuthority());
+                    if (connection.Uri != null) {
+                        _securityService.DeleteUserCredentials(connection.Uri.ToCredentialAuthority());
+                    }
                 }
             }
 

--- a/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
@@ -102,10 +102,17 @@
                         <WrapPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,0">
                             <Button Margin="0,0,4,0" Padding="6,2,6,2" MinWidth="75" MinHeight="23"
                                     VerticalAlignment="Center" Click="ButtonSave_Click" 
-                                    IsEnabled="{Binding Path=HasChanges, Mode=OneWay}" ToolTipService.ShowOnDisabled="True"
+                                    ToolTipService.ShowOnDisabled="True"
                                     Content="{x:Static components:Resources.ConnectionManager_Save}" 
-                                    ToolTip="{Binding Path=SaveButtonTooltip}"/>
-<!--
+                                    ToolTip="{Binding Path=SaveButtonTooltip}">
+                                <Button.IsEnabled>
+                                    <MultiBinding Converter="{x:Static rwpf:Converters.All}">
+                                        <Binding Path="IsValid" />
+                                        <Binding Path="HasChanges" Mode="OneWay" />
+                                    </MultiBinding>
+                                </Button.IsEnabled>
+                            </Button>
+                            <!--
                             <Button VerticalAlignment="Center" Click="ButtonTestConnection_Click"
                                     Style="{StaticResource HyperlinkButton}"
                                     Content="{x:Static components:Resources.ConnectionManager_TestConnection}"

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionViewModel.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionViewModel.cs
@@ -301,8 +301,16 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.ViewModel {
 
         private static bool IsValidConnectionName(string name) {
             // Broker derives log name from connection name and hence the connection cannot contain all characters. 
-            return !string.IsNullOrWhiteSpace(name) &&
-                   !name.Where(ch => !Char.IsLetterOrDigit(ch) && !_allowedNameChars.Contains(ch)).Any();
+            if (string.IsNullOrWhiteSpace(name)) {
+                return false;
+            }
+            if (!char.IsLetterOrDigit(name[0])) {
+                return false;
+            }
+            if (name.IndexOfOrdinal("..") >= 0) {
+                return false;
+            }
+            return !name.Where(ch => !char.IsLetterOrDigit(ch) && !_allowedNameChars.Contains(ch)).Any();
         }
     }
 }

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionViewModel.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.Shell;
@@ -223,7 +224,12 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.ViewModel {
                 // Check if the name was calculated from the previous path
                 var currentName = Name ?? string.Empty;
                 if (string.IsNullOrEmpty(currentName) || string.Compare(currentName, previousProposedName, StringComparison.CurrentCultureIgnoreCase) == 0) {
-                    Name = currentProposedName;
+                    // Broker derives log name from connection name and hence the connection
+                    // cannot contain all characters. Characters allowed in the path is a good bet.
+                    var invalidChars = System.IO.Path.GetInvalidPathChars().Union(System.IO.Path.GetInvalidFileNameChars()).ToArray();
+                    if (currentProposedName == null || currentProposedName.IndexOfAny(invalidChars) < 0) {
+                        Name = currentProposedName;
+                    }
                 }
             }
 


### PR DESCRIPTION
- Pipe must be opened in async mode for the WaitForConnectionAsync to be cancellable. Otherwise token is ignored.
- We need to cancel on either process exit or user clicks cancel
- Actual issue is that broker derives log name from the connection name. Hence we need to make sure the name is reasonably clean.
- Also fixed the issue when typing bad connection names crashed VS