### PR TITLE
Fix #3140: Move message text from R code to C#

### DIFF
--- a/src/Host/API/Impl/RSessionCallback.cs
+++ b/src/Host/API/Impl/RSessionCallback.cs
@@ -51,5 +51,7 @@ namespace Microsoft.R.Host.Client {
         public Task ViewFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken = default(CancellationToken)) => Task.CompletedTask;
         public Task ViewLibraryAsync(CancellationToken cancellationToken = default(CancellationToken)) => Task.CompletedTask;
         public Task ViewObjectAsync(string expression, string title, CancellationToken cancellationToken = default(CancellationToken)) => Task.CompletedTask;
+
+        public string GetLocalizedString(string id) => null;
     }
 }

--- a/src/Host/Client/Impl/Definitions/IRCallbacks.cs
+++ b/src/Host/Client/Impl/Definitions/IRCallbacks.cs
@@ -97,5 +97,10 @@ namespace Microsoft.R.Host.Client {
         /// Called when user invokes rtvs:::fetch_file() in R.
         /// </summary>
         Task<string> FetchFileAsync(string remoteFileName, ulong remoteFileBlobId, string localPath, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Implements rtvs:::locstr().
+        /// </summary>
+        string GetLocalizedString(string id);
     }
 }

--- a/src/Host/Client/Impl/Definitions/IRSessionCallback.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionCallback.cs
@@ -80,5 +80,7 @@ namespace Microsoft.R.Host.Client {
         /// Saves data to file sent from RHost.
         /// </summary>
         Task<string> FetchFileAsync(string remoteFileName, ulong remoteBlobId, string localPath, CancellationToken cancellationToken);
+
+        string GetLocalizedString(string id);
     }
 }

--- a/src/Host/Client/Impl/Host/NullRCallbacks.cs
+++ b/src/Host/Client/Impl/Host/NullRCallbacks.cs
@@ -39,6 +39,7 @@ namespace Microsoft.R.Host.Client.Host {
         public void PackagesInstalled() { }
         public void PackagesRemoved() {}
         public Task<string> FetchFileAsync(string remoteFileName, ulong remoteBlocbId, string localPath, CancellationToken cancellationToken) => Task.FromResult(string.Empty);
+        public string GetLocalizedString(string id) => null;
 
         public async Task<string> ReadConsole(IReadOnlyList<IRContext> contexts, string prompt, int len, bool addToHistory, CancellationToken ct) {
             await _mrs.WaitAsync(ct);

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -551,6 +551,11 @@ namespace Microsoft.R.Host.Client {
                                     }
                                 }).DoNotWait();
                                 break;
+
+                            case "?LocStr":
+                                await RespondAsync(message, ct, _callbacks.GetLocalizedString(message.GetString(0, "id")));
+                                break;
+
                             default:
                                 throw ProtocolError($"Unrecognized host message name:", message);
                         }

--- a/src/Host/Client/Impl/Program.cs
+++ b/src/Host/Client/Impl/Program.cs
@@ -182,6 +182,8 @@ namespace Microsoft.R.Host.Client {
             await Console.Error.WriteLineAsync(Invariant($"PlotDeviceDestroy called for {deviceId}."));
         }
 
