### PR TITLE
Fix  #3091: WebSocketMessageTransport.ReceiveAsync null return value isn't handled

### DIFF
--- a/src/Host/Client/Impl/Definitions/IMessageTransport.cs
+++ b/src/Host/Client/Impl/Definitions/IMessageTransport.cs
@@ -8,6 +8,8 @@ using Microsoft.R.Host.Protocol;
 
 namespace Microsoft.R.Host.Client {
     public interface IMessageTransport {
+        string CloseStatusDescription { get; }
+
         Task CloseAsync(CancellationToken cancellationToken = default(CancellationToken));
         Task SendAsync(Message message, CancellationToken cancellationToken = default(CancellationToken));
         Task<Message> ReceiveAsync(CancellationToken cancellationToken = default(CancellationToken));

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -81,6 +81,8 @@ namespace Microsoft.R.Host.Client {
 
             if (message != null) {
                 Log.Response(message.ToString(), _rLoopDepth);
+            } else {
+                Log.Response(_transport.CloseStatusDescription, _rLoopDepth);
             }
 
             return message;
@@ -588,7 +590,12 @@ namespace Microsoft.R.Host.Client {
 
             try {
                 var message = await ReceiveMessageAsync(ct);
-                if (message == null || !message.IsNotification || message.Name != "!Microsoft.R.Host") {
+                if (message == null) {
+                    // Socket is closed before connection is established. Just exit.
+                    return;
+                }
+
+                if (!message.IsNotification || message.Name != "!Microsoft.R.Host") {
                     throw ProtocolError($"Microsoft.R.Host handshake expected:", message);
                 }
 

--- a/src/Host/Client/Impl/Transports/WebSocketMessageTransport.cs
+++ b/src/Host/Client/Impl/Transports/WebSocketMessageTransport.cs
@@ -15,6 +15,8 @@ namespace Microsoft.R.Host.Client {
         private readonly SemaphoreSlim _receiveLock = new SemaphoreSlim(1, 1);
         private readonly SemaphoreSlim _sendLock = new SemaphoreSlim(1, 1);
 
+        public string CloseStatusDescription => _socket.CloseStatusDescription ?? string.Empty;
+
         public WebSocketMessageTransport(WebSocket socket) {
             _socket = socket;
         }

--- a/src/Package/Impl/History/Commands/LoadHistoryCommand.cs
+++ b/src/Package/Impl/History/Commands/LoadHistoryCommand.cs
@@ -14,8 +14,9 @@ using Microsoft.VisualStudio.R.Packages.R;
 using Microsoft.VisualStudio.Text.Editor;
 #if VS14
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
-#endif
+#else
 using PathHelper = Microsoft.VisualStudio.ProjectSystem.PathHelper;
+#endif
 
 namespace Microsoft.VisualStudio.R.Package.History.Commands {
     internal class LoadHistoryCommand : ViewCommand {


### PR DESCRIPTION
RHost can fail at any time after start, including the moment when RTVS requests the handshake.