### PR TITLE
Accessibility for Workspaces Window

### DIFF
--- a/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
@@ -33,26 +33,50 @@
             </Style>
 
             <Style x:Key="DeleteButtonStyle" TargetType="Button" BasedOn="{StaticResource ToolWindowButtonStyle}">
-                <Style.Triggers>
-                    <Trigger Property="IsEnabled" Value="True">
-                        <Setter Property="ToolTip" Value="{x:Static components:Resources.ConnectionManager_DeleteTooltip}" />
-                    </Trigger>
-                    <Trigger Property="IsEnabled" Value="False">
-                        <Setter Property="ToolTip" Value="{x:Static components:Resources.ConnectionManager_DeleteTooltipDisabled}" />
-                    </Trigger>
-                </Style.Triggers>
+                <EventSetter Event="Click" Handler="ButtonDelete_Click" />
                 <Setter Property="Opacity" Value="{Binding Path=IsUserCreated, Converter={x:Static rwpf:Converters.FalseIsGrayedOut}}" />
                 <Setter Property="IsEnabled" Value="{Binding Path=IsUserCreated}" />
                 <Setter Property="ToolTipService.ShowOnDisabled" Value="True" />
+                <Setter Property="Background" Value="{DynamicResource {x:Static rwpf:Brushes.ToolWindowBackgroundKey}}" />
+                <Style.Triggers>
+                    <Trigger Property="IsEnabled" Value="True">
+                        <Setter Property="ToolTip">
+                            <Setter.Value>
+                                <TextBlock Text="{Binding Path=Name, StringFormat={x:Static components:Resources.ConnectionManager_DeleteTooltip_Format}}" />
+                            </Setter.Value>
+                        </Setter>
+                        <Setter Property="AutomationProperties.Name" Value="{Binding Path=Name, StringFormat={x:Static components:Resources.ConnectionManager_DeleteTooltip_Format}}" />
+                    </Trigger>
+                    <Trigger Property="IsEnabled" Value="False">
+                        <Setter Property="ToolTip">
+                            <Setter.Value>
+                                <TextBlock Text="{x:Static components:Resources.ConnectionManager_DeleteTooltipDisabled}" />
+                            </Setter.Value>
+                        </Setter>
+                        <Setter Property="AutomationProperties.Name" Value="{x:Static components:Resources.ConnectionManager_DeleteTooltipDisabled}" />
+                    </Trigger>
+                </Style.Triggers>
             </Style>
 
             <Style x:Key="EditButtonStyle" TargetType="Button" BasedOn="{StaticResource ToolWindowButtonStyle}">
+                <EventSetter Event="Click" Handler="ButtonEdit_Click" />
+                <Setter Property="Background" Value="{DynamicResource {x:Static rwpf:Brushes.ToolWindowBackgroundKey}}" />
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding Path=IsRemote}" Value="False">
-                        <Setter Property="ToolTip" Value="{x:Static components:Resources.ConnectionManager_EditLocalTooltip}" />
+                        <Setter Property="ToolTip">
+                            <Setter.Value>
+                                <TextBlock Text="{Binding Path=Name, StringFormat={x:Static components:Resources.ConnectionManager_EditLocalTooltip_Format}}" />
+                            </Setter.Value>
+                        </Setter>
+                        <Setter Property="AutomationProperties.Name" Value="{Binding Path=Name, StringFormat={x:Static components:Resources.ConnectionManager_EditLocalTooltip_Format}}" />
                     </DataTrigger>
                     <DataTrigger Binding="{Binding Path=IsRemote}" Value="True">
-                        <Setter Property="ToolTip" Value="{x:Static components:Resources.ConnectionManager_EditRemoteTooltip}" />
+                        <Setter Property="ToolTip">
+                            <Setter.Value>
+                                <TextBlock Text="{Binding Path=Name, StringFormat={x:Static components:Resources.ConnectionManager_EditRemoteTooltip_Format}}" />
+                            </Setter.Value>
+                        </Setter>
+                        <Setter Property="AutomationProperties.Name" Value="{Binding Path=Name, StringFormat={x:Static components:Resources.ConnectionManager_EditRemoteTooltip_Format}}" />
                     </DataTrigger>
                 </Style.Triggers>
             </Style>
@@ -68,9 +92,56 @@
                 </Style.Setters>
             </Style>
 