+        public string GetLocalizedString(string id) => null;
+
         class MaxLoggingPermissions : ILoggingPermissions {
             public LogVerbosity CurrentVerbosity { get; set; } = LogVerbosity.Traffic;
             public bool IsFeedbackPermitted => true;

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -725,6 +725,9 @@ if (rtvs:::version != {rtvsPackageVersion}) {{
             return callback != null ? callback.FetchFileAsync(remoteFileName, remoteBlobId, localPath, cancellationToken) : Task.FromResult(string.Empty);
         }
 
+        string IRCallbacks.GetLocalizedString(string id) =>
+            _callback?.GetLocalizedString(id);
+
         private class BeforeInitializedRExpressionEvaluator : IRExpressionEvaluator {
             private readonly RSession _session;
 

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -19,6 +19,10 @@ send_request_and_get_response <- function(name, ...) {
     call_embedded('send_request_and_get_response', name, list(...))
 }
 
+locstr <- function(id) {
+    send_request_and_get_response('?LocStr', id)[[1]]
+}
+
 memory_connection <- function(max_length = NA, expected_length = NA, overflow_suffix = '', eof_marker = '') {
     call_embedded('memory_connection', max_length, expected_length, overflow_suffix, eof_marker)
 }
@@ -267,7 +271,7 @@ query_reload_autosave <- function() {
         return(FALSE);
     }
 
-    msg <- 'Previous R session terminated unexpectedly, and its global workspace has been saved to image "%s". Would you like to reload it?';
+    msg <- locstr('rtvs_SessionTerminatedUnexpectedly');
     res <- winDialog('yesno', sprintf(msg, autosave_filename));
 
     if (identical(res, 'YES')) {
@@ -279,25 +283,25 @@ query_reload_autosave <- function() {
         });
 
         if (loaded) {
-            message(sprintf('Loaded workspace from autosaved image "%s".', autosave_filename));
+            message(sprintf(locstr('rtvs_LoadedWorkspace'), autosave_filename));
             # If we loaded the file successfully, it's safe to delete it - this session contains the reloaded
             # state now, and if there's another disconnect, it will be autosaved again.
             return(TRUE);
         } else {
-            warning(sprintf('Failed to load workspace from autosaved image "%s".', autosave_filename), call. = FALSE, immediate. = TRUE);
+            warning(sprintf(locstr('rtvs_FailedToLoadWorkspace'), autosave_filename), call. = FALSE, immediate. = TRUE);
             return(FALSE);
         }
     } else {
-        msg <- 'Delete autosaved workspace image "%s"?';
+        msg <- locstr('rtvs_ConfirmDeleteWorkspace');
         res <- winDialog('yesno', sprintf(msg, autosave_filename));
         return(identical(res, 'YES'));
     }
 }
 
 save_state <- function() {
-    message(sprintf('Autosaving workspace to image "%s" ...', autosave_filename));
+    message(sprintf(locstr('rtvs_AutosavingWorkspace'), autosave_filename));
     save.image(autosave_filename);
-    message(' workspace saved successfully.');
+    message(locstr('rtvs_WorkspaceSavedSuccessfully'));
 }
 
 enable_autosave <- function(delete_existing) {
@@ -305,7 +309,7 @@ enable_autosave <- function(delete_existing) {
         set_disconnect_callback(save_state);
 
         if (delete_existing) {
-            message(sprintf('Deleting autosaved workspace image "%s".', autosave_filename));
+            message(sprintf(locstr('rtvs_DeletingWorkspace'), autosave_filename));
             unlink(autosave_filename);
         }
     });

--- a/src/Host/Client/Test/Script/RHostClientTestApp.cs
+++ b/src/Host/Client/Test/Script/RHostClientTestApp.cs
@@ -77,5 +77,9 @@ namespace Microsoft.R.Host.Client.Test.Script {
             }
             throw new NotImplementedException();
         }
+
+        public string GetLocalizedString(string id) {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Host/Client/Test/Stubs/RSessionCallbackStub.cs
+++ b/src/Host/Client/Test/Stubs/RSessionCallbackStub.cs
@@ -22,6 +22,7 @@ namespace Microsoft.R.Host.Client.Test.Stubs {
         public IList<int> ViewLibraryCalls { get; } = new List<int>();
         public IList<Tuple<string, string, bool>> ShowFileCalls { get; } = new List<Tuple<string, string, bool>>();
         public IList<Tuple<string, string>> SaveFileCalls { get; } = new List<Tuple<string, string>>();
+        public IList<string> GetLocalizedStringCalls { get; } = new List<string>();
 
         public Func<string, MessageButtons, Task<MessageButtons>> ShowMessageCallsHandler { get; set; } = 
             (m, b) => Task.FromResult(b.HasFlag(MessageButtons.Yes) ? MessageButtons.Yes : MessageButtons.OK);
@@ -105,6 +106,11 @@ namespace Microsoft.R.Host.Client.Test.Stubs {
             SaveFileCalls.Add(new Tuple<string, string>(remotePath, localPath));
             SaveFileHandler?.Invoke(remotePath, remoteBlobId, localPath);
             return Task.FromResult(string.Empty);
+        }
+
+        public string GetLocalizedString(string id) {
+            GetLocalizedStringCalls.Add(id);
+            return null;
         }
     }
 }

