### PR TITLE
Fix #3209: After running tests R.Host.exe processes do not terminate

### DIFF
--- a/src/Host/Client/Impl/Session/RSessionProvider.cs
+++ b/src/Host/Client/Impl/Session/RSessionProvider.cs
@@ -153,7 +153,8 @@ namespace Microsoft.R.Host.Client.Session {
                     BrokerChanging?.Invoke(this, EventArgs.Empty);
 
                     await StopSessionsAsync(_sessions.Values, false, cancellationToken);
-                    _brokerProxy.Set(new NullBrokerClient());
+                    var oldBroker = _brokerProxy.Set(new NullBrokerClient());
+                    oldBroker?.Dispose();
 
                     OnBrokerChanged();
                 }

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -299,9 +299,12 @@ query_reload_autosave <- function() {
 }
 
 save_state <- function() {
-    message(sprintf(locstr('rtvs_AutosavingWorkspace'), autosave_filename));
+    # This function runs when client is already disconnected, so locstr() cannot be used, since it requires
+    # a connected client to provide translated strings. However, since messages are not user-visible and are
+    # here for logging purposes only, they don't need to be localized in the first place.
+    message(sprintf('Autosaving workspace to image "%s" ...', autosave_filename), appendLF = FALSE);
     save.image(autosave_filename);
-    message(locstr('rtvs_WorkspaceSavedSuccessfully'));
+    message(' workspace saved successfully.');
 }
 
 enable_autosave <- function(delete_existing) {


### PR DESCRIPTION
Do not request localized strings from client in autosave-on-shutdown code.

Dispose broker when it is removed from the session provider.