### PR TITLE
Fix #3217: Sometime package manager appears empty

### DIFF
--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
@@ -187,11 +187,6 @@
                     <TextBlock Grid.Column="1" Text="{x:Static components:Resources.Loading}" HorizontalAlignment="Left" VerticalAlignment="Center"
                                Foreground="{DynamicResource {x:Static rwpf:Brushes.UITextKey}}"/>
                 </Grid>
-                <Grid.Visibility>
-                    <MultiBinding Converter="{x:Static rwpf:Converters.AnyIsNotCollapsed}">
-                        <Binding Path="IsLoading" />
-                    </MultiBinding>
-                </Grid.Visibility>
             </Grid>
             <ListBox x:Name="List" Background="{DynamicResource {x:Static rwpf:Brushes.ListPaneBackgroundKey}}" Foreground="{DynamicResource {x:Static rwpf:Brushes.UITextKey}}"
                      ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Visible" ItemContainerStyle="{DynamicResource PackageItemStyle}"

--- a/src/R/Components/Impl/Resources.Designer.cs
+++ b/src/R/Components/Impl/Resources.Designer.cs
@@ -958,6 +958,33 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error: Can&apos;t get list of available packages because connection to workspace failed..
+        /// </summary>
+        public static string PackageManager_CantLoadAvailablePackages_NoConnection {
+            get {
+                return ResourceManager.GetString("PackageManager_CantLoadAvailablePackages_NoConnection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error: Can&apos;t get list of installed packages because connection to workspace failed..
+        /// </summary>
+        public static string PackageManager_CantLoadInstalledPackages_NoConnection {
+            get {
+                return ResourceManager.GetString("PackageManager_CantLoadInstalledPackages_NoConnection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error: Can&apos;t get list of loaded packages because connection to workspace failed..
+        /// </summary>
+        public static string PackageManager_CantLoadLoadedPackages_NoConnection {
+            get {
+                return ResourceManager.GetString("PackageManager_CantLoadLoadedPackages_NoConnection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error: Package {0} can&apos;t be loaded because Interactive Window is disconnected from R session..
         /// </summary>
         public static string PackageManager_CantLoadPackageNoRSession {

--- a/src/R/Components/Impl/Resources.resx
+++ b/src/R/Components/Impl/Resources.resx
@@ -168,6 +168,15 @@
   <data name="PackageManager_NoLoadedPackagesNoRSession" xml:space="preserve">
     <value>Warning: Interactive Window is disconnected from R Session, so there is no information about loaded packages.</value>
   </data>
+  <data name="PackageManager_CantLoadAvailablePackages_NoConnection" xml:space="preserve">
+    <value>Error: Can't get list of available packages because connection to workspace failed.</value>
+  </data>
+  <data name="PackageManager_CantLoadInstalledPackages_NoConnection" xml:space="preserve">
+    <value>Error: Can't get list of installed packages because connection to workspace failed.</value>
+  </data>
+  <data name="PackageManager_CantLoadLoadedPackages_NoConnection" xml:space="preserve">
+    <value>Error: Can't get list of loaded packages because connection to workspace failed.</value>
+  </data>
   <data name="PackageManager_CantLoadPackageNoRSession" xml:space="preserve">
     <value>Error: Package {0} can't be loaded because Interactive Window is disconnected from R session.</value>
   </data>


### PR DESCRIPTION
The reason why we get "cyclic namespace dependency" error isn't clear, especially after CRAN mirror was successfully updated, but error message now remain visible until list installed packages are loaded or explicitly dismissed.