### PR TITLE
Fixes to user profile tests.

### DIFF
--- a/src/Common/Core/Impl/IO/IUserProfileNamedPipeFactory.cs
+++ b/src/Common/Core/Impl/IO/IUserProfileNamedPipeFactory.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.IO.Pipes;
+
+namespace Microsoft.Common.Core.IO {
+    public interface IUserProfileNamedPipeFactory {
+        NamedPipeServerStream CreatePipe(string name, int maxInstances = NamedPipeServerStream.MaxAllowedServerInstances);
+    }
+}

--- a/src/Common/Core/Impl/Microsoft.Common.Core.csproj
+++ b/src/Common/Core/Impl/Microsoft.Common.Core.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Extensions\SettingsExtensions.cs" />
     <Compile Include="Extensions\StreamExtensions.cs" />
     <Compile Include="Extensions\TaskCompletionSourceExtensions.cs" />
+    <Compile Include="IO\IUserProfileNamedPipeFactory.cs" />
     <Compile Include="IO\KnownFolderGuids.cs" />
     <Compile Include="Json\Json.cs" />
     <Compile Include="Logging\ILoggerProvider.cs" />

--- a/src/Host/Protocol/Test/Microsoft.R.Host.Protocol.Test.csproj
+++ b/src/Host/Protocol/Test/Microsoft.R.Host.Protocol.Test.csproj
@@ -81,6 +81,7 @@
     <Compile Include="UserProfileServicePipe\UserProfileServiceFuzzTestMock.cs" />
     <Compile Include="UserProfileServicePipe\UserProfileResultMock.cs" />
     <Compile Include="UserProfileServicePipe\UserProfileServicePipeTest.cs" />
+    <Compile Include="UserProfileServicePipe\UserProfileTestNamedPipeTestStreamFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/Host/Protocol/Test/UserProfileServicePipe/UserProfileServicePipeTest.cs
+++ b/src/Host/Protocol/Test/UserProfileServicePipe/UserProfileServicePipeTest.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Common.Core;
+using Microsoft.Common.Core.IO;
 using Microsoft.Common.Core.Json;
 using Microsoft.Common.Core.OS;
 using Microsoft.R.Host.UserProfile;
@@ -37,15 +38,15 @@ namespace Microsoft.R.Host.Protocol.Test.UserProfileServicePipe {
             return Json.DeserializeObject<UserProfileResultMock>(jsonResp);
         }
 
-        private async Task CreateProfileTestRunnerAsync(IUserProfileServices creator, string input, bool isValidParse, bool isValidAccount, bool isExistingAccount, int serverTimeOut, int clientTimeOut) {
+        private async Task CreateProfileTestRunnerAsync(IUserProfileServices creator, IUserProfileNamedPipeFactory pipeFactory, string input, bool isValidParse, bool isValidAccount, bool isExistingAccount, int serverTimeOut, int clientTimeOut) {
             ManualResetEventSlim testDone = new ManualResetEventSlim(false);
             Task.Run(async () => {
                 try {
                     if (isValidParse) {
-                        Func<Task> f = async () => await RUserProfileServicesHelper.CreateProfileAsync(serverTimeOutms: serverTimeOut, clientTimeOutms: clientTimeOut, userProfileService: creator);
+                        Func<Task> f = async () => await RUserProfileServicesHelper.CreateProfileAsync(serverTimeOutms: serverTimeOut, clientTimeOutms: clientTimeOut, userProfileService: creator, pipeFactory: pipeFactory);
                         f.ShouldNotThrow();
                     } else {
-                        Func<Task> f = () => RUserProfileServicesHelper.CreateProfileAsync(serverTimeOutms: serverTimeOut, clientTimeOutms: clientTimeOut, userProfileService: creator);
+                        Func<Task> f = () => RUserProfileServicesHelper.CreateProfileAsync(serverTimeOutms: serverTimeOut, clientTimeOutms: clientTimeOut, userProfileService: creator, pipeFactory: pipeFactory);
                         await f.ShouldThrowAsync<Exception>();
                     }
                 } finally {
@@ -66,10 +67,10 @@ namespace Microsoft.R.Host.Protocol.Test.UserProfileServicePipe {
             testDone.Wait(serverTimeOut + clientTimeOut);
         }
 
-        private async Task CreateProfileFuzzTestRunnerAsync(IUserProfileServices creator, string input, int serverTimeOut, int clientTimeOut) {
+        private async Task CreateProfileFuzzTestRunnerAsync(IUserProfileServices creator, IUserProfileNamedPipeFactory pipeFactory, string input, int serverTimeOut, int clientTimeOut) {
             var task = Task.Run(async () => {
                 try {
-                    await RUserProfileServicesHelper.CreateProfileAsync(serverTimeOutms: serverTimeOut, clientTimeOutms: clientTimeOut, userProfileService: creator);
+                    await RUserProfileServicesHelper.CreateProfileAsync(serverTimeOutms: serverTimeOut, clientTimeOutms: clientTimeOut, userProfileService: creator, pipeFactory: pipeFactory);
                 } catch (JsonReaderException) {
                     // expecting JSON parsing to fail
                     // JSON parsing may fail due to randomly generated strings as input.
@@ -104,7 +105,8 @@ namespace Microsoft.R.Host.Protocol.Test.UserProfileServicePipe {
         [InlineData("", null, null, null, false, false, false)]
         public async Task CreateProfileTest(string input, string username, string domain, string sid, bool isValidParse, bool isValidAccount, bool isExistingAccount) {
             var creator = UserProfileServiceMock.Create(username, domain, sid, isValidParse, isValidAccount, isExistingAccount);
-            await CreateProfileTestRunnerAsync(creator, input, isValidParse, isValidAccount, isExistingAccount, 500, 500);
+            var pipeFactory = new UserProfileTestNamedPipeTestStreamFactory();
+            await CreateProfileTestRunnerAsync(creator, pipeFactory, input, isValidParse, isValidAccount, isExistingAccount, 500, 500);
         }
 
         [Test]
@@ -124,10 +126,10 @@ namespace Microsoft.R.Host.Protocol.Test.UserProfileServicePipe {
                 string json = "{" + string.Format(inner, username, domain, sid) + "}";
                 
                 string testResult = string.Empty;
-                UserProfileServiceFuzzTestMock creator = new UserProfileServiceFuzzTestMock();
-
+                var creator = new UserProfileServiceFuzzTestMock();
+                var pipeFactory = new UserProfileTestNamedPipeTestStreamFactory();
                 try {
-                    await CreateProfileFuzzTestRunnerAsync(creator, json, 100, 100);
+                    await CreateProfileFuzzTestRunnerAsync(creator, pipeFactory, json, 100, 100);
                 } catch (IOException) {
                     // expect pipe to fail. The client side pipe throws an IOException when the server side pipe 
                     // closes due to IO error or attempt to access unauthorized memory.

--- a/src/Host/Protocol/Test/UserProfileServicePipe/UserProfileTestNamedPipeTestStreamFactory.cs
+++ b/src/Host/Protocol/Test/UserProfileServicePipe/UserProfileTestNamedPipeTestStreamFactory.cs
@@ -5,14 +5,14 @@ using System.IO.Pipes;
 using System.Security.Principal;
 using Microsoft.Common.Core.IO;
 
-namespace Microsoft.R.Host.Protocol {
-    public class NamedPipeServerStreamFactory : IUserProfileNamedPipeFactory {
+namespace Microsoft.R.Host.Protocol.Test.UserProfileServicePipe {
+    public class UserProfileTestNamedPipeTestStreamFactory : IUserProfileNamedPipeFactory {
         public static string CreatorName = "Microsoft.R.Host.UserProfile.Creator{b101cc2d-156e-472e-8d98-b9d999a93c7a}";
         public static string DeletorName = "Microsoft.R.Host.UserProfile.Deletor{9c2aa072-7549-4992-8c17-0ccb9b8f196e}";
 
         public NamedPipeServerStream CreatePipe(string name, int maxInstances = NamedPipeServerStream.MaxAllowedServerInstances) {
             PipeSecurity ps = new PipeSecurity();
-            SecurityIdentifier sid = new SecurityIdentifier(WellKnownSidType.NetworkServiceSid, null);
+            SecurityIdentifier sid = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
             PipeAccessRule par = new PipeAccessRule(sid, PipeAccessRights.ReadWrite, System.Security.AccessControl.AccessControlType.Allow);
             ps.AddAccessRule(par);
             return new NamedPipeServerStream(name, PipeDirection.InOut, maxInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous, 1024, 1024, ps);

--- a/src/Host/UserProfile/Impl/RUserProfileService.cs
+++ b/src/Host/UserProfile/Impl/RUserProfileService.cs
@@ -6,9 +6,9 @@ using System.ServiceProcess;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core;
-using Microsoft.Extensions.Logging;
-using Microsoft.R.Host.Protocol;
+using Microsoft.Common.Core.IO;
 using Microsoft.Common.Core.OS;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.R.Host.UserProfile {
     partial class RUserProfileService : ServiceBase {
@@ -56,10 +56,10 @@ namespace Microsoft.R.Host.UserProfile {
             await ProfileWorkerAsync(RUserProfileServicesHelper.DeleteProfileAsync, ServiceReadAfterConnectTimeoutMs, ClientResponseReadTimeoutMs, _deleteWorkerDone, ct, _logger);
         }
 
-        private static async Task ProfileWorkerAsync( Func<int,int, IUserProfileServices,CancellationToken, ILogger, Task> action, int serverTimeOutms, int clientTimeOutms,  ManualResetEvent workerDone, CancellationToken ct, ILogger logger) {
+        private static async Task ProfileWorkerAsync( Func<int,int, IUserProfileServices, IUserProfileNamedPipeFactory, CancellationToken, ILogger, Task> action, int serverTimeOutms, int clientTimeOutms,  ManualResetEvent workerDone, CancellationToken ct, ILogger logger) {
             while (!ct.IsCancellationRequested) {
                 try {
-                    await action?.Invoke(ServiceReadAfterConnectTimeoutMs, ClientResponseReadTimeoutMs, null, ct, logger);
+                    await action?.Invoke(ServiceReadAfterConnectTimeoutMs, ClientResponseReadTimeoutMs, null, null, ct, logger);
                 } catch (TaskCanceledException) {
                 } catch (Exception ex) when (!ex.IsCriticalException()) {
                     logger?.LogError(Resources.Error_UserProfileServiceError, ex.Message);


### PR DESCRIPTION
Fixes #3012. The named pipe server in user-profile service only accepts connections from a network service. Since the tests run as user the connection is not authorized. Added a factory interface to create a server pipe for testing that does not require client to be a network service.