### PR TITLE
Fix #3076: Getting the class of an object after a failed View() hangs the REPL

### DIFF
--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -413,7 +413,7 @@ namespace Microsoft.R.Host.Client {
                             throw ProtocolError($"Mismatched response - message name does not match request '{request.MessageName}':", message);
                         }
 
-                        request.Handle(this, message);
+                        Task.Run(() => request.Handle(this, message)).DoNotWait();
                         continue;
                     }
 

--- a/src/Package/Impl/DataInspect/VisualGrid/VisualGridScroller.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/VisualGridScroller.cs
@@ -10,7 +10,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Common.Core;
+using Microsoft.Common.Core.Logging;
 using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.R.Package.Shell;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect {
     /// <summary>
@@ -98,7 +100,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                         batch.Clear();
                     }
                 } catch (Exception ex) {
-                    Debug.Fail(ex.ToString());
+                    VsAppShell.Current.Services.Log.Write(LogVerbosity.Normal, MessageCategory.Error, "VisualGridScroller exception: " + ex);
                     batch.Clear();
                 }
             }


### PR DESCRIPTION
Set task completion sources for request handlers asynchronously, so that the continuation for the task does not hijack the message handling thread and block it.

Log errors in VisualGridScroller instead of asserting.