### PR TITLE
Prevent hang after using locator()

### DIFF
--- a/src/R/Components/Impl/Plots/IRPlotDeviceVisualComponent.cs
+++ b/src/R/Components/Impl/Plots/IRPlotDeviceVisualComponent.cs
@@ -14,17 +14,13 @@ namespace Microsoft.R.Components.Plots {
         void Unassign();
         int InstanceId { get; }
         bool HasPlot { get; }
-        bool LocatorMode { get; }
         int ActivePlotIndex { get; }
         int PlotCount { get; }
         string DeviceName { get; }
         bool IsDeviceActive { get; }
         IRPlotDevice Device { get; }
         IRPlot ActivePlot { get; }
-        Task<LocatorResult> StartLocatorModeAsync(CancellationToken ct);
-        void EndLocatorMode();
         // Functions below are for use by tests
-        void ClickPlot(int x, int y);
         Task ResizePlotAsync(int pixelWidth, int pixelHeight, int resolution);
     }
 }

--- a/src/R/Components/Impl/Plots/IRPlotManager.cs
+++ b/src/R/Components/Impl/Plots/IRPlotManager.cs
@@ -84,6 +84,11 @@ namespace Microsoft.R.Components.Plots {
         Task<LocatorResult> StartLocatorModeAsync(Guid deviceId, CancellationToken cancellationToken);
 
         /// <summary>
+        /// End the locator mode with the specified result.
+        /// </summary>
+        Task EndLocatorModeAsync(IRPlotDevice device, LocatorResult result);
+
+        /// <summary>
         /// Process an incoming device creation message from the host.
         /// This assigns the new device to an available visual component (creating one if necessary).
         /// </summary>

--- a/src/R/Components/Impl/Plots/IRPlotManager.cs
+++ b/src/R/Components/Impl/Plots/IRPlotManager.cs
@@ -86,7 +86,7 @@ namespace Microsoft.R.Components.Plots {
         /// <summary>
         /// End the locator mode with the specified result.
         /// </summary>
-        Task EndLocatorModeAsync(IRPlotDevice device, LocatorResult result);
+        void EndLocatorMode(IRPlotDevice device, LocatorResult result);
 
         /// <summary>
         /// Process an incoming device creation message from the host.

--- a/src/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceCommand.cs
+++ b/src/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceCommand.cs
@@ -19,7 +19,7 @@ namespace Microsoft.R.Components.Plots.Implementation.Commands {
 
         protected bool IsInLocatorMode {
             get {
-                return VisualComponent.LocatorMode;
+                return VisualComponent.Device.LocatorMode;
             }
         }
 

--- a/src/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceCommand.cs
+++ b/src/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceCommand.cs
@@ -19,7 +19,7 @@ namespace Microsoft.R.Components.Plots.Implementation.Commands {
 
         protected bool IsInLocatorMode {
             get {
-                return VisualComponent.Device.LocatorMode;
+                return VisualComponent.Device?.LocatorMode ?? false;
             }
         }
 

--- a/src/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceEndLocatorCommand.cs
+++ b/src/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceEndLocatorCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.Common.Core;
 using Microsoft.R.Components.Controller;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Host.Client;
@@ -23,7 +24,7 @@ namespace Microsoft.R.Components.Plots.Implementation.Commands {
         }
 
         public Task<CommandResult> InvokeAsync() {
-            InteractiveWorkflow.Plots.EndLocatorModeAsync(VisualComponent.Device, LocatorResult.CreateNotClicked());
+            InteractiveWorkflow.Plots.EndLocatorModeAsync(VisualComponent.Device, LocatorResult.CreateNotClicked()).DoNotWait();
 
             return Task.FromResult(CommandResult.Executed);
         }

--- a/src/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceEndLocatorCommand.cs
+++ b/src/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceEndLocatorCommand.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using Microsoft.R.Components.Controller;
 using Microsoft.R.Components.InteractiveWorkflow;
+using Microsoft.R.Host.Client;
 
 namespace Microsoft.R.Components.Plots.Implementation.Commands {
     internal sealed class PlotDeviceEndLocatorCommand : PlotDeviceCommand, IAsyncCommand {
@@ -22,7 +23,8 @@ namespace Microsoft.R.Components.Plots.Implementation.Commands {
         }
 
         public Task<CommandResult> InvokeAsync() {
-            VisualComponent.EndLocatorMode();
+            InteractiveWorkflow.Plots.EndLocatorModeAsync(VisualComponent.Device, LocatorResult.CreateNotClicked());
+
             return Task.FromResult(CommandResult.Executed);
         }
     }

--- a/src/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceEndLocatorCommand.cs
+++ b/src/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceEndLocatorCommand.cs
@@ -24,7 +24,7 @@ namespace Microsoft.R.Components.Plots.Implementation.Commands {
         }
 
         public Task<CommandResult> InvokeAsync() {
-            InteractiveWorkflow.Plots.EndLocatorModeAsync(VisualComponent.Device, LocatorResult.CreateNotClicked()).DoNotWait();
+            InteractiveWorkflow.Plots.EndLocatorMode(VisualComponent.Device, LocatorResult.CreateNotClicked());
 
             return Task.FromResult(CommandResult.Executed);
         }

--- a/src/R/Components/Impl/Plots/Implementation/RPlotDeviceVisualComponent.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotDeviceVisualComponent.cs
@@ -47,8 +47,8 @@ namespace Microsoft.R.Components.Plots.Implementation {
                 .Add(() => control.ContextMenuRequested -= Control_ContextMenuRequested)
                 .Add(() => _viewModel.DeviceNameChanged -= ViewModel_DeviceNameChanged)
                 .Add(() => _viewModel.LocatorModeChanged -= ViewModel_LocatorModeChanged)
-                .Add(() => _viewModel.PlotChanged += ViewModel_PlotChanged)
-                .Add(() => _plotManager.ActiveDeviceChanged += PlotManager_ActiveDeviceChanged);
+                .Add(() => _viewModel.PlotChanged -= ViewModel_PlotChanged)
+                .Add(() => _plotManager.ActiveDeviceChanged -= PlotManager_ActiveDeviceChanged);
 
             control.ContextMenuRequested += Control_ContextMenuRequested;
             _viewModel.DeviceNameChanged += ViewModel_DeviceNameChanged;
@@ -74,8 +74,6 @@ namespace Microsoft.R.Components.Plots.Implementation {
         public IVisualComponentContainer<IVisualComponent> Container { get; }
 
         public bool HasPlot => _viewModel.PlotImage != null;
-
-        public bool LocatorMode => _viewModel.LocatorMode;
 
         public int ActivePlotIndex {
             get {
@@ -133,14 +131,6 @@ namespace Microsoft.R.Components.Plots.Implementation {
         public void Unassign() {
              _viewModel.Unassign();
             Container.UpdateCommandStatus(false);
-        }
-
-        public Task<LocatorResult> StartLocatorModeAsync(CancellationToken ct) => _viewModel.StartLocatorModeAsync(ct);
-
-        public void EndLocatorMode() => _viewModel.EndLocatorMode();
-
-        public void ClickPlot(int x, int y) {
-            _viewModel.ClickPlot(x, y);
         }
 
         public async Task ResizePlotAsync(int pixelWidth, int pixelHeight, int resolution) {

--- a/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
         private readonly ICoreShell _shell;
 
         private TaskCompletionSource<LocatorResult> _locatorTcs;
-        private CancellationTokenRegistration? _locatorCancelTokenRegistration;
+        private CancellationTokenRegistration _locatorCancelTokenRegistration;
 
         public event EventHandler<RPlotDeviceEventArgs> ActiveDeviceChanged;
         public event EventHandler<RPlotDeviceEventArgs> DeviceAdded;
@@ -211,8 +211,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
             _locatorTcs = null;
             tcs?.TrySetResult(result);
 
-            _locatorCancelTokenRegistration?.Dispose();
-            _locatorCancelTokenRegistration = null;
+            _locatorCancelTokenRegistration.Dispose();
 
             return Task.CompletedTask;
         }
@@ -224,8 +223,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
             _locatorTcs = null;
             tcs?.TrySetCanceled();
 
-            _locatorCancelTokenRegistration?.Dispose();
-            _locatorCancelTokenRegistration = null;
+            _locatorCancelTokenRegistration.Dispose();
         }
 
         public async Task RemoveAllPlotsAsync(IRPlotDevice device) {

--- a/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
@@ -209,7 +209,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
 
             var tcs = _locatorTcs;
             _locatorTcs = null;
-            tcs?.SetResult(result);
+            tcs?.TrySetResult(result);
 
             _locatorCancelTokenRegistration?.Dispose();
             _locatorCancelTokenRegistration = null;
@@ -222,7 +222,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
 
             var tcs = _locatorTcs;
             _locatorTcs = null;
-            tcs?.SetCanceled();
+            tcs?.TrySetCanceled();
 
             _locatorCancelTokenRegistration?.Dispose();
             _locatorCancelTokenRegistration = null;

--- a/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
@@ -204,7 +204,7 @@ namespace Microsoft.R.Components.Plots.Implementation {
             return _locatorTcs.Task;
         }
 
-        public Task EndLocatorModeAsync(IRPlotDevice device, LocatorResult result) {
+        public void EndLocatorMode(IRPlotDevice device, LocatorResult result) {
             device.LocatorMode = false;
 
             var tcs = _locatorTcs;
@@ -212,8 +212,6 @@ namespace Microsoft.R.Components.Plots.Implementation {
             tcs?.TrySetResult(result);
 
             _locatorCancelTokenRegistration.Dispose();
-
-            return Task.CompletedTask;
         }
 
         private void CancelLocatorMode(IRPlotDevice device) {

--- a/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
+++ b/src/R/Components/Impl/Plots/Implementation/RPlotManager.cs
@@ -24,11 +24,15 @@ namespace Microsoft.R.Components.Plots.Implementation {
         private readonly IRInteractiveWorkflow _interactiveWorkflow;
         private readonly IFileSystem _fileSystem;
         private readonly DisposableBag _disposableBag;
+        private readonly object _devicesLock = new object();
         private readonly List<IRPlotDevice> _devices = new List<IRPlotDevice>();
         private readonly Dictionary<int, IRPlotDeviceVisualComponent> _visualComponents = new Dictionary<int, IRPlotDeviceVisualComponent>();
         private readonly Dictionary<Guid, IRPlotDeviceVisualComponent> _assignedVisualComponents = new Dictionary<Guid, IRPlotDeviceVisualComponent>();
         private readonly List<IRPlotDeviceVisualComponent> _unassignedVisualComponents = new List<IRPlotDeviceVisualComponent>();
         private readonly ICoreShell _shell;
+
+        private TaskCompletionSource<LocatorResult> _locatorTcs;
+        private CancellationTokenRegistration? _locatorCancelTokenRegistration;
 
         public event EventHandler<RPlotDeviceEventArgs> ActiveDeviceChanged;
         public event EventHandler<RPlotDeviceEventArgs> DeviceAdded;
@@ -109,7 +113,9 @@ namespace Microsoft.R.Components.Plots.Implementation {
                 return;
             }
 
-            _devices.Remove(device);
+            lock (_devicesLock) {
+                _devices.Remove(device);
+            }
 
             IRPlotDeviceVisualComponent component;
             if (_assignedVisualComponents.TryGetValue(deviceId, out component)) {
@@ -159,7 +165,9 @@ namespace Microsoft.R.Components.Plots.Implementation {
             await _shell.SwitchToMainThreadAsync(cancellationToken);
 
             var device = new RPlotDevice(deviceId);
-            _devices.Add(device);
+            lock (_devicesLock) {
+                _devices.Add(device);
+            }
 
             PlotDeviceProperties props;
 
@@ -181,16 +189,43 @@ namespace Microsoft.R.Components.Plots.Implementation {
             return props;
         }
 
-        public async Task<LocatorResult> StartLocatorModeAsync(Guid deviceId, CancellationToken cancellationToken) {
-            await _shell.SwitchToMainThreadAsync(cancellationToken);
+        public Task<LocatorResult> StartLocatorModeAsync(Guid deviceId, CancellationToken cancellationToken) {
+            var device = FindDevice(deviceId);
+            device.LocatorMode = true;
 
-            var visualComponent = GetVisualComponentForDevice(deviceId);
-            if (visualComponent == null) {
-                return default(LocatorResult);
-            }
+            _locatorTcs = new TaskCompletionSource<LocatorResult>();
+            _locatorCancelTokenRegistration = cancellationToken.Register(() => CancelLocatorMode(device));
 
-            visualComponent.Container.Show(focus: false, immediate: true);
-            return await visualComponent.StartLocatorModeAsync(cancellationToken);
+            _shell.DispatchOnUIThread(() => {
+                var visualComponent = GetVisualComponentForDevice(deviceId);
+                visualComponent?.Container.Show(focus: false, immediate: true);
+            });
+
+            return _locatorTcs.Task;
+        }
+
+        public Task EndLocatorModeAsync(IRPlotDevice device, LocatorResult result) {
+            device.LocatorMode = false;
+
+            var tcs = _locatorTcs;
+            _locatorTcs = null;
+            tcs?.SetResult(result);
+
+            _locatorCancelTokenRegistration?.Dispose();
+            _locatorCancelTokenRegistration = null;
+
+            return Task.CompletedTask;
+        }
+
+        private void CancelLocatorMode(IRPlotDevice device) {
+            device.LocatorMode = false;
+
+            var tcs = _locatorTcs;
+            _locatorTcs = null;
+            tcs?.SetCanceled();
+
+            _locatorCancelTokenRegistration?.Dispose();
+            _locatorCancelTokenRegistration = null;
         }
 
         public async Task RemoveAllPlotsAsync(IRPlotDevice device) {
@@ -316,9 +351,12 @@ namespace Microsoft.R.Components.Plots.Implementation {
             InteractiveWorkflow.Shell.AssertIsOnMainThread();
 
             var plots = new List<IRPlot>();
-            foreach (var device in _devices) {
-                for (int i = 0; i < device.PlotCount; i++) {
-                    plots.Add(device.GetPlotAt(i));
+
+            lock (_devicesLock) {
+                foreach (var device in _devices) {
+                    for (int i = 0; i < device.PlotCount; i++) {
+                        plots.Add(device.GetPlotAt(i));
+                    }
                 }
             }
 
@@ -411,9 +449,9 @@ namespace Microsoft.R.Components.Plots.Implementation {
         }
 
         private IRPlotDevice FindDevice(Guid deviceId) {
-            InteractiveWorkflow.Shell.AssertIsOnMainThread();
-
-            return _devices.SingleOrDefault(d => d.DeviceId == deviceId);
+            lock (_devicesLock) {
+                return _devices.SingleOrDefault(d => d.DeviceId == deviceId);
+            }
         }
 
         private IRPlot FindPlot(Guid deviceId, Guid plotId) {
@@ -430,8 +468,11 @@ namespace Microsoft.R.Components.Plots.Implementation {
         private void RemoveAllDevices() {
             InteractiveWorkflow.Shell.AssertIsOnMainThread();
 
-            IRPlotDevice[] devices = _devices.ToArray();
-            _devices.Clear();
+            IRPlotDevice[] devices;
+            lock (_devicesLock) {
+                devices = _devices.ToArray();
+                _devices.Clear();
+            }
 
             foreach (var device in devices) {
                 DeviceRemoved?.Invoke(this, new RPlotDeviceEventArgs(device));
@@ -491,7 +532,12 @@ namespace Microsoft.R.Components.Plots.Implementation {
                 ActiveDevice = device;
 
                 // Update all the devices in parallel
-                var tasks = _devices.Select(RefreshDeviceNum);
+                IRPlotDevice[] devices;
+                lock (_devicesLock) {
+                    devices = _devices.ToArray();
+                }
+
+                var tasks = devices.Select(RefreshDeviceNum);
                 await Task.WhenAll(tasks);
 
                 _interactiveWorkflow.ActiveWindow?.Container.UpdateCommandStatus(false);

--- a/src/R/Components/Impl/Plots/Implementation/ViewModel/RPlotDeviceViewModel.cs
+++ b/src/R/Components/Impl/Plots/Implementation/ViewModel/RPlotDeviceViewModel.cs
@@ -117,12 +117,12 @@ namespace Microsoft.R.Components.Plots.Implementation.ViewModel {
             }
         }
 
-        public async Task ClickPlot(int pixelX, int pixelY) {
+        public void ClickPlot(int pixelX, int pixelY) {
             _shell.AssertIsOnMainThread();
 
             if (LocatorMode) {
                 var result = LocatorResult.CreateClicked(pixelX, pixelY);
-                await _plotManager.EndLocatorModeAsync(_device, result);
+                _plotManager.EndLocatorMode(_device, result);
             }
         }
 

--- a/src/R/Components/Impl/Plots/ViewModel/IRPlotDeviceViewModel.cs
+++ b/src/R/Components/Impl/Plots/ViewModel/IRPlotDeviceViewModel.cs
@@ -93,7 +93,7 @@ namespace Microsoft.R.Components.Plots.ViewModel {
         /// </summary>
         /// <param name="pixelX"></param>
         /// <param name="pixelY"></param>
-        void ClickPlot(int pixelX, int pixelY);
+        Task ClickPlot(int pixelX, int pixelY);
 
         /// <summary>
         /// Copy the specified plot from another device to this device.
@@ -102,24 +102,5 @@ namespace Microsoft.R.Components.Plots.ViewModel {
         /// <param name="sourcePlotId">Plot to copy.</param>
         /// <param name="isMove"><c>true</c> to delete the source plot after move.</param>
         Task CopyPlotFromAsync(Guid sourceDeviceId, Guid sourcePlotId, bool isMove);
-
-        /// <summary>
-        /// User initiated locator mode via script, wait for the user to click
-        /// on plot or end locator mode.
-        /// </summary>
-        /// <returns>Click result.</returns>
-        Task<LocatorResult> StartLocatorModeAsync(CancellationToken ct);
-
-        /// <summary>
-        /// End the locator mode with a locator result that indicate the user
-        /// wants to end the locator session.
-        /// </summary>
-        void EndLocatorMode();
-
-        /// <summary>
-        /// End the locator mode with the specified result.
-        /// </summary>
-        /// <param name="result">Click result.</param>
-        void EndLocatorMode(LocatorResult result);
     }
 }

--- a/src/R/Components/Impl/Plots/ViewModel/IRPlotDeviceViewModel.cs
+++ b/src/R/Components/Impl/Plots/ViewModel/IRPlotDeviceViewModel.cs
@@ -93,7 +93,7 @@ namespace Microsoft.R.Components.Plots.ViewModel {
         /// </summary>
         /// <param name="pixelX"></param>
         /// <param name="pixelY"></param>
-        Task ClickPlot(int pixelX, int pixelY);
+        void ClickPlot(int pixelX, int pixelY);
 
         /// <summary>
         /// Copy the specified plot from another device to this device.

--- a/src/R/Components/Test/Plots/RPlotIntegrationTest.cs
+++ b/src/R/Components/Test/Plots/RPlotIntegrationTest.cs
@@ -761,7 +761,7 @@ namespace Microsoft.R.Components.Test.Plots {
                 // Send a result with a click point, which will causes
                 // locator mode to end and immediately start again
                 var locatorModeTask = EventTaskSources.IRPlotDevice.LocatorModeChanged.Create(device);
-                await _workflow.Plots.EndLocatorModeAsync(device, LocatorResult.CreateClicked((int)point.X, (int)point.Y));
+                _workflow.Plots.EndLocatorMode(device, LocatorResult.CreateClicked((int)point.X, (int)point.Y));
                 await locatorModeTask;
 
                 device.LocatorMode.Should().BeFalse();


### PR DESCRIPTION
Fix #3011 Assert and sometimes hang when quitting VS after using locator function
Fix #2939 LocatorCommandNoClick test fails with NRE

Change plot manager so `StartLocatorModeAsync` doesn't need to switch to the main thread, same for the code that ends locator mode.

This means that the `_devices` list is now being accessed from multiple threads, before it used to be guaranteed from main thread only. I'm locking around the use of the list, but I don't know if I need to go further and protect the device object themselves. I'm worried about introducing new deadlocks so close to release.

The view model state updates itself by listening to the plot manager plot device object LocatorModeChanged event, by posting to the main thread.

Scenarios that now work that used to be causing issues:
- Call `locator` and then quit VS
- Call `locator`, and then reset REPL
- Call `locator`, ..., click End Locator, Reset REPL or quit VS

For the test issue, R `dev.cur()` was returning null device, and I didn't find out why. I've tested similar scenario in the product, and that never seem to happen. Anyway the test will pass now.

