### PR TITLE
Fix #3205: VE crash for objects with length exceeding 32-bit

### DIFF
--- a/src/Host/API/Impl/Definitions/IRObjectInformation.cs
+++ b/src/Host/API/Impl/Definitions/IRObjectInformation.cs
@@ -16,11 +16,11 @@ namespace Microsoft.R.Host.Client {
         /// <summary>
         /// Object length (such an number of elements in a list)
         /// </summary>
-        int Length { get; }
+        long Length { get; }
 
         /// <summary>
         /// Number of dimensions in the object.
         /// </summary>
-        IReadOnlyList<int> Dim { get; }
+        IReadOnlyList<long> Dim { get; }
     }
 }

--- a/src/Host/API/Impl/RHostSession.Interop.cs
+++ b/src/Host/API/Impl/RHostSession.Interop.cs
@@ -175,8 +175,8 @@ namespace Microsoft.R.Host.Client {
 
         private class RObjectInfo: IRObjectInformation {
             public string TypeName { get; set; }
-            public int Length { get; set; }
-            public IReadOnlyList<int> Dim { get; set; }
+            public long Length { get; set; }
+            public IReadOnlyList<long> Dim { get; set; }
         }
     }
 }

--- a/src/Host/API/Impl/RHostSessionExtensions.cs
+++ b/src/Host/API/Impl/RHostSessionExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.R.Host.Client {
         /// <param name="expression">Expression to evaluate</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Object kength</returns>
-        public static async Task<int> GetLengthAsync(this IRHostSession session, string expression, CancellationToken cancellationToken = default(CancellationToken)) {
+        public static async Task<long> GetLengthAsync(this IRHostSession session, string expression, CancellationToken cancellationToken = default(CancellationToken)) {
             var info = await session.GetInformationAsync(expression, cancellationToken);
             return info.Length;
         }

--- a/src/Host/Client/Impl/DataInspection/IRValueInfo.cs
+++ b/src/Host/Client/Impl/DataInspection/IRValueInfo.cs
@@ -39,22 +39,22 @@ namespace Microsoft.R.DataInspection {
         /// <summary>
         /// Length of the value, as computed by <c>length(...)</c>.
         /// </summary>
-        int? Length { get; }
+        long? Length { get; }
 
         /// <summary>
         /// Number of attributes that this value has, as computed by <c>length(attributes(...))</c>.
         /// </summary>
-        int? AttributeCount { get; }
+        long? AttributeCount { get; }
 
         /// <summary>
         /// Number of slots that this value has, as computed by <c>length(slotNames(class(...)))</c>.
         /// </summary>
-        int? SlotCount { get; }
+        long? SlotCount { get; }
 
         /// <summary>
         /// Number of names that the children of value have, as computed by <c>length(names(...))</c>.
         /// </summary>
-        int? NameCount { get; }
+        long? NameCount { get; }
 
         /// <summary>
         /// Dimensions that this value has, as computed by <c>dim(...)</c>.
@@ -63,7 +63,7 @@ namespace Microsoft.R.DataInspection {
         /// If <see cref="REvaluationResultProperties.DimProperty"/> was not specified, this property will be
         /// <see langword="null"/>, rather than an empty collection.
         /// </remarks>
-        IReadOnlyList<int> Dim { get; }
+        IReadOnlyList<long> Dim { get; }
 
         /// <summary>
         /// Various miscellaneous flags describing this value.

--- a/src/Host/Client/Impl/DataInspection/RValueInfo.cs
+++ b/src/Host/Client/Impl/DataInspection/RValueInfo.cs
@@ -19,15 +19,15 @@ namespace Microsoft.R.DataInspection {
 
         public IReadOnlyList<string> Classes { get; }
 
-        public int? Length { get; }
+        public long? Length { get; }
 
-        public int? AttributeCount { get; }
+        public long? AttributeCount { get; }
 
-        public int? SlotCount { get; }
+        public long? SlotCount { get; }
 
-        public int? NameCount { get; }
+        public long? NameCount { get; }
 
-        public IReadOnlyList<int> Dim { get; }
+        public IReadOnlyList<long> Dim { get; }
 
         public RValueFlags Flags { get; }
 
@@ -71,11 +71,11 @@ namespace Microsoft.R.DataInspection {
             RChildAccessorKind accessorKind,
             string typeName,
             IReadOnlyList<string> classes,
-            int? length,
-            int? attributeCount,
-            int? slotCount,
-            int? nameCount,
-            IReadOnlyList<int> dim,
+            long? length,
+            long? attributeCount,
+            long? slotCount,
+            long? nameCount,
+            IReadOnlyList<long> dim,
             RValueFlags flags,
             bool canCoerceToDataFrame
         ) : base(evaluator, environmentExpression, expression, name) {
@@ -98,10 +98,10 @@ namespace Microsoft.R.DataInspection {
 
             Representation = json.Value<string>(FieldNames.Repr);
             TypeName = json.Value<string>(FieldNames.Type);
-            Length = json.Value<int?>(FieldNames.Length);
-            AttributeCount = json.Value<int?>(FieldNames.AttributeCount);
-            SlotCount = json.Value<int?>(FieldNames.SlotCount);
-            NameCount = json.Value<int?>(FieldNames.NameCount);
+            Length = json.Value<long?>(FieldNames.Length);
+            AttributeCount = json.Value<long?>(FieldNames.AttributeCount);
+            SlotCount = json.Value<long?>(FieldNames.SlotCount);
+            NameCount = json.Value<long?>(FieldNames.NameCount);
             CanCoerceToDataFrame = json.Value<bool?>(FieldNames.CanCoerceToDataFrame) ?? false;
 
             var classes = json.Value<JArray>(FieldNames.Classes);
@@ -111,7 +111,7 @@ namespace Microsoft.R.DataInspection {
 
             var dim = json.Value<JArray>(FieldNames.Dim);
             if (dim != null) {
-                Dim = dim.Select(t => t.Value<int>()).ToArray();
+                Dim = dim.Select(t => t.Value<long>()).ToArray();
             }
 
             var kind = json.Value<string>(FieldNames.AccessorKind);

--- a/src/Host/Client/Impl/rtvs/R/eval.R
+++ b/src/Host/Client/Impl/rtvs/R/eval.R
@@ -39,6 +39,12 @@ describe_object <- function(obj, res, fields, repr = NULL) {
 
     if (field('classes')) {
         classes <- NA_if_error(class(obj));
+
+        # Since the entire class vector is serialized, restrict exceedingly large numbers of classes.
+        if (length(classes) > 1000) {
+            classes <- classes[1:1000];
+        }
+
         res$classes <- lapply(classes, function(cls) {
             if (!is.character(cls) || length(cls) != 1 || is.na(cls)) NA else cls
         });
@@ -62,7 +68,8 @@ describe_object <- function(obj, res, fields, repr = NULL) {
 
     if (field('dim')) {
         dim <- NA_if_error(dim(obj));
-        if (is.integer(dim) && !anyNA(dim)) {
+        # Since the entire dimension vector is serialized, restrict exceedingly large numbers of dimensions.
+        if (is.integer(dim) && !anyNA(dim) && length(dim) < 1000) {
             res$dim <- as.list(dim);
         }
     }

--- a/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml.cs
+++ b/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml.cs
@@ -158,7 +158,6 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
                 if (expression != null) {
                     try {
                         var grid = await GridDataSource.GetGridDataAsync(expression, null);
-
                         PopulateDataFramePreview(grid);
                         DataFramePreview.Visibility = Visibility.Visible;
                     } catch (Exception ex) {
@@ -200,7 +199,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
             var dg = DataFramePreview;
             dg.Columns.Clear();
 
-            for (int i = 0; i < gridData.ColumnHeader.Range.Count; i++) {
+            for (long i = 0; i < gridData.ColumnHeader.Range.Count; i++) {
                 dg.Columns.Add(new DataGridTextColumn() {
                     Header = gridData.ColumnHeader[gridData.ColumnHeader.Range.Start + i],
                     Binding = new Binding(Invariant($"Values[{i}]")),
@@ -208,12 +207,12 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
             }
 
             var rows = new List<DataFramePreviewRowItem>();
-            for (var r = 0; r < gridData.Grid.Range.Rows.Count; r++) {
+            for (long r = 0; r < gridData.Grid.Range.Rows.Count; r++) {
                 var row = new DataFramePreviewRowItem {
                     RowName = gridData.RowHeader[gridData.RowHeader.Range.Start + r]
                 };
 
-                for (int c = 0; c < gridData.Grid.Range.Columns.Count; c++) {
+                for (long c = 0; c < gridData.Grid.Range.Columns.Count; c++) {
                     row.Values.Add(gridData.Grid[gridData.Grid.Range.Rows.Start + r, gridData.Grid.Range.Columns.Start + c].ToUnicodeQuotes());
                 }
 

--- a/src/Package/Impl/DataInspect/DataSource/Grid.cs
+++ b/src/Package/Impl/DataInspect/DataSource/Grid.cs
@@ -12,10 +12,10 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
     public class Grid<T> : IGrid<T> {
         private IList<T> _list;
 
-        public Grid(GridRange range, Func<int, int, T> createNew) {
+        public Grid(GridRange range, Func<long, long, T> createNew) {
             Range = range;
 
-            _list = new List<T>(range.Rows.Count * range.Columns.Count);
+            _list = new List<T>(checked((int)(range.Rows.Count * range.Columns.Count)));
 
             foreach (int c in range.Columns.GetEnumerable()) {
                 foreach (int r in range.Rows.GetEnumerable()) {
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             _list = list;
         }
 
-        public T this[int rowIndex, int columnIndex] {
+        public T this[long rowIndex, long columnIndex] {
             get {
                 return _list[ListIndex(rowIndex, columnIndex)];
             }
@@ -44,8 +44,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         public GridRange Range { get; }
 
-        private int ListIndex(int rowIndex, int columnIndex) {
-            return ((columnIndex - Range.Columns.Start) * Range.Rows.Count) + (rowIndex - Range.Rows.Start);
+        private int ListIndex(long rowIndex, long columnIndex) {
+            return checked((int)(((columnIndex - Range.Columns.Start) * Range.Rows.Count) + (rowIndex - Range.Rows.Start)));
         }
     }
 
@@ -55,8 +55,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
     /// <typeparam name="T"></typeparam>
     public class RangeToGrid<T> : IGrid<T> {
         IRange<T> _data;
-        Func<int, int, T> _getItemFunc;
-        Action<int, int, T> _setItemFunc;
+        Func<long, long, T> _getItemFunc;
+        Action<long, long, T> _setItemFunc;
 
         public RangeToGrid(Range range, IRange<T> data, bool takeColumn) {
             if (takeColumn) {
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             _data = data;
         }
 
-        public T this[int rowIndex, int columnIndex] {
+        public T this[long rowIndex, long columnIndex] {
             get {
                 return _getItemFunc(rowIndex, columnIndex);
             }
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         public GridRange Range { get; }
 
-        private T GetItemColumnMode(int rowIndex, int columnIndex) {
+        private T GetItemColumnMode(long rowIndex, long columnIndex) {
             if (rowIndex != 0) {
                 throw new ArgumentOutOfRangeException(nameof(rowIndex));
             }
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             return _data[columnIndex];
         }
 
-        private void SetItemColumnMode(int rowIndex, int columnIndex, T value) {
+        private void SetItemColumnMode(long rowIndex, long columnIndex, T value) {
             if (rowIndex != 0) {
                 throw new ArgumentOutOfRangeException(nameof(rowIndex));
             }
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             _data[columnIndex] = value;
         }
 
-        private T GetItemRowMode(int rowIndex, int columnIndex) {
+        private T GetItemRowMode(long rowIndex, long columnIndex) {
             if (columnIndex != 0) {
                 throw new ArgumentOutOfRangeException(nameof(columnIndex));
             }
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             return _data[rowIndex];
         }
 
-        private void SetItemRowMode(int rowIndex, int columnIndex, T value) {
+        private void SetItemRowMode(long rowIndex, long columnIndex, T value) {
             if (columnIndex != 0) {
                 throw new ArgumentOutOfRangeException(nameof(columnIndex));
             }
@@ -123,14 +123,15 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             Range = range;
             _data = data;
         }
+
         public GridRange Range { get; }
 
-        public T this[int rowIndex, int columnIndex] {
+        public T this[long rowIndex, long columnIndex] {
             get {
-                return _data[columnIndex - Range.Columns.Start][rowIndex - Range.Rows.Start];
+                return _data[checked((int)(columnIndex - Range.Columns.Start))][checked((int)(rowIndex - Range.Rows.Start))];
             }
             set {
-                _data[columnIndex - Range.Columns.Start][rowIndex - Range.Rows.Start] = value;
+                _data[checked((int)(columnIndex - Range.Columns.Start))][checked((int)(rowIndex - Range.Rows.Start))] = value;
             }
         }
     }

--- a/src/Package/Impl/DataInspect/DataSource/GridRange.cs
+++ b/src/Package/Impl/DataInspect/DataSource/GridRange.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         public Range Columns { get; }
 
-        public bool Contains(int row, int column) {
+        public bool Contains(long row, long column) {
             return Rows.Contains(row) && Columns.Contains(column);
         }
 

--- a/src/Package/Impl/DataInspect/DataSource/IGrid.cs
+++ b/src/Package/Impl/DataInspect/DataSource/IGrid.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         /// <exception cref="ArgumentOutOfRangeException">when index is out of range</exception>
         /// <exception cref="InvalidOperationException">when failed at setting or getting the value</exception>
         /// <exception cref="NotSupportedException">setter, when the grid is read only</exception>
-        T this[int rowIndex, int columnIndex] {
+        T this[long rowIndex, long columnIndex] {
             get; set;
         }
     }
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
     public interface IRange<T> {
         Range Range { get; }
 
-        T this[int index] {
+        T this[long index] {
             get; set;
         }
     }

--- a/src/Package/Impl/DataInspect/DataSource/IGridProvider.cs
+++ b/src/Package/Impl/DataInspect/DataSource/IGridProvider.cs
@@ -20,12 +20,12 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         /// <summary>
         /// total number of items in row
         /// </summary>
-        int RowCount { get; }
+        long RowCount { get; }
 
         /// <summary>
         /// total number of items in column
         /// </summary>
-        int ColumnCount { get; }
+        long ColumnCount { get; }
 
         bool CanSort { get; }
 

--- a/src/Package/Impl/DataInspect/DataSource/ListToRange.cs
+++ b/src/Package/Impl/DataInspect/DataSource/ListToRange.cs
@@ -23,13 +23,13 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         public Range Range { get; }
 
-        public T this[int index] {
+        public T this[long index] {
             get {
-                return _list[index - Range.Start];
+                return _list[checked((int)(index - Range.Start))];
             }
 
             set {
-                _list[index - Range.Start] = value;
+                _list[checked((int)( index - Range.Start))] = value;
             }
         }
     }

--- a/src/Package/Impl/DataInspect/DataSource/Range.cs
+++ b/src/Package/Impl/DataInspect/DataSource/Range.cs
@@ -11,19 +11,19 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
     /// </summary>
     [DebuggerDisplay("[{Start},{_end})")]
     public struct Range {
-        int _end;
+        long _end;
 
-        public Range(int start, int count) {
+        public Range(long start, long count) {
             Start = start;
             Count = count;
             _end = start + count;
         }
 
-        public int Start { get; }
+        public long Start { get; }
 
-        public int Count { get; }
+        public long Count { get; }
 
-        public bool Contains(int value) {
+        public bool Contains(long value) {
             return (value >= Start) && (value < _end);
         }
 
@@ -33,13 +33,13 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             return (other.Start <= this.Start) && (other._end >= this._end);
         }
 
-        public IEnumerable<int> GetEnumerable(bool ascending = true) {
+        public IEnumerable<long> GetEnumerable(bool ascending = true) {
             if (ascending) {
-                for (int i = Start; i < _end; i++) {
+                for (long i = Start; i < _end; i++) {
                     yield return i;
                 }
             } else {
-                for (int i = _end - 1; i >= Start; i--) {
+                for (long i = _end - 1; i >= Start; i--) {
                     yield return i;
                 }
             }

--- a/src/Package/Impl/DataInspect/DefaultHeaderData.cs
+++ b/src/Package/Impl/DataInspect/DefaultHeaderData.cs
@@ -20,9 +20,9 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             _is1D = is1D;
         }
 
-        public string this[int index] {
+        public string this[long index] {
             get {
-                int rIndex = checked(index + 1);
+                long rIndex = checked(index + 1);
                 if (_is1D) {
                     switch (_mode) {
                         case Mode.Column:

--- a/src/Package/Impl/DataInspect/GridDataProvider.cs
+++ b/src/Package/Impl/DataInspect/GridDataProvider.cs
@@ -29,9 +29,9 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
         }
 
-        public int ColumnCount { get; }
+        public long ColumnCount { get; }
 
-        public int RowCount { get; }
+        public long RowCount { get; }
 
         public bool CanSort { get; }
 

--- a/src/Package/Impl/DataInspect/VisualGrid/ColumnSortOrder.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/ColumnSortOrder.cs
@@ -3,9 +3,9 @@
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect {
     public class ColumnSortOrder {
-        public int ColumnIndex { get; }
+        public long ColumnIndex { get; }
         public bool Descending { get; set; }
-        public ColumnSortOrder(int columnIndex, bool descending) {
+        public ColumnSortOrder(long columnIndex, bool descending) {
             ColumnIndex = columnIndex;
             Descending = descending;
         }

--- a/src/Package/Impl/DataInspect/VisualGrid/GridPoints.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/GridPoints.cs
@@ -13,8 +13,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
     internal class GridPoints {
         #region fields and ctor
 
-        private int _rowCount;
-        private int _columnCount;
+        private long _rowCount;
+        private long _columnCount;
 
         private double[] _xPositions;
         private double[] _yPositions;
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         private bool _xPositionValid;
         private bool _yPositionValid;
 
-        public GridPoints(int rowCount, int columnCount, Size initialViewportSize) {
+        public GridPoints(long rowCount, long columnCount, Size initialViewportSize) {
             Reset(rowCount, columnCount);
 
             _viewportHeight = Math.Max(MinItemHeight, initialViewportSize.Height);
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         #endregion
 
-        public void Reset(int rowCount, int columnCount) {
+        public void Reset(long rowCount, long columnCount) {
             _rowCount = rowCount;
             _columnCount = columnCount;
 
@@ -185,21 +185,21 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             return new PointAccessor(this, scrollDirection);
         }
 
-        public double xPosition(int xIndex) {
+        public double xPosition(long xIndex) {
             EnsureXPositions();
             return _xPositions[xIndex] - HorizontalComputedOffset;
         }
 
-        public double yPosition(int yIndex) {
+        public double yPosition(long yIndex) {
             EnsureYPositions();
             return _yPositions[yIndex] - VerticalComputedOffset;
         }
 
-        public double GetWidth(int columnIndex) {
+        public double GetWidth(long columnIndex) {
             return _width[columnIndex];
         }
 
-        public void SetWidth(int xIndex, double value) {
+        public void SetWidth(long xIndex, double value) {
             if (_width[xIndex].LessThan(value)) {
                 _width[xIndex] = value;
                 _xPositionValid = false;
@@ -207,11 +207,11 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
         }
 
-        public double GetHeight(int rowIndex) {
+        public double GetHeight(long rowIndex) {
             return _height[rowIndex];
         }
 
-        public void SetHeight(int yIndex, double value) {
+        public void SetHeight(long yIndex, double value) {
             if (_height[yIndex].LessThan(value)) {
                 _height[yIndex] = value;
                 _yPositionValid = false;
@@ -243,33 +243,33 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
         }
 
-        public int xIndex(double position) {
+        public long xIndex(double position) {
             EnsureXPositions();
-            int index = Index(position, _xPositions);
+            long index = Index(position, _xPositions);
 
             // _xPositions has one more item than columns
             return Math.Min(index, _columnCount - 1);
         }
 
-        public int yIndex(double position) {
+        public long yIndex(double position) {
             EnsureYPositions();
-            int index = Index(position, _yPositions);
+            long index = Index(position, _yPositions);
 
             // _yPositions has one more item than rows
             return Math.Min(index, _rowCount - 1);
         }
 
-        private int Index(double position, double[] positions) {
-            int index = Array.BinarySearch(positions, position);
+        private long Index(double position, double[] positions) {
+            long index = Array.BinarySearch(positions, position);
             return (index < 0) ? (~index) - 1 : index;
         }
 
         private void InitializeWidthAndHeight() {
-            for (int i = 0; i < _columnCount; i++) {
+            for (long i = 0; i < _columnCount; i++) {
                 _width[i] = MinItemWidth;
             }
 
-            for (int i = 0; i < _rowCount; i++) {
+            for (long i = 0; i < _rowCount; i++) {
                 _height[i] = MinItemHeight;
             }
 
@@ -280,15 +280,15 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         }
 
         public GridRange ComputeDataViewport(Rect visualViewport) {
-            int columnStart = Math.Max(0, xIndex(visualViewport.X));
-            int rowStart = Math.Max(0, yIndex(visualViewport.Y));
+            long columnStart = Math.Max(0, xIndex(visualViewport.X));
+            long rowStart = Math.Max(0, yIndex(visualViewport.Y));
 
             Debug.Assert(HorizontalComputedOffset >= _xPositions[columnStart]);
             Debug.Assert(VerticalComputedOffset >= _yPositions[rowStart]);
 
             double width = _xPositions[columnStart] - HorizontalComputedOffset;
-            int columnCount = 0;
-            for (int c = columnStart; c < _columnCount; c++) {
+            long columnCount = 0;
+            for (long c = columnStart; c < _columnCount; c++) {
                 width += GetWidth(c);
                 columnCount++;
                 if (width.GreaterThanOrClose(visualViewport.Width)) {
@@ -297,7 +297,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
 
             if (width.LessThan(visualViewport.Width)) {
-                for (int c = columnStart - 1; c >= 0; c--) {
+                for (long c = columnStart - 1; c >= 0; c--) {
                     width += GetWidth(c);
                     if (width.GreaterThanOrClose(visualViewport.Width)) {
                         break;
@@ -306,9 +306,9 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
 
             double height = _yPositions[rowStart] - VerticalComputedOffset;
-            int rowEnd = rowStart;
-            int rowCount = 0;
-            for (int r = rowStart; r < _rowCount; r++) {
+            long rowEnd = rowStart;
+            long rowCount = 0;
+            for (long r = rowStart; r < _rowCount; r++) {
                 height += GetHeight(r);
                 rowCount++;
                 if (height.GreaterThanOrClose(visualViewport.Height)) {
@@ -317,7 +317,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
 
             if (height.LessThan(visualViewport.Height)) {
-                for (int r = rowStart - 1; r >= 0; r--) {
+                for (long r = rowStart - 1; r >= 0; r--) {
                     height += GetHeight(r);
                     if (height.GreaterThanOrClose(visualViewport.Height)) {
                         break;
@@ -345,7 +345,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         private void ComputeYPositions() {
             double height = 0.0;
-            for (int i = 0; i < _rowCount; i++) {
+            for (long i = 0; i < _rowCount; i++) {
                 height += _height[i];
                 _yPositions[i + 1] = height;
             }
@@ -360,7 +360,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         private void ComputeXPositions() {
             double width = 0.0;
-            for (int i = 0; i < _columnCount; i++) {
+            for (long i = 0; i < _columnCount; i++) {
                 width += _width[i];
                 _xPositions[i + 1] = width;
             }
@@ -422,7 +422,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
             public Indexer<double> yPosition { get; }
 
-            private static void NotSupportedSetter(int index, double value) {
+            private static void NotSupportedSetter(long index, double value) {
                 throw new NotSupportedException("Setter is not supported");
             }
         }

--- a/src/Package/Impl/DataInspect/VisualGrid/HeaderTextVisual.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/HeaderTextVisual.cs
@@ -29,11 +29,11 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         }
         #endregion
 
-        public HeaderTextVisual(int columnIndex) {
+        public HeaderTextVisual(long columnIndex) {
             ColumnIndex = columnIndex;
         }
 
-        public int ColumnIndex { get; }
+        public long ColumnIndex { get; }
 
         /// <summary>
         /// Name of the column

--- a/src/Package/Impl/DataInspect/VisualGrid/Indexer.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/Indexer.cs
@@ -9,15 +9,15 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
     /// </summary>
     /// <typeparam name="TValue"></typeparam>
     internal class Indexer<TValue> {
-        private Func<int, TValue> _getter;
-        private Action<int, TValue> _setter;
+        private Func<long, TValue> _getter;
+        private Action<long, TValue> _setter;
 
-        public Indexer(Func<int, TValue> getter, Action<int, TValue> setter) {
+        public Indexer(Func<long, TValue> getter, Action<long, TValue> setter) {
             _getter = getter;
             _setter = setter;
         }
 
-        public TValue this[int index] {
+        public TValue this[long index] {
             get {
                 return _getter(index);
             }

--- a/src/Package/Impl/DataInspect/VisualGrid/TextVisual.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/TextVisual.cs
@@ -21,18 +21,18 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         }
 
         public static readonly DependencyProperty RowProperty =
-            DependencyProperty.Register("Row", typeof(int), typeof(TextVisual), new PropertyMetadata());
+            DependencyProperty.Register("Row", typeof(long), typeof(TextVisual), new PropertyMetadata());
 
-        public virtual int Row {
-            get { return (int)GetValue(RowProperty); }
+        public virtual long Row {
+            get { return (long)GetValue(RowProperty); }
             set { SetValue(RowProperty, value); }
         }
 
         public static readonly DependencyProperty ColumnProperty =
-            DependencyProperty.Register("Column", typeof(int), typeof(TextVisual), new PropertyMetadata());
+            DependencyProperty.Register("Column", typeof(long), typeof(TextVisual), new PropertyMetadata());
 
-        public virtual int Column {
-            get { return (int)GetValue(ColumnProperty); }
+        public virtual long Column {
+            get { return (long)GetValue(ColumnProperty); }
             set { SetValue(ColumnProperty, value); }
         }
         #endregion

--- a/src/Package/Impl/DataInspect/VisualGrid/VisualGrid.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/VisualGrid.cs
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
         }
 
-        private void InitVisual(int r, int c, IGrid<string> data, TextVisual visual) {
+        private void InitVisual(long r, long c, IGrid<string> data, TextVisual visual) {
             visual.Row = r;
             visual.Column = c;
             visual.Text = data[r, c];

--- a/src/Package/TestApp/Data/GridDataTest.cs
+++ b/src/Package/TestApp/Data/GridDataTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Data {
     [ExcludeFromCodeCoverage]
     public class GridDataTest : IAsyncLifetime {
         private struct GridElement<T> {
-            public int X, Y;
+            public long X, Y;
             public T Value;
 
             public override string ToString() => $"[{Y}, {X}] = {Value}";
@@ -47,8 +47,8 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Data {
         }
 
         private static IEnumerable<T> ToEnumerable<T>(IRange<T> range) {
-            int start = range.Range.Start, end = start + range.Range.Count;
-            for (int i = start; i < end; ++i) {
+            long start = range.Range.Start, end = start + range.Range.Count;
+            for (long i = start; i < end; ++i) {
                 yield return range[i];
             }
         }

--- a/src/R/Editor/Impl/Data/IRSessionDataObject.cs
+++ b/src/R/Editor/Impl/Data/IRSessionDataObject.cs
@@ -16,7 +16,7 @@ namespace Microsoft.R.Editor.Data {
 
         bool HasChildren { get; }
 
-        IReadOnlyList<int> Dimensions { get; }
+        IReadOnlyList<long> Dimensions { get; }
 
         bool IsHidden { get; }
 

--- a/src/R/Editor/Impl/Data/RSessionDataObject.cs
+++ b/src/R/Editor/Impl/Data/RSessionDataObject.cs
@@ -58,7 +58,9 @@ namespace Microsoft.R.Editor.Data {
                 }
             }
 
-            if (Dimensions == null) Dimensions = new List<int>();
+            if (Dimensions == null) {
+                Dimensions = new List<long>();
+            }
 
             MaxChildrenCount = maxChildrenCount;
         }
@@ -77,9 +79,9 @@ namespace Microsoft.R.Editor.Data {
             if (valueInfo.Dim != null) {
                 Dimensions = valueInfo.Dim;
             } else if (valueInfo.Length.HasValue) {
-                Dimensions = new List<int>() { valueInfo.Length.Value, 1 };
+                Dimensions = new List<long>() { valueInfo.Length.Value, 1 };
             } else {
-                Dimensions = new List<int>();
+                Dimensions = new List<long>();
             }
         }
 
@@ -172,7 +174,7 @@ namespace Microsoft.R.Editor.Data {
 
         public bool HasChildren { get; protected set; }
 
-        public IReadOnlyList<int> Dimensions { get; protected set; }
+        public IReadOnlyList<long> Dimensions { get; protected set; }
 
         public bool IsHidden {
             get { return Name.StartsWithOrdinal(HiddenVariablePrefix); }


### PR DESCRIPTION
Use 64-bit integers for number of elements / rows / columns, and the corresponding indices.

Guard against objects with extremely large extents in one or more dimensions.