### PR TITLE
Fix #3090: Grid is enabled for single-element collections

### DIFF
--- a/src/Package/Impl/DataInspect/Viewers/GridViewer.cs
+++ b/src/Package/Impl/DataInspect/Viewers/GridViewer.cs
@@ -15,7 +15,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
 
         public override bool CanView(IRValueInfo value) {
             // We can only view collections that have elements.
-            if (value?.Length == null || value.Length == 0) {
+            var length = value?.Length ?? 0;
+            if (length == 0) {
                 return false;
             }
 
@@ -25,8 +26,11 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
                 return false;
             }
 
-            // We can only view dimensionless, 1D, or 2D collections. 
-            if (value.Dim != null && value.Dim.Count > 2) {
+            // We can only view dimensionless (treated as 1D), 1D, or 2D collections. 
+            // For 1D collections, only view if there's more than one element (for 2D, we still want
+            // to enable grid in that case to expose row & column names).
+            var dimCount = value.Dim?.Count ?? 1;
+            if (dimCount > 2 || (dimCount == 1 && length == 1)) {
                 return false;
             }
 

--- a/src/Package/Test/DataInspect/ViewersTest.cs
+++ b/src/Package/Test/DataInspect/ViewersTest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.R.Package.Test.DataInspect {
                 gridViewer = await _aggregator.GetViewer(session, REnvironments.GlobalEnv, "AirPassengers");
                 gridViewer.Should().BeOfType<GridViewer>();
 
-                gridViewer = await _aggregator.GetViewer(session, REnvironments.GlobalEnv, "list(c(1:10))");
+                gridViewer = await _aggregator.GetViewer(session, REnvironments.GlobalEnv, "as.list(c(1:10))");
                 gridViewer.Should().BeOfType<GridViewer>();
 
                 gridViewer = await _aggregator.GetViewer(session, REnvironments.GlobalEnv, "c(1:10)");
@@ -145,7 +145,19 @@ namespace Microsoft.VisualStudio.R.Package.Test.DataInspect {
 
                 await session.ExecuteAsync($"x <- {cast}(1)");
                 value = await session.EvaluateAndDescribeAsync("x", AllFields, null);
+                viewer.CanView(value).Should().BeFalse();
+
+                value = await session.EvaluateAndDescribeAsync("dim(x) <- 1", AllFields, null);
+                value = await session.EvaluateAndDescribeAsync("x", AllFields, null);
+                viewer.CanView(value).Should().BeFalse();
+
+                value = await session.EvaluateAndDescribeAsync("dim(x) <- c(1, 1)", AllFields, null);
+                value = await session.EvaluateAndDescribeAsync("x", AllFields, null);
                 viewer.CanView(value).Should().BeTrue();
+
+                value = await session.EvaluateAndDescribeAsync("dim(x) <- c(1, 1, 1)", AllFields, null);
+                value = await session.EvaluateAndDescribeAsync("x", AllFields, null);
+                viewer.CanView(value).Should().BeFalse();
 
                 await session.ExecuteAsync($"x <- {cast}(1:100)");
                 value = await session.EvaluateAndDescribeAsync("x", AllFields, null);


### PR DESCRIPTION
Disable grid viewer for 1D collections that only have a single element in them.