--- a/src/Package/Test/DataInspect/EvaluationWrapperTest.cs
+++ b/src/Package/Test/DataInspect/EvaluationWrapperTest.cs
@@ -40,9 +40,9 @@ namespace Microsoft.VisualStudio.R.Package.Test.DataInspect {
         };
 
         object[,] factorTestData = new object[,] {
-            { "factor.5 <- factor(1:5)", new VariableExpectation() { Name = "factor.5", Value = "Factor w/ 5 levels \"1\",\"2\",\"3\",\"4\",..: 1 2 3 4 5", TypeName = "integer", Class = "factor", HasChildren = true, CanShowDetail = false } },
-            { "factor.ordered <- ordered(c('5','4','100','2','1'))", new VariableExpectation() { Name = "factor.ordered", Value = "Ord.factor w/ 5 levels \"1\"<\"100\"<\"2\"<..: 5 4 2 3 1", TypeName = "integer", Class = "ordered, factor", HasChildren = true, CanShowDetail = false } },
-            { "factor.gender <- factor(c('male','female','male','male','female'))", new VariableExpectation() { Name = "factor.gender", Value = "Factor w/ 2 levels \"female\",\"male\": 2 1 2 2 1", TypeName = "integer", Class = "factor", HasChildren = true, CanShowDetail = false } },
+            { "factor.5 <- factor(1:5)", new VariableExpectation() { Name = "factor.5", Value = "Factor w/ 5 levels \"1\",\"2\",\"3\",\"4\",..: 1 2 3 4 5", TypeName = "integer", Class = "factor", HasChildren = true, CanShowDetail = true } },
+            { "factor.ordered <- ordered(c('5','4','100','2','1'))", new VariableExpectation() { Name = "factor.ordered", Value = "Ord.factor w/ 5 levels \"1\"<\"100\"<\"2\"<..: 5 4 2 3 1", TypeName = "integer", Class = "ordered, factor", HasChildren = true, CanShowDetail = true } },
+            { "factor.gender <- factor(c('male','female','male','male','female'))", new VariableExpectation() { Name = "factor.gender", Value = "Factor w/ 2 levels \"female\",\"male\": 2 1 2 2 1", TypeName = "integer", Class = "factor", HasChildren = true, CanShowDetail = true } },
         };
 
         object[,] formulaTestData32 = new object[,] {
@@ -58,7 +58,8 @@ namespace Microsoft.VisualStudio.R.Package.Test.DataInspect {
         };
 
         object[,] listTestData = new object[,] {
-            { "list.length1 <- list(c(1, 2, 3))", new VariableExpectation() { Name = "list.length1", Value = "List of 1", TypeName = "list", Class = "list", HasChildren = true, CanShowDetail = true } },
+            { "list.length1 <- list(c(1, 2, 3))", new VariableExpectation() { Name = "list.length1", Value = "List of 1", TypeName = "list", Class = "list", HasChildren = true, CanShowDetail = false } },
+            { "list.length3 <- list(1, 2, 3)", new VariableExpectation() { Name = "list.length3", Value = "List of 3", TypeName = "list", Class = "list", HasChildren = true, CanShowDetail = true } },
         };
 
         object[,] activeBindingTestData = new object[,] {

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RSessionCallback.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RSessionCallback.cs
@@ -146,5 +146,8 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             }
             return localPath;
         }
+
+        public string GetLocalizedString(string id) =>
+            Resources.ResourceManager.GetString(id, Resources.Culture);
     }
 }

--- a/src/R/Components/Impl/Resources.Designer.cs
+++ b/src/R/Components/Impl/Resources.Designer.cs
@@ -1435,6 +1435,69 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Autosaving workspace to image &quot;%s&quot; ....
+        /// </summary>
+        public static string rtvs_AutosavingWorkspace {
+            get {
+                return ResourceManager.GetString("rtvs_AutosavingWorkspace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete autosaved workspace image &quot;%s&quot;?.
+        /// </summary>
+        public static string rtvs_ConfirmDeleteWorkspace {
+            get {
+                return ResourceManager.GetString("rtvs_ConfirmDeleteWorkspace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deleting autosaved workspace image &quot;%s&quot;..
+        /// </summary>
+        public static string rtvs_DeletingWorkspace {
+            get {
+                return ResourceManager.GetString("rtvs_DeletingWorkspace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to load workspace from autosaved image &quot;%s&quot;..
+        /// </summary>
+        public static string rtvs_FailedToLoadWorkspace {
+            get {
+                return ResourceManager.GetString("rtvs_FailedToLoadWorkspace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loaded workspace from autosaved image &quot;%s&quot;..
+        /// </summary>
+        public static string rtvs_LoadedWorkspace {
+            get {
+                return ResourceManager.GetString("rtvs_LoadedWorkspace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Previous R session terminated, and its global workspace has been saved to image &quot;%s&quot;. Would you like to reload it?.
+        /// </summary>
+        public static string rtvs_SessionTerminatedUnexpectedly {
+            get {
+                return ResourceManager.GetString("rtvs_SessionTerminatedUnexpectedly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  workspace saved successfully..
+        /// </summary>
+        public static string rtvs_WorkspaceSavedSuccessfully {
+            get {
+                return ResourceManager.GetString("rtvs_WorkspaceSavedSuccessfully", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Secure.
         /// </summary>
         public static string SecureConnection {

--- a/src/R/Components/Impl/Resources.resx
+++ b/src/R/Components/Impl/Resources.resx
@@ -646,6 +646,27 @@ Please upgrade remote R Services installation to match.</value>
   <data name="Plot_EmptyWatermark" xml:space="preserve">
     <value>Run plotting command in R Interactive Window</value>
   </data>
+  <data name="rtvs_AutosavingWorkspace" xml:space="preserve">
+    <value>Autosaving workspace to image "%s" ...</value>
+  </data>
+  <data name="rtvs_ConfirmDeleteWorkspace" xml:space="preserve">
+    <value>Delete autosaved workspace image "%s"?</value>
+  </data>
+  <data name="rtvs_DeletingWorkspace" xml:space="preserve">
+    <value>Deleting autosaved workspace image "%s".</value>
+  </data>
+  <data name="rtvs_FailedToLoadWorkspace" xml:space="preserve">
+    <value>Failed to load workspace from autosaved image "%s".</value>
+  </data>
+  <data name="rtvs_LoadedWorkspace" xml:space="preserve">
+    <value>Loaded workspace from autosaved image "%s".</value>
+  </data>
+  <data name="rtvs_SessionTerminatedUnexpectedly" xml:space="preserve">
+    <value>Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?</value>
+  </data>
+  <data name="rtvs_WorkspaceSavedSuccessfully" xml:space="preserve">
+    <value> workspace saved successfully.</value>
+  </data>
   <data name="Error_FailedToSaveState" xml:space="preserve">
     <value>Failed to save state, resetting anyway.</value>
   </data>


### PR DESCRIPTION
Add an R helper function to get localizable strings from the IDE, and use it for all user-visible string literals in R code.

This depends on https://github.com/Microsoft/R-Host/pull/109