### PR TITLE
#2974 Can not input line break between " and other command.

### DIFF
--- a/src/R/Editor/Application.Test/Formatting/AutoFormatTest.cs
+++ b/src/R/Editor/Application.Test/Formatting/AutoFormatTest.cs
@@ -417,5 +417,44 @@ namespace Microsoft.R.Editor.Application.Test.Formatting {
                 actual.Should().Be(expected);
             }
         }
+
+        [Test]
+        [Category.Interactive]
+        public async Task R_AutoFormatLineBreak() {
+            using (var script = await _editorHost.StartScript(_exportProvider, "x <- 1", RContentTypeDefinition.ContentType)) {
+                script.MoveRight(2);
+                script.Enter();
+
+                string actual = script.EditorText;
+                string expected =
+@"x
+<- 1";
+                actual.Should().Be(expected);
+                script.View.Caret.Position.BufferPosition.Position.Should().Be(3);
+            }
+        }
+
+        [Test]
+        [Category.Interactive]
+        public async Task R_NoAutoFormatInsideString() {
+            string content = 
+@"s <- '
+    string
+   'x <- 1";
+            using (var script = await _editorHost.StartScript(_exportProvider, content, RContentTypeDefinition.ContentType)) {
+                script.MoveDown(2);
+                script.MoveRight(4);
+                script.Enter();
+
+                string actual = script.EditorText;
+                string expected = 
+@"s <- '
+    string
+   '
+x <- 1";
+                actual.Should().Be(expected);
+                script.View.Caret.Position.BufferPosition.Position.Should().Be(26);
+            }
+        }
     }
 }

--- a/src/R/Editor/Impl/Formatting/AutoFormat.cs
+++ b/src/R/Editor/Impl/Formatting/AutoFormat.cs
@@ -4,11 +4,14 @@
 using System;
 using Microsoft.Common.Core;
 using Microsoft.Languages.Editor.ContainedLanguage;
+using Microsoft.Languages.Editor.Services;
 using Microsoft.Languages.Editor.Shell;
 using Microsoft.R.Components.ContentTypes;
 using Microsoft.R.Core.AST;
 using Microsoft.R.Core.AST.Scopes;
 using Microsoft.R.Core.AST.Statements;
+using Microsoft.R.Core.Tokens;
+using Microsoft.R.Editor.Classification;
 using Microsoft.R.Editor.Document;
 using Microsoft.R.Editor.Settings;
 using Microsoft.VisualStudio.Text;
@@ -65,7 +68,7 @@ namespace Microsoft.R.Editor.Formatting {
                     // Do not format large scope blocks for performance reasons
                     if (scopeStatement != null && scopeStatement.Length < 200) {
                         FormatOperations.FormatNode(textView, subjectBuffer, editorShell, scopeStatement);
-                    } else if(CanFormatLine(textView, subjectBuffer.CurrentSnapshot, ast, -1)){
+                    } else if(CanFormatLine(textView, subjectBuffer, -1)){
                         FormatOperations.FormatViewLine(textView, subjectBuffer, -1, editorShell);
                     }
                 }
@@ -83,20 +86,20 @@ namespace Microsoft.R.Editor.Formatting {
             }
         }
 
-        private static bool CanFormatLine(ITextView textView, ITextSnapshot snapshot, AstRoot ast, int offset) {
-            // Do not format inside strings or when change was destructive
-            if(ast.Children == null) {
-                return false;
-            }
-            var gs = ast.Children[0] as GlobalScope;
-            if (gs != null && gs.Children.Count == 0) {
-                return false;
-            }
+        private static bool CanFormatLine(ITextView textView, ITextBuffer textBuffer, int lineOffset) {
+            // Do not format inside strings. At this point AST may be empty due to the nature 
+            // of [destructive] changes made to the document. We have to resort to tokenizer. 
+            // In order to keep performance good during typing we'll use token stream from the classifier.
             SnapshotPoint? caretPoint = REditorDocument.MapCaretPositionFromView(textView);
             if (caretPoint.HasValue) {
+                var snapshot = textBuffer.CurrentSnapshot;
                 int lineNumber = snapshot.GetLineNumberFromPosition(caretPoint.Value.Position);
-                var line = snapshot.GetLineFromLineNumber(lineNumber + offset);
-                return !ast.IsPositionInsideString(line.Start);
+                var line = snapshot.GetLineFromLineNumber(lineNumber + lineOffset);
+
+                var classifier = ServiceManager.GetService<RClassifier>(textBuffer);
+                var tokenIndex = classifier.Tokens.GetItemContaining(line.Start);
+
+                return tokenIndex < 0 || classifier.Tokens[tokenIndex].TokenType != RTokenType.String;
             }
             return false;
         }

--- a/src/R/Editor/Impl/Selection/RSelectionTracker.cs
+++ b/src/R/Editor/Impl/Selection/RSelectionTracker.cs
@@ -26,9 +26,8 @@ namespace Microsoft.R.Editor.Selection {
         /// Offset from token to the caret position
         /// </summary>
         private int _offset;
-
         private ITextRange _changingRange;
-        private int _lengthBeforeChange;
+        private readonly int _lengthBeforeChange;
 
         /// <summary>
         /// SelectionTracker constructor
@@ -80,6 +79,13 @@ namespace Microsoft.R.Editor.Selection {
             // that caret position is going to remain relative to the same token index
             itemIndex = -1;
             offset = 0;
+
+            // Expand range to include the next line. This is needed when user introduces line break.
+            var lineNumber = snapshot.GetLineNumberFromPosition(_changingRange.End);
+            if (lineNumber < snapshot.LineCount - 1) {
+                var end = snapshot.GetLineFromLineNumber(lineNumber + 1).End;
+                _changingRange = TextRange.FromBounds(_changingRange.Start, end);
+            }
 
             var tokenizer = new RTokenizer();
             IReadOnlyTextRangeCollection<RToken> tokens =


### PR DESCRIPTION
The issue was twofold:

1). Caret positioning after formatting was incorrect. For example, in 

`x |<- 1`

typing ENTER produced

```
x
<|- 1
```

because caret position tracker only tracked changed range and offset from `x` was incorrect since autoformat removes trailing space. The fix is to for the tracking range to include next line do next token after the CRLF will be seen.

2). In

```
s <- 
    "
     string
    "|x <- 1
```

upon ENTER formatter attempted to format `    "` not seeing that it is inside the string.

