### PR TITLE
Fix #3119: ggvis sample crashes on remote

### DIFF
--- a/src/Host/Client/Impl/Host/RemoteBrokerClient.cs
+++ b/src/Host/Client/Impl/Host/RemoteBrokerClient.cs
@@ -52,8 +52,14 @@ namespace Microsoft.R.Host.Client.Host {
             return host;
         }
 
-        public override Task<string> HandleUrlAsync(string url, CancellationToken cancellationToken) =>
-            WebServer.CreateWebServerAsync(url, HttpClient.BaseAddress.ToString(), Name, _services, _console, cancellationToken);
+        public override async Task<string> HandleUrlAsync(string url, CancellationToken cancellationToken) {
+            if (!url.StartsWithIgnoreCase("http://")) {
+                _console.WriteError(string.Format(Resources.Error_RemoteUriNotSupported, url));
+                return null;
+            }
+
+            return await WebServer.CreateWebServerAsync(url, HttpClient.BaseAddress.ToString(), Name, _services, _console, cancellationToken);
+        }
 
         protected override async Task<Exception> HandleHttpRequestExceptionAsync(HttpRequestException exception) {
             // Broker is not responding. Try regular ping.

--- a/src/Host/Client/Impl/Resources.Designer.cs
+++ b/src/Host/Client/Impl/Resources.Designer.cs
@@ -207,6 +207,15 @@ namespace Microsoft.R.Host.Client {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remote R requested to open {0}, but only http:// URIs are supported for remote..
+        /// </summary>
+        internal static string Error_RemoteUriNotSupported {
+            get {
+                return ResourceManager.GetString("Error_RemoteUriNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Version of R Services on the remote machine ({0})
         ///is higher than the version of R Tools on the local computer ({1}). 
         ///Please upgrade local R Tools installation to match..

--- a/src/Host/Client/Impl/Resources.resx
+++ b/src/Host/Client/Impl/Resources.resx
@@ -248,4 +248,7 @@ Please upgrade local R Tools installation to match.</value>
 is lower than the version of R Tools on the local computer ({1}). 
 Please upgrade remote R Services installation to match.</value>
   </data>
+  <data name="Error_RemoteUriNotSupported" xml:space="preserve">
+    <value>Remote R requested to open {0}, but only http:// URIs are supported for remote.</value>
+  </data>
 </root>

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -689,7 +689,9 @@ if (rtvs:::version != {rtvsPackageVersion}) {{
             var callback = _callback;
             if (callback != null) {
                 var newUrl = await BrokerClient.HandleUrlAsync(url, cancellationToken);
-                await callback.ShowHelpAsync(newUrl, cancellationToken);
+                if (newUrl != null) {
+                    await callback.ShowHelpAsync(newUrl, cancellationToken);
+                }
             }
         }
 


### PR DESCRIPTION
Block non http:// URLs in remote sessions.