+            <Style x:Key="ToggleButtonLocalConnectionsStyle" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource ExpandCollapseToggleStyle}">
+                <Setter Property="IsChecked" Value="True" />
+                <Setter Property="Content" Value="{x:Static components:Resources.ConnectionManager_LocalConnections}" />
+                <Setter Property="Visibility" Value="{Binding Path=HasLocalConnections, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}" />
+                <Style.Triggers>
+                    <Trigger Property="IsChecked" Value="True">
+                        <Setter Property="ToolTip">
+                            <Setter.Value>
+                                <TextBlock Text="{x:Static components:Resources.ConnectionManager_LocalConnections_Collapse}" />
+                            </Setter.Value>
+                        </Setter>
+                        <Setter Property="AutomationProperties.Name" Value="{x:Static components:Resources.ConnectionManager_LocalConnections_Collapse}" />
+                    </Trigger>
+                    <Trigger Property="IsChecked" Value="False">
+                        <Setter Property="ToolTip">
+                            <Setter.Value>
+                                <TextBlock Text="{x:Static components:Resources.ConnectionManager_LocalConnections_Expand}" />
+                            </Setter.Value>
+                        </Setter>
+                        <Setter Property="AutomationProperties.Name" Value="{x:Static components:Resources.ConnectionManager_LocalConnections_Expand}" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style x:Key="ToggleButtonRemoteConnectionsStyle" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource ExpandCollapseToggleStyle}">
+                <Setter Property="IsChecked" Value="True" />
+                <Setter Property="Content" Value="{x:Static components:Resources.ConnectionManager_RemoteConnections}" />
+                <Style.Triggers>
+                    <Trigger Property="IsChecked" Value="True">
+                        <Setter Property="ToolTip">
+                            <Setter.Value>
+                                <TextBlock Text="{x:Static components:Resources.ConnectionManager_RemoteConnections_Collapse}" />
+                            </Setter.Value>
+                        </Setter>
+                        <Setter Property="AutomationProperties.Name" Value="{x:Static components:Resources.ConnectionManager_RemoteConnections_Collapse}" />
+                    </Trigger>
+                    <Trigger Property="IsChecked" Value="False">
+                        <Setter Property="ToolTip">
+                            <Setter.Value>
+                                <TextBlock Text="{x:Static components:Resources.ConnectionManager_RemoteConnections_Expand}" />
+                            </Setter.Value>
+                        </Setter>
+                        <Setter Property="AutomationProperties.Name" Value="{x:Static components:Resources.ConnectionManager_RemoteConnections_Expand}" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+            
             <DataTemplate x:Key="EditConnectionDataTemplate" DataType="{x:Type viewModel:IConnectionViewModel}">
                 <AdornerDecorator>
-                    <Grid Margin="0,6,0,8"
+                    <Grid Margin="0,6,0,8" PreviewKeyUp="EditConnection_PreviewKeyUp"
                           Background="{DynamicResource {x:Static rwpf:Brushes.ToolWindowBackgroundKey}}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
@@ -86,15 +157,16 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
 
-                        <imaging:CrispImage Grid.Row="0" x:Name="NameValidityIndicator" Style="{StaticResource ValidityIndicatorStyle}" />
-                        <imaging:CrispImage Grid.Row="1" x:Name="PathValidityIndicator" Style="{StaticResource ValidityIndicatorStyle}" />
+                        <imaging:CrispImage Grid.Row="0" Grid.Column="0" x:Name="NameValidityIndicator" Style="{StaticResource ValidityIndicatorStyle}" />
+                        <imaging:CrispImage Grid.Row="1" Grid.Column="0" x:Name="PathValidityIndicator" Style="{StaticResource ValidityIndicatorStyle}" />
 
                         <TextBox Grid.Row="0" Grid.Column="1" Style="{StaticResource InputTextBoxStyle}"
                                  Text="{Binding Path=Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                  controls:Watermark.TextBoxHint="{x:Static components:Resources.ConnectionManager_Name}"
                                  Background="{DynamicResource {x:Static rwpf:Brushes.BackgroundBrushKey}}" 
                                  Foreground="{DynamicResource {x:Static rwpf:Brushes.UITextKey}}"
-                                 ToolTip="{Binding Path=NameTextBoxTooltip}"/>
+                                 ToolTip="{Binding Path=NameTextBoxTooltip}"
+                                 IsVisibleChanged="TextBoxName_IsVisibleChanged"/>
 
                         <TextBox Grid.Row="1" Grid.Column="1" Style="{StaticResource InputTextBoxStyle}" 
                                  Text="{Binding Path=Path, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -173,10 +245,10 @@
                 </AdornerDecorator>
                 
                 <DataTemplate.Triggers>
-                    <DataTrigger Binding="{Binding IsNameValid}" Value="False">
+                    <DataTrigger Binding="{Binding Path=IsNameValid}" Value="False">
                         <Setter TargetName="NameValidityIndicator" Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StatusRequiredOutline}"/>
                     </DataTrigger>
-                    <DataTrigger Binding="{Binding IsPathValid}" Value="False">
+                    <DataTrigger Binding="{Binding Path=IsPathValid}" Value="False">
                         <Setter TargetName="PathValidityIndicator" Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StatusRequiredOutline}"/>
                     </DataTrigger>
                 </DataTemplate.Triggers>
@@ -213,8 +285,7 @@
                                           ContentTemplate="{StaticResource ConnectButtonDataTemplate}" />
 
                         <!-- Name, path  -->
-                        <TextBlock Grid.Row="0" Grid.Column="2" Margin="0,1,6,2" 
-                                   Text="{Binding Path=Name}"
+                        <TextBlock Grid.Row="0" Grid.Column="2" Margin="0,1,6,2" Text="{Binding Path=Name}"
                                    FontWeight="{Binding Path=IsConnected, Converter={x:Static rwpf:Converters.TrueIsBold}}"
                                    ToolTip="{Binding Path=ConnectionTooltip}"
                                    TextTrimming="CharacterEllipsis" TextWrapping="NoWrap"/>
@@ -230,6 +301,8 @@
                                 Visibility="{Binding Path=IsConnected, Converter={x:Static rwpf:Converters.TrueIsCollapsed}}"
                                 Margin="0,0,8,0" Background="{DynamicResource {x:Static rwpf:Brushes.ToolWindowBackgroundKey}}"
                                 IsEnabled="{Binding Path=IsValid}"
+                                AutomationProperties.Name="{Binding Path=Name, StringFormat={x:Static components:Resources.ConnectionManager_ConnectTooltip}}"
+                                AutomationProperties.HelpText="{Binding Path=ConnectionTooltip}"
                                 Opacity="{Binding Path=IsValid, Converter={x:Static rwpf:Converters.FalseIsGrayedOut}}">
                             <Button.ToolTip>
                                 <TextBlock Text="{Binding Path=Name, StringFormat={x:Static components:Resources.ConnectionManager_ConnectTooltip}}" />
@@ -238,14 +311,12 @@
                         </Button>
 
                         <!-- edit/properties button -->
-                        <Button x:Name="ButtonEdit" Grid.Row="0" Grid.Column="4" Style="{StaticResource EditButtonStyle}" Click="ButtonEdit_Click"
-                                Background="{DynamicResource {x:Static rwpf:Brushes.ToolWindowBackgroundKey}}">
+                        <Button x:Name="ButtonEdit" Grid.Row="0" Grid.Column="4" Style="{StaticResource EditButtonStyle}">
                             <imaging:CrispImage  Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.Settings}" />
                         </Button>
 
                         <!-- delete button -->
-                        <Button x:Name="ButtonDelete" Grid.Row="0" Grid.Column="5" Style="{StaticResource DeleteButtonStyle}" Click="ButtonDelete_Click"
-                                Background="{DynamicResource {x:Static rwpf:Brushes.ToolWindowBackgroundKey}}">
+                        <Button x:Name="ButtonDelete" Grid.Row="0" Grid.Column="5" Style="{StaticResource DeleteButtonStyle}">
                             <imaging:CrispImage  Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.Cancel}" />
                         </Button>
 
@@ -259,7 +330,9 @@
 
             <Style x:Key="ConnectionsListBoxItemStyle" TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource FillingListBoxItemStyle}">
                 <EventSetter Event="MouseDoubleClick" Handler="Connection_MouseDoubleClick" />
-                <EventSetter Event="KeyUp" Handler="Connection_KeyUp" />
+                <EventSetter Event="PreviewKeyUp" Handler="Connection_PreviewKeyUp" />
+                <Setter Property="IsTabStop" Value="False" />
+                <Setter Property="Focusable" Value="False"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ListBoxItem}">
@@ -301,9 +374,11 @@
                 <Setter Property="VirtualizingPanel.CacheLengthUnit" Value="Page"/>
                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                 <Setter Property="BorderThickness" Value="0,0,0,0" />
+                <Setter Property="IsTabStop" Value="False" />
                 <Setter Property="ItemContainerStyle" Value="{StaticResource ConnectionsListBoxItemStyle}" />
                 <Setter Property="ItemTemplateSelector" Value="{StaticResource TypeDataTemplateSelector}"/>
                 <Setter Property="SelectionMode" Value="Multiple"/>
+                <Setter Property="KeyboardNavigation.TabNavigation" Value="Continue" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ListBox}">
@@ -354,11 +429,7 @@
             </DockPanel>
 
             <!-- Local connections header -->
-            <ToggleButton x:Name="ToggleButtonLocalConnections"
-                          DockPanel.Dock="Top" Style="{StaticResource ExpandCollapseToggleStyle}"
-                          ToolTip="{x:Static components:Resources.ConnectionManager_LocalConnectionsTooltip}" IsChecked="True"
-                          Content="{x:Static components:Resources.ConnectionManager_LocalConnections}"
-                          Visibility="{Binding Path=HasLocalConnections, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}"/>
+            <ToggleButton x:Name="ToggleButtonLocalConnections" Style="{StaticResource ToggleButtonLocalConnectionsStyle}" DockPanel.Dock="Top" />
 
             <!-- Local connections -->
             <ListBox x:Name="LocalList" 
@@ -366,10 +437,7 @@
                      Visibility="{Binding ElementName=ToggleButtonLocalConnections, Path=IsChecked, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}"/>
 
             <!-- Remote connections header -->
-            <ToggleButton x:Name="ToggleButtonRemoteConnections"
-                          DockPanel.Dock="Top" Style="{StaticResource ExpandCollapseToggleStyle}"
-                          ToolTip="{x:Static components:Resources.ConnectionManager_RemoteConnectionsTooltip}" IsChecked="True"
-                          Content="{x:Static components:Resources.ConnectionManager_RemoteConnections}"/>
+            <ToggleButton x:Name="ToggleButtonRemoteConnections" Style="{StaticResource ToggleButtonRemoteConnectionsStyle}" DockPanel.Dock="Top" />
 
             <!-- Remote connections -->
             <ListBox x:Name="RemoteList"

--- a/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml.cs
@@ -38,7 +38,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View {
         }
 
         private void ButtonAdd_Click(object sender, RoutedEventArgs e) {
-            Model?.EditNew();
+            Model?.TryEditNew();
         }
 
         private void ButtonPath_Click(object sender, RoutedEventArgs e) {
@@ -46,8 +46,9 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View {
         }
 
         private void ButtonEdit_Click(object sender, RoutedEventArgs e) {
-            Model?.Edit(GetConnection(e));
-            ScrollEditedIntoView();
+            if (Model?.TryEdit(GetConnection(e)) == true) {
+                ScrollEditedIntoView();
+            }
         }
 
         private void ButtonDelete_Click(object sender, RoutedEventArgs e) {
@@ -72,10 +73,10 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View {
                 list.SelectedItems.Add(model.EditedConnection);
             }
         }
-
-        private void Connection_KeyUp(object sender, KeyEventArgs e) {
-            if (e.Key == Key.Enter) {
-                HandleConnect(e, true);
+        
+        private void Connection_PreviewKeyUp(object sender, KeyEventArgs e) {
+            if (e.Key == Key.Delete && !(e.OriginalSource is TextBox)) {
+                Model?.TryDelete(GetConnection(e));
             }
         }
 
@@ -84,8 +85,20 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View {
             e.Handled = true;
         }
 
+        private void EditConnection_PreviewKeyUp(object sender, KeyEventArgs e) {
+            if (e.Key == Key.Escape) {
+                Model?.CancelEdit();
+            }
+        }
+
         private void PathTextBox_LostFocus(object sender, RoutedEventArgs e) {
             ((sender as TextBox)?.DataContext as IConnectionViewModel)?.UpdatePath();
+        }
+
+        private void TextBoxName_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e) {
+            if (e.NewValue != e.OldValue && (bool)e.NewValue) {
+                (sender as TextBox)?.Focus();
+            }
         }
 
         private void HandleConnect(RoutedEventArgs e, bool connectToEdited) {

--- a/src/R/Components/Impl/ConnectionManager/Implementation/View/DesignTime/DesignTimeConnectionManagerViewModel.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/View/DesignTime/DesignTimeConnectionManagerViewModel.cs
@@ -33,10 +33,10 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View.DesignTim
         public bool IsEditingNew => true;
         public bool IsConnected => false;
         
-        public void EditNew() {}
+        public bool TryEditNew() => false;
         public void CancelEdit() { }
         public void BrowseLocalPath(IConnectionViewModel connection) { }
-        public void Edit(IConnectionViewModel connection) { }
+        public bool TryEdit(IConnectionViewModel connection) => false;
         public Task TestConnectionAsync(IConnectionViewModel connection) => Task.CompletedTask;
         public void CancelTestConnection() { }
         public void Save(IConnectionViewModel connectionViewModel) { }

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionManagerViewModel.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionManagerViewModel.cs
@@ -89,9 +89,10 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.ViewModel {
             return true;
         }
 
-        public void EditNew() {
+        public bool TryEditNew() {
             Shell.AssertIsOnMainThread();
             IsEditingNew = TryStartEditing(new ConnectionViewModel());
+            return IsEditingNew;
         }
 
         public void CancelEdit() {
@@ -135,13 +136,13 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.ViewModel {
             }
         }
 
-        public void Edit(IConnectionViewModel connection) {
+        public bool TryEdit(IConnectionViewModel connection) {
             Shell.AssertIsOnMainThread();
             if (connection == null) {
-                return;
+                return false;
             }
 
-            TryStartEditing(connection);
+            return TryStartEditing(connection);
         }
 
         public void CancelTestConnection() {

--- a/src/R/Components/Impl/ConnectionManager/ViewModel/IConnectionManagerViewModel.cs
+++ b/src/R/Components/Impl/ConnectionManager/ViewModel/IConnectionManagerViewModel.cs
@@ -15,8 +15,8 @@ namespace Microsoft.R.Components.ConnectionManager.ViewModel {
         bool IsEditingNew { get; }
         bool IsConnected { get; }
         
-        void Edit(IConnectionViewModel connection);
-        void EditNew();
+        bool TryEdit(IConnectionViewModel connection);
+        bool TryEditNew();
         void CancelEdit();
         void Save(IConnectionViewModel connectionViewModel);
 

--- a/src/R/Components/Impl/Resources.Designer.cs
+++ b/src/R/Components/Impl/Resources.Designer.cs
@@ -160,7 +160,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Connect to &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Connect to &apos;{0}&apos;.
         /// </summary>
         public static string ConnectionManager_ConnectTooltip {
             get {
@@ -178,11 +178,11 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete connection.
+        ///   Looks up a localized string similar to Delete connection &apos;{0}&apos;.
         /// </summary>
-        public static string ConnectionManager_DeleteTooltip {
+        public static string ConnectionManager_DeleteTooltip_Format {
             get {
-                return ResourceManager.GetString("ConnectionManager_DeleteTooltip", resourceCulture);
+                return ResourceManager.GetString("ConnectionManager_DeleteTooltip_Format", resourceCulture);
             }
         }
         
@@ -214,20 +214,20 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit R interpreter information.
+        ///   Looks up a localized string similar to Edit local connection &apos;{0}&apos;.
         /// </summary>
-        public static string ConnectionManager_EditLocalTooltip {
+        public static string ConnectionManager_EditLocalTooltip_Format {
             get {
-                return ResourceManager.GetString("ConnectionManager_EditLocalTooltip", resourceCulture);
+                return ResourceManager.GetString("ConnectionManager_EditLocalTooltip_Format", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit remote connection information.
+        ///   Looks up a localized string similar to Edit remote connection &apos;{0}&apos;.
         /// </summary>
-        public static string ConnectionManager_EditRemoteTooltip {
+        public static string ConnectionManager_EditRemoteTooltip_Format {
             get {
-                return ResourceManager.GetString("ConnectionManager_EditRemoteTooltip", resourceCulture);
+                return ResourceManager.GetString("ConnectionManager_EditRemoteTooltip_Format", resourceCulture);
             }
         }
         
@@ -243,8 +243,7 @@ namespace Microsoft.R.Components {
         
         /// <summary>
         ///   Looks up a localized string similar to Host: {0}
-        ///Arguments: {1}
-        ///    .
+        ///Arguments: {1}.
         /// </summary>
         public static string ConnectionManager_InformationTooltipFormatRemote {
             get {
@@ -280,11 +279,20 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Expand/Collapse list of local R installations.
+        ///   Looks up a localized string similar to Collapse list of local R installations.
         /// </summary>
-        public static string ConnectionManager_LocalConnectionsTooltip {
+        public static string ConnectionManager_LocalConnections_Collapse {
             get {
-                return ResourceManager.GetString("ConnectionManager_LocalConnectionsTooltip", resourceCulture);
+                return ResourceManager.GetString("ConnectionManager_LocalConnections_Collapse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expand list of local R installations.
+        /// </summary>
+        public static string ConnectionManager_LocalConnections_Expand {
+            get {
+                return ResourceManager.GetString("ConnectionManager_LocalConnections_Expand", resourceCulture);
             }
         }
         
@@ -343,11 +351,20 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Expand/Collapse list of remote workspaces.
+        ///   Looks up a localized string similar to Collapse list of remote workspaces.
         /// </summary>
-        public static string ConnectionManager_RemoteConnectionsTooltip {
+        public static string ConnectionManager_RemoteConnections_Collapse {
             get {
-                return ResourceManager.GetString("ConnectionManager_RemoteConnectionsTooltip", resourceCulture);
+                return ResourceManager.GetString("ConnectionManager_RemoteConnections_Collapse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expand list of remote workspaces.
+        /// </summary>
+        public static string ConnectionManager_RemoteConnections_Expand {
+            get {
+                return ResourceManager.GetString("ConnectionManager_RemoteConnections_Expand", resourceCulture);
             }
         }
         

--- a/src/R/Components/Impl/Resources.resx
+++ b/src/R/Components/Impl/Resources.resx
@@ -318,14 +318,29 @@
   <data name="ConnectionManager_RemoteConnections" xml:space="preserve">
     <value>Remote</value>
   </data>
-  <data name="ConnectionManager_LocalConnectionsTooltip" xml:space="preserve">
-    <value>Expand/Collapse list of local R installations</value>
+  <data name="ConnectionManager_LocalConnections_Expand" xml:space="preserve">
+    <value>Expand list of local R installations</value>
   </data>
-  <data name="ConnectionManager_RemoteConnectionsTooltip" xml:space="preserve">
-    <value>Expand/Collapse list of remote workspaces</value>
+  <data name="ConnectionManager_RemoteConnections_Expand" xml:space="preserve">
+    <value>Expand list of remote workspaces</value>
+  </data>
+  <data name="ConnectionManager_LocalConnections_Collapse" xml:space="preserve">
+    <value>Collapse list of local R installations</value>
+  </data>
+  <data name="ConnectionManager_RemoteConnections_Collapse" xml:space="preserve">
+    <value>Collapse list of remote workspaces</value>
   </data>
   <data name="ConnectionManager_ConnectTooltip" xml:space="preserve">
-    <value>Connect to '{0}'.</value>
+    <value>Connect to '{0}'</value>
+  </data>
+  <data name="ConnectionManager_EditLocalTooltip_Format" xml:space="preserve">
+    <value>Edit local connection '{0}'</value>
+  </data>
+  <data name="ConnectionManager_EditRemoteTooltip_Format" xml:space="preserve">
+    <value>Edit remote connection '{0}'</value>
+  </data>
+  <data name="ConnectionManager_DeleteTooltip_Format" xml:space="preserve">
+    <value>Delete connection '{0}'</value>
   </data>
   <data name="ConnectionManager_Name" xml:space="preserve">
     <value>Entry name</value>
@@ -338,12 +353,6 @@
   </data>
   <data name="ConnectionManager_Add" xml:space="preserve">
     <value>Add</value>
-  </data>
-  <data name="ConnectionManager_EditLocalTooltip" xml:space="preserve">
-    <value>Edit R interpreter information</value>
-  </data>
-  <data name="ConnectionManager_DeleteTooltip" xml:space="preserve">
-    <value>Delete connection</value>
   </data>
   <data name="ConnectionManager_Save" xml:space="preserve">
     <value>Save</value>
@@ -493,9 +502,6 @@ If you want to delete all data on the remote machine you must delete your user p
   <data name="ConnectionManager_DeleteTooltipDisabled" xml:space="preserve">
     <value>Entry for the automatically detected local R cannot be deleted. It will be removed when this R version is uninstalled.</value>
   </data>
-  <data name="ConnectionManager_EditRemoteTooltip" xml:space="preserve">
-    <value>Edit remote connection information</value>
-  </data>
   <data name="ConnectionManager_Connected" xml:space="preserve">
     <value>Connected</value>
   </data>
@@ -508,8 +514,7 @@ Arguments: {1}</value>
   </data>
   <data name="ConnectionManager_InformationTooltipFormatRemote" xml:space="preserve">
     <value>Host: {0}
-Arguments: {1}
-    </value>
+Arguments: {1}</value>
   </data>
   <data name="ConnectionManager_SwitchConnectionProgressBarMessage" xml:space="preserve">
     <value>Switching connection "{0}" to "{1}"</value>

--- a/src/R/Components/Test/ConnectionManager/ConnectionManagerViewModelTest.cs
+++ b/src/R/Components/Test/ConnectionManager/ConnectionManagerViewModelTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
             _cmvm.Connect(connection, true);
 
             connection = _cmvm.LocalConnections.Should().ContainSingle(c => c.Name == name).Which;
-            _cmvm.Edit(connection);
+            _cmvm.TryEdit(connection);
 
             _cmvm.Connect(connection, connectToEdited);
 
@@ -111,7 +111,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
             connection = _cmvm.LocalConnections.First(c => c.IsConnected);
             var name = connection.Name;
 
-            _cmvm.EditNew();
+            _cmvm.TryEditNew();
             _cmvm.EditedConnection.Name = name;
             _cmvm.EditedConnection.Path = connection.Path;
             _cmvm.EditedConnection.UpdatePath();
@@ -126,7 +126,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
             var connection = _cmvm.LocalConnections.First(c => c.IsUserCreated);
             var copyName = $"{connection.Name} Copy";
 
-            _cmvm.EditNew();
+            _cmvm.TryEditNew();
             _cmvm.EditedConnection.Name = copyName;
             _cmvm.EditedConnection.Path = connection.Path;
             _cmvm.EditedConnection.UpdatePath();
@@ -144,7 +144,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
             var connection = _cmvm.LocalConnections.First(c => c.IsUserCreated);
             var copyName = $"{connection.Name} Copy";
 
-            _cmvm.EditNew();
+            _cmvm.TryEditNew();
             _cmvm.EditedConnection.Name = copyName;
             _cmvm.EditedConnection.Path = connection.Path;
             _cmvm.EditedConnection.UpdatePath();
@@ -156,7 +156,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
             connectionCopy = _cmvm.LocalConnections.First(c => c.IsConnected);
 
             var copy2Name = $"{copyName} 2";
-            _cmvm.Edit(connectionCopy);
+            _cmvm.TryEdit(connectionCopy);
             connectionCopy.Name = copy2Name;
             _cmvm.Save(connectionCopy);
 
@@ -177,7 +177,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
             connection = _cmvm.LocalConnections.First(c => c.IsConnected);
             var name = connection.Name + Guid.NewGuid();
 
-            _cmvm.EditNew();
+            _cmvm.TryEditNew();
             _cmvm.EditedConnection.Name = name;
             _cmvm.EditedConnection.Path = connection.Path;
             _cmvm.EditedConnection.UpdatePath();
@@ -201,7 +201,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
             var connectedName = connection.Name;
             var name = Guid.NewGuid().ToString();
 
-            _cmvm.EditNew();
+            _cmvm.TryEditNew();
             _cmvm.EditedConnection.Name = name;
             _cmvm.EditedConnection.Path = connection.Path;
             _cmvm.EditedConnection.UpdatePath();
@@ -210,7 +210,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
             var names = _cmvm.LocalConnections.Select(c => c.Name).ToList();
 
             connection = _cmvm.LocalConnections.First(c => c.Name.EqualsOrdinal(name));
-            _cmvm.Edit(connection);
+            _cmvm.TryEdit(connection);
             connection.Name = connectedName;
             _cmvm.Save(connection);
 
@@ -224,14 +224,14 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
 
         [Test(ThreadType.UI)]
         public void AddRemote_Edit_NoChanges() {
-            _cmvm.EditNew();
+            _cmvm.TryEditNew();
 
             _cmvm.EditedConnection.Path = "https://machine";
             _cmvm.EditedConnection.UpdatePath();
             _cmvm.Save(_cmvm.EditedConnection);
 
             var connection = _cmvm.RemoteConnections.Should().ContainSingle(c => c.Name == "machine").Which;
-            _cmvm.Edit(connection);
+            _cmvm.TryEdit(connection);
             _cmvm.Save(connection);
 
             _cmvm.RemoteConnections.Should().ContainSingle(c => ReferenceEquals(c, connection))
@@ -240,12 +240,12 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
 
         [Test(ThreadType.UI)]
         public void AddTwoRemotesWithFragments() {
-            _cmvm.EditNew();
+            _cmvm.TryEditNew();
             _cmvm.EditedConnection.Path = "https://machine#123";
             _cmvm.EditedConnection.UpdatePath();
             _cmvm.Save(_cmvm.EditedConnection);
 
-            _cmvm.EditNew();
+            _cmvm.TryEditNew();
             _cmvm.EditedConnection.Name = "machine2";
             _cmvm.EditedConnection.Path = "https://machine#456";
             _cmvm.EditedConnection.UpdatePath();
@@ -264,7 +264,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
         [InlineData("https://machine2", "machine2", "https://machine2:5444")]
         [InlineData("https://machine2:5444", "machine2", "https://machine2:5444")]
         public void AddRemote_Edit_ChangePath(string newPath, string expectedMachineName, string expectedPath) {
-            _cmvm.EditNew();
+            _cmvm.TryEditNew();
 
             _cmvm.EditedConnection.Path = "https://machine";
             _cmvm.EditedConnection.UpdatePath();
@@ -272,7 +272,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
 
             var connection = _cmvm.RemoteConnections.Should().ContainSingle(c => c.Name == "machine").Which;
 
-            _cmvm.Edit(connection);
+            _cmvm.TryEdit(connection);
             connection.Path = newPath;
             _cmvm.EditedConnection.UpdatePath();
             _cmvm.Save(connection);
@@ -283,7 +283,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
 
         [Test(ThreadType.UI)]
         public void AddRemote_Edit_ChangeCommandLine() {
-            _cmvm.EditNew();
+            _cmvm.TryEditNew();
 
             _cmvm.EditedConnection.Path = "https://machine";
             _cmvm.EditedConnection.UpdatePath();
@@ -291,7 +291,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
 
             var connection = _cmvm.RemoteConnections.Should().ContainSingle(c => c.Name == "machine").Which;
 
-            _cmvm.Edit(connection);
+            _cmvm.TryEdit(connection);
             connection.RCommandLineArguments = "--args 5";
             _cmvm.Save(connection);
 
@@ -301,7 +301,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
 
         [Test(ThreadType.UI)]
         public void AddRemote_Edit_Rename() {
-            _cmvm.EditNew();
+            _cmvm.TryEditNew();
 
             _cmvm.EditedConnection.Path = "https://machine";
             _cmvm.EditedConnection.UpdatePath();
@@ -309,7 +309,7 @@ namespace Microsoft.R.Components.Test.ConnectionManager {
 
             var connection = (ConnectionViewModel)_cmvm.RemoteConnections.Should().ContainSingle(c => c.Name == "machine").Which;
 
-            _cmvm.Edit(connection);
+            _cmvm.TryEdit(connection);
             connection.Name = "Custom Name";
             _cmvm.Save(connection);
 

--- a/src/R/Wpf/Impl/CommonResources.xaml
+++ b/src/R/Wpf/Impl/CommonResources.xaml
@@ -399,7 +399,6 @@
     </Style>
 
     <Style x:Key="ExpandCollapseToggleStyle" TargetType="{x:Type ToggleButton}">
-        <Setter Property="Focusable" Value="False" />
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static wpf:Brushes.UITextKey}}"/>
         <Setter Property="Template">


### PR DESCRIPTION
- Fix #3199: Focus doesn't switch from one line in Workspaces to another
- Fix #3172: Unable to get to connection fields with keyboard
- Fix #3171: Narrator: Entries in Workspace window are read as class names