### PR TITLE
3235

### DIFF
--- a/src/Package/Impl/DataInspect/VisualGrid/MatrixView.xaml
+++ b/src/Package/Impl/DataInspect/VisualGrid/MatrixView.xaml
@@ -41,17 +41,29 @@
                     MinWidth="10" MinHeight="10" SnapsToDevicePixels="true"
                    Fill="{Binding HeaderBackground, RelativeSource={RelativeSource AncestorType={x:Type local:MatrixView}}}" />
         </Border>
+        
         <local:VisualGrid x:Name="ColumnHeader" ScrollDirection="Horizontal" FocusVisualStyle="{StaticResource EmptyFocusVisualStyle}"
-                          Grid.Row="0" Grid.Column="1" Header="{Binding CanSort}" />
+                          Grid.Row="0" Grid.Column="1" Header="{Binding CanSort}" 
+                          FontFamily="{DynamicResource {x:Static rwpf:FontKeys.CaptionFontFamilyKey}}"
+                          FontSize="{DynamicResource {x:Static rwpf:FontKeys.CaptionFontSizeKey}}"
+                          FontWeight="DemiBold" />
+        
         <Rectangle x:Name="RightTopCorner"
                    Grid.Row="0" Grid.Column="2" MinWidth="10" MinHeight="10"
-                   Fill="{DynamicResource {x:Static rwpf:Brushes.ScrollBarBackgroundBrushKey}}"/>
+                   Fill="{DynamicResource {x:Static rwpf:Brushes.ScrollBarBackgroundBrushKey}}" />
         
         <!-- Row 1 -->
         <local:VisualGrid x:Name="RowHeader" ScrollDirection="Vertical" FocusVisualStyle="{StaticResource EmptyFocusVisualStyle}"
-                            Grid.Row="1" Grid.Column="0" />
+                            Grid.Row="1" Grid.Column="0" 
+                          FontFamily="{DynamicResource {x:Static rwpf:FontKeys.CaptionFontFamilyKey}}"
+                          FontSize="{DynamicResource {x:Static rwpf:FontKeys.CaptionFontSizeKey}}"
+                          FontWeight="DemiBold" />
+        
         <local:VisualGrid x:Name="Data" ScrollDirection="Both" FocusVisualStyle="{StaticResource EmptyFocusVisualStyle}"
-                        Grid.Row="1" Grid.Column="1" />
+                        Grid.Row="1" Grid.Column="1" 
+                          FontFamily="{DynamicResource {x:Static rwpf:FontKeys.EnvironmentFontFamilyKey}}"
+                          FontSize="{DynamicResource {x:Static rwpf:FontKeys.EnvironmentFontSizeKey}}"/>
+        
         <ScrollBar x:Name="VerticalScrollBar" Orientation="Vertical"
                    Grid.Row="1" Grid.Column="2"
                    Minimum="0"

--- a/src/Package/Impl/DataInspect/VisualGrid/VisualGrid.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/VisualGrid.cs
@@ -53,8 +53,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         #region Font
 
-        public static readonly DependencyProperty FontFamilyProperty =
-                TextElement.FontFamilyProperty.AddOwner(typeof(VisualGrid));
+        public static readonly DependencyProperty FontFamilyProperty = TextElement.FontFamilyProperty.AddOwner(typeof(VisualGrid));
 
         [Localizability(LocalizationCategory.Font)]
         public FontFamily FontFamily {
@@ -65,33 +64,40 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
         }
 
-        public static readonly DependencyProperty FontSizeProperty =
-                TextElement.FontSizeProperty.AddOwner(
-                        typeof(VisualGrid));
+        public static readonly DependencyProperty FontSizeProperty = TextElement.FontSizeProperty.AddOwner(typeof(VisualGrid));
 
         [TypeConverter(typeof(FontSizeConverter))]
         public double FontSize {
             get { return (double)GetValue(FontSizeProperty); }
-            set { SetValue(FontSizeProperty, value); }
+            set {
+                _typeFace = null;
+                SetValue(FontSizeProperty, value);
+            }
+        }
+
+        public static readonly DependencyProperty FontWeightProperty = TextElement.FontWeightProperty.AddOwner(typeof(VisualGrid));
+
+        [TypeConverter(typeof(FontWeightConverter))]
+        public FontWeight FontWeight {
+            get { return (FontWeight)GetValue(FontWeightProperty); }
+            set {
+                _typeFace = null;
+                SetValue(FontWeightProperty, value);
+            }
         }
 
         private Typeface _typeFace;
         private Typeface Typeface {
             get {
                 if (_typeFace == null) {
-                    _typeFace = ChooseTypeface();
+                    if (FontFamily != null && FontSize > 0) {
+                        try {
+                            _typeFace = new Typeface(FontFamily, FontStyles.Normal, FontWeight, FontStretches.Normal);
+                        } catch(ArgumentException) { }
+                    }
+                    _typeFace = _typeFace ?? new Typeface(new FontFamily("Segoe UI"), FontStyles.Normal, FontWeights.Normal, FontStretches.Normal);
                 }
                 return _typeFace;
-            }
-        }
-
-        private Typeface ChooseTypeface() {
-            if (ScrollDirection == ScrollDirection.Vertical
-                || ScrollDirection == ScrollDirection.Horizontal) {
-                // TODO: fall back
-                return FontFamily.GetTypefaces().First(tf => tf.Style == FontStyles.Normal && tf.Weight == FontWeights.DemiBold && tf.Stretch == FontStretches.Normal);
-            } else {
-                return FontFamily.GetTypefaces().First(tf => tf.Style == FontStyles.Normal && tf.Weight == FontWeights.Normal && tf.Stretch == FontStretches.Normal);
             }
         }
 

--- a/src/Package/Impl/DataInspect/VisualGrid/VisualGrid.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/VisualGrid.cs
@@ -53,38 +53,34 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         #region Font
 
-        public static readonly DependencyProperty FontFamilyProperty = TextElement.FontFamilyProperty.AddOwner(typeof(VisualGrid));
-
+        public static readonly DependencyProperty FontFamilyProperty = TextElement.FontFamilyProperty.AddOwner(typeof(VisualGrid),
+                                                        new FrameworkPropertyMetadata(new FontFamily("Segoe UI"), FrameworkPropertyMetadataOptions.Inherits,
+                                                        new PropertyChangedCallback(OnTypefaceParametersChanged)));
         [Localizability(LocalizationCategory.Font)]
         public FontFamily FontFamily {
             get { return (FontFamily)GetValue(FontFamilyProperty); }
-            set {
-                _typeFace = null;
-                SetValue(FontFamilyProperty, value);
-            }
+            set { SetValue(FontFamilyProperty, value); }
         }
 
-        public static readonly DependencyProperty FontSizeProperty = TextElement.FontSizeProperty.AddOwner(typeof(VisualGrid));
-
+        public static readonly DependencyProperty FontSizeProperty = TextElement.FontSizeProperty.AddOwner(typeof(VisualGrid),
+                                                       new FrameworkPropertyMetadata(12.0, FrameworkPropertyMetadataOptions.Inherits,
+                                                       new PropertyChangedCallback(OnTypefaceParametersChanged)));
         [TypeConverter(typeof(FontSizeConverter))]
         public double FontSize {
             get { return (double)GetValue(FontSizeProperty); }
-            set {
-                _typeFace = null;
-                SetValue(FontSizeProperty, value);
-            }
+            set { SetValue(FontSizeProperty, value); }
         }
 
-        public static readonly DependencyProperty FontWeightProperty = TextElement.FontWeightProperty.AddOwner(typeof(VisualGrid));
-
+        public static readonly DependencyProperty FontWeightProperty = TextElement.FontWeightProperty.AddOwner(typeof(VisualGrid),
+                                                       new FrameworkPropertyMetadata(FontWeights.Normal, FrameworkPropertyMetadataOptions.Inherits,
+                                                       new PropertyChangedCallback(OnTypefaceParametersChanged)));
         [TypeConverter(typeof(FontWeightConverter))]
         public FontWeight FontWeight {
             get { return (FontWeight)GetValue(FontWeightProperty); }
-            set {
-                _typeFace = null;
-                SetValue(FontWeightProperty, value);
-            }
+            set { SetValue(FontWeightProperty, value); }
         }
+
+        private static void OnTypefaceParametersChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) => ((VisualGrid)d)._typeFace = null;
 
         private Typeface _typeFace;
         private Typeface Typeface {
@@ -93,7 +89,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                     if (FontFamily != null && FontSize > 0) {
                         try {
                             _typeFace = new Typeface(FontFamily, FontStyles.Normal, FontWeight, FontStretches.Normal);
-                        } catch(ArgumentException) { }
+                        } catch (ArgumentException) { }
                     }
                     _typeFace = _typeFace ?? new Typeface(new FontFamily("Segoe UI"), FontStyles.Normal, FontWeights.Normal, FontStretches.Normal);
                 }

--- a/src/Package/Impl/Options/R/Editor/REditorOptionsDialog.cs
+++ b/src/Package/Impl/Options/R/Editor/REditorOptionsDialog.cs
@@ -77,6 +77,7 @@ namespace Microsoft.VisualStudio.R.Package.Options.R.Editor {
         [LocCategory("Settings_FormattingCategory")]
         [CustomLocDisplayName("Settings_BracesExpanded")]
         [LocDescription("Settings_BracesExpanded_Description")]
+        [TypeConverter(typeof(OnOffTypeConverter))]
         [DefaultValue(false)]
         public bool BracesOnNewLine {
             get { return REditorSettings.FormatOptions.BracesOnNewLine; }
@@ -101,6 +102,26 @@ namespace Microsoft.VisualStudio.R.Package.Options.R.Editor {
         public bool SpaceAfterComma {
             get { return REditorSettings.FormatOptions.SpaceAfterComma; }
             set { REditorSettings.FormatOptions.SpaceAfterComma = value; }
+        }
+
+        [LocCategory("Settings_FormattingCategory")]
+        [CustomLocDisplayName("Settings_SpaceBeforeCurly")]
+        [LocDescription("Settings_SpaceBeforeCurly_Description")]
+        [TypeConverter(typeof(OnOffTypeConverter))]
+        [DefaultValue(true)]
+        public bool SpaceBeforeCurly {
+            get { return REditorSettings.FormatOptions.SpaceBeforeCurly; }
+            set { REditorSettings.FormatOptions.SpaceBeforeCurly = value; }
+        }
+
+        [LocCategory("Settings_FormattingCategory")]
+        [CustomLocDisplayName("Settings_SpacesAroundEquals")]
+        [LocDescription("Settings_SpacesAroundEquals_Description")]
+        [TypeConverter(typeof(OnOffTypeConverter))]
+        [DefaultValue(true)]
+        public bool SpacesAroundEquals {
+            get { return REditorSettings.FormatOptions.SpacesAroundEquals; }
+            set { REditorSettings.FormatOptions.SpacesAroundEquals = value; }
         }
 
         [LocCategory("Settings_FormattingCategory")]

--- a/src/Package/Impl/Resources.Designer.cs
+++ b/src/Package/Impl/Resources.Designer.cs
@@ -2230,6 +2230,42 @@ namespace Microsoft.VisualStudio.R.Package {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Space before {.
+        /// </summary>
+        public static string Settings_SpaceBeforeCurly {
+            get {
+                return ResourceManager.GetString("Settings_SpaceBeforeCurly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Determines if formatter should be adding space before opening curly brace.
+        /// </summary>
+        public static string Settings_SpaceBeforeCurly_Description {
+            get {
+                return ResourceManager.GetString("Settings_SpaceBeforeCurly_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Spaces around =.
+        /// </summary>
+        public static string Settings_SpacesAroundEquals {
+            get {
+                return ResourceManager.GetString("Settings_SpacesAroundEquals", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Determines if formatter should place spaces around equals sign.
+        /// </summary>
+        public static string Settings_SpacesAroundEquals_Description {
+            get {
+                return ResourceManager.GetString("Settings_SpacesAroundEquals_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Survey/News Check.
         /// </summary>
         public static string Settings_SurveyNewsCheck {

--- a/src/Package/Impl/Resources.resx
+++ b/src/Package/Impl/Resources.resx
@@ -1117,4 +1117,16 @@ Click OK to open MiKTeX download page in the default browser. R Remote Services 
   <data name="Settings_WorkingDirectory_Description" xml:space="preserve">
     <value>Working directory to set when R session starts.</value>
   </data>
+  <data name="Settings_SpaceBeforeCurly" xml:space="preserve">
+    <value>Space before {</value>
+  </data>
+  <data name="Settings_SpaceBeforeCurly_Description" xml:space="preserve">
+    <value>Determines if formatter should be adding space before opening curly brace</value>
+  </data>
+  <data name="Settings_SpacesAroundEquals" xml:space="preserve">
+    <value>Spaces around =</value>
+  </data>
+  <data name="Settings_SpacesAroundEquals_Description" xml:space="preserve">
+    <value>Determines if formatter should place spaces around equals sign</value>
+  </data>
 </root>

--- a/src/R/Core/Impl/Formatting/RFormatOptions.cs
+++ b/src/R/Core/Impl/Formatting/RFormatOptions.cs
@@ -19,7 +19,8 @@ namespace Microsoft.R.Core.Formatting {
         public IndentType IndentType { get; set; } = IndentType.Spaces;
 
         public bool SpaceAfterComma { get; set; } = true;
-
         public bool SpaceAfterKeyword { get; set; } = true;
+        public bool SpacesAroundEquals { get; set; } = true;
+        public bool SpaceBeforeCurly { get; set; } = true;
     }
 }

--- a/src/R/Core/Impl/Formatting/RFormatter.cs
+++ b/src/R/Core/Impl/Formatting/RFormatter.cs
@@ -103,7 +103,8 @@ namespace Microsoft.R.Core.Formatting {
             // If scope is empty, make it { } unless there is a line break already in it
             if (_tokens.NextToken.TokenType == RTokenType.CloseCurlyBrace &&
                 _textProvider.IsWhiteSpaceOnlyRange(_tokens.CurrentToken.End, _tokens.NextToken.Start)) {
-                AppendToken(leadingSpace: _tokens.PreviousToken.TokenType == RTokenType.CloseBrace, trailingSpace: true);
+                var ls = _tokens.PreviousToken.TokenType == RTokenType.CloseBrace && _options.SpaceBeforeCurly;
+                AppendToken(leadingSpace: ls, trailingSpace: true);
                 AppendToken(leadingSpace: false, trailingSpace: false);
                 return;
             }
@@ -122,7 +123,7 @@ namespace Microsoft.R.Core.Formatting {
             } else {
                 // Add space if curly is preceded by )
                 bool precededByCloseBrace = _tokens.PreviousToken.TokenType == RTokenType.CloseBrace;
-                if (precededByCloseBrace) {
+                if (precededByCloseBrace && _options.SpaceBeforeCurly) {
                     _tb.AppendSpace();
                 }
             }
@@ -584,6 +585,8 @@ namespace Microsoft.R.Core.Formatting {
                 case "$":
                 case "@":
                     return true;
+                case "=":
+                    return _braceHandler != null && _braceHandler.IsInArguments() && !_options.SpacesAroundEquals;
             }
 
             return false;

--- a/src/R/Editor/Impl/Completion/Providers/ParameterNameCompletionProvider.cs
+++ b/src/R/Editor/Impl/Completion/Providers/ParameterNameCompletionProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.Languages.Editor.Imaging;
 using Microsoft.R.Core.AST;
 using Microsoft.R.Core.AST.Arguments;
 using Microsoft.R.Core.AST.Operators;
+using Microsoft.R.Editor.Settings;
 using Microsoft.R.Editor.Signatures;
 using Microsoft.R.Support.Help;
 using Microsoft.VisualStudio.Language.Intellisense;
@@ -61,8 +62,8 @@ namespace Microsoft.R.Editor.Completion.Providers {
             var possibleArguments = arguments.Where(x => !x.Key.EqualsOrdinal("...") && !declaredArguments.Contains(x.Key, StringComparer.OrdinalIgnoreCase));
 
             foreach (var arg in possibleArguments) {
-                string displayText = arg.Key + " =";
-                string insertionText = arg.Key + " = ";
+                string displayText = arg.Key + (REditorSettings.FormatOptions.SpacesAroundEquals ? " =" : "=");
+                string insertionText = arg.Key + (REditorSettings.FormatOptions.SpacesAroundEquals ? " = " : "=");
                 completions.Add(new RCompletion(displayText, insertionText, arg.Value.Description, functionGlyph));
             }
 

--- a/src/R/Editor/Impl/Formatting/FormatOperations.cs
+++ b/src/R/Editor/Impl/Formatting/FormatOperations.cs
@@ -98,16 +98,13 @@ namespace Microsoft.R.Editor.Formatting {
             ITextSnapshotLine line = snapshot.GetLineFromLineNumber(lineNumber + offset);
             ITextRange formatRange = new TextRange(line.Start, line.Length);
 
-            UndoableFormatRange(textView, textBuffer, formatRange, editorShell, exactRange: true);
+            UndoableFormatRange(textView, textBuffer, formatRange, editorShell);
         }
 
-        public static void UndoableFormatRange(ITextView textView, ITextBuffer textBuffer, ITextRange formatRange, IEditorShell editorShell, bool exactRange = false) {
+        public static void UndoableFormatRange(ITextView textView, ITextBuffer textBuffer, ITextRange formatRange, IEditorShell editorShell) {
             using (var undoAction = editorShell.CreateCompoundAction(textView, textView.TextBuffer)) {
                 undoAction.Open(Resources.AutoFormat);
-                var result = exactRange
-                    ? RangeFormatter.FormatRangeExact(textView, textBuffer, formatRange, REditorSettings.FormatOptions, editorShell)
-                    : RangeFormatter.FormatRange(textView, textBuffer, formatRange, REditorSettings.FormatOptions, editorShell);
-
+                var result = RangeFormatter.FormatRange(textView, textBuffer, formatRange, REditorSettings.FormatOptions, editorShell);
                 if (result) {
                     undoAction.Commit();
                 }

--- a/src/R/Support/Impl/Help/FunctionRdDataProvider.cs
+++ b/src/R/Support/Impl/Help/FunctionRdDataProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.R.Host.Client.Signatures {
             string command = GetCommandText(functionName, packageName);
             try {
                 return await _host.Session.EvaluateAsync<string>(command, REvaluationKind.Normal);
-            } catch (REvaluationException) { } catch (OperationCanceledException) { }
+            } catch (RException) { }
 
             // Sometimes there is no information in a specific package.
             // For example, Matrix exports 'as.matrix' and base does it as well.
@@ -56,7 +56,7 @@ namespace Microsoft.R.Host.Client.Signatures {
             command = GetCommandText(functionName, null);
             try {
                 return await _host.Session.EvaluateAsync<string>(command, REvaluationKind.Normal);
-            } catch (REvaluationException) { } catch (OperationCanceledException) { }
+            } catch (RException) { }
 
             return string.Empty;
         }

--- a/src/R/Support/Impl/Help/FunctionRdDataProvider.cs
+++ b/src/R/Support/Impl/Help/FunctionRdDataProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.R.Host.Client.Signatures {
             string command = GetCommandText(functionName, packageName);
             try {
                 return await _host.Session.EvaluateAsync<string>(command, REvaluationKind.Normal);
-            } catch (RException) { }
+            } catch (RException) { } catch (OperationCanceledException) { }
 
             // Sometimes there is no information in a specific package.
             // For example, Matrix exports 'as.matrix' and base does it as well.
@@ -56,7 +56,7 @@ namespace Microsoft.R.Host.Client.Signatures {
             command = GetCommandText(functionName, null);
             try {
                 return await _host.Session.EvaluateAsync<string>(command, REvaluationKind.Normal);
-            } catch (RException) { }
+            } catch (RException) { } catch (OperationCanceledException) { }
 
             return string.Empty;
         }

--- a/src/R/Support/Impl/Help/FunctionRdDataProvider.cs
+++ b/src/R/Support/Impl/Help/FunctionRdDataProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.R.Host.Client.Signatures {
         /// Asynchronously fetches RD data on the function from R.
         /// </summary>
         public async Task<string> GetFunctionRdDataAsync(string functionName, string packageName) {
-            if(packageName.EqualsOrdinal("rtvs")) {
+            if (packageName.EqualsOrdinal("rtvs")) {
                 return GetRtvsFunctionRdData(functionName);
             }
 
@@ -48,7 +48,7 @@ namespace Microsoft.R.Host.Client.Signatures {
             string command = GetCommandText(functionName, packageName);
             try {
                 return await _host.Session.EvaluateAsync<string>(command, REvaluationKind.Normal);
-            } catch (RException) { }
+            } catch (REvaluationException) { } catch (OperationCanceledException) { }
 
             // Sometimes there is no information in a specific package.
             // For example, Matrix exports 'as.matrix' and base does it as well.
@@ -56,7 +56,7 @@ namespace Microsoft.R.Host.Client.Signatures {
             command = GetCommandText(functionName, null);
             try {
                 return await _host.Session.EvaluateAsync<string>(command, REvaluationKind.Normal);
-            } catch (RException) { }
+            } catch (REvaluationException) { } catch (OperationCanceledException) { }
 
             return string.Empty;
         }
@@ -72,7 +72,7 @@ namespace Microsoft.R.Host.Client.Signatures {
             var asmPath = Assembly.GetExecutingAssembly().GetAssemblyPath();
             var asmFolder = Path.GetDirectoryName(asmPath);
             var dataFilePath = Path.Combine(asmFolder, @"rtvs\man", Path.ChangeExtension(functionName, "rd"));
-            if(File.Exists(dataFilePath)) {
+            if (File.Exists(dataFilePath)) {
                 return File.ReadAllText(dataFilePath);
             }
             return string.Empty;

--- a/src/R/Support/Impl/Help/IntelliSenseRSession.cs
+++ b/src/R/Support/Impl/Help/IntelliSenseRSession.cs
@@ -127,7 +127,7 @@ namespace Microsoft.R.Support.Help {
                     var loadedPackages = await session.EvaluateAsync<string[]>("as.list(.packages())", REvaluationKind.Normal);
                     Interlocked.Exchange(ref _loadedPackages, loadedPackages);
                 }
-            } catch (RHostDisconnectedException) { } catch (RException) { }
+            } catch (OperationCanceledException) { } catch (RException) { }
         }
 
         private IRSession GetLoadedPackagesInspectionSession() {

--- a/src/R/Support/Impl/Help/Packages/PackageIndex.cs
+++ b/src/R/Support/Impl/Help/Packages/PackageIndex.cs
@@ -109,7 +109,7 @@ namespace Microsoft.R.Support.Help.Packages {
 
                     stopwatch.Stop();
                 }
-            } catch (RException ex) {
+            } catch (Exception ex) when (!ex.IsCriticalException()) {
                 Debug.WriteLine(ex.Message);
                 ScheduleIdleTimeRebuild();
             } finally {
@@ -193,7 +193,7 @@ namespace Microsoft.R.Support.Help.Packages {
                 if (!_packages.ContainsKey("rtvs")) {
                     _packages["rtvs"] = new PackageInfo(_host, "rtvs", "R Tools", "1.0");
                 }
-            } catch (RException) { }
+            } catch (RException) { } catch (OperationCanceledException) { }
         }
 
         private async Task LoadRemainingPackagesFunctions() {
@@ -215,8 +215,7 @@ namespace Microsoft.R.Support.Help.Packages {
 
                     var added = installed.Where(p => !currentNames.Contains(p.Package));
                     await AddPackagesToIndexAsync(added);
-                } catch (RException) {
-                } finally {
+                } catch (RException) { } catch (OperationCanceledException) { } finally {
                     token.Reset();
                 }
             }
@@ -234,7 +233,7 @@ namespace Microsoft.R.Support.Help.Packages {
                     var installedPackages = await GetInstalledPackagesAsync();
                     var packagesNotInIndex = installedPackages.Where(p => packageNames.Contains(p.Package));
                     info = await AddPackagesToIndexAsync(packagesNotInIndex);
-                } catch (RException) { }
+                } catch (RException) { } catch (OperationCanceledException) { }
             }
             return info;
         }
@@ -262,7 +261,7 @@ namespace Microsoft.R.Support.Help.Packages {
             try {
                 await _host.StartSessionAsync();
                 return _host.LoadedPackageNames;
-            } catch (RException) { }
+            } catch (RException) { } catch (OperationCanceledException) { }
             return Enumerable.Empty<string>();
         }
 

--- a/src/R/Support/Impl/Help/Packages/PackageIndex.cs
+++ b/src/R/Support/Impl/Help/Packages/PackageIndex.cs
@@ -109,7 +109,7 @@ namespace Microsoft.R.Support.Help.Packages {
 
                     stopwatch.Stop();
                 }
-            } catch (OperationCanceledException ex) {
+            } catch (RException ex) {
                 Debug.WriteLine(ex.Message);
                 ScheduleIdleTimeRebuild();
             } finally {
@@ -193,7 +193,7 @@ namespace Microsoft.R.Support.Help.Packages {
                 if (!_packages.ContainsKey("rtvs")) {
                     _packages["rtvs"] = new PackageInfo(_host, "rtvs", "R Tools", "1.0");
                 }
-            } catch (REvaluationException) { }
+            } catch (RException) { }
         }
 
         private async Task LoadRemainingPackagesFunctions() {
@@ -215,8 +215,7 @@ namespace Microsoft.R.Support.Help.Packages {
 
                     var added = installed.Where(p => !currentNames.Contains(p.Package));
                     await AddPackagesToIndexAsync(added);
-                } catch (REvaluationException) {
-                } catch (OperationCanceledException) {
+                } catch (RException) {
                 } finally {
                     token.Reset();
                 }
@@ -235,7 +234,7 @@ namespace Microsoft.R.Support.Help.Packages {
                     var installedPackages = await GetInstalledPackagesAsync();
                     var packagesNotInIndex = installedPackages.Where(p => packageNames.Contains(p.Package));
                     info = await AddPackagesToIndexAsync(packagesNotInIndex);
-                } catch (REvaluationException) { } catch (OperationCanceledException) { }
+                } catch (RException) { }
             }
             return info;
         }
@@ -263,7 +262,7 @@ namespace Microsoft.R.Support.Help.Packages {
             try {
                 await _host.StartSessionAsync();
                 return _host.LoadedPackageNames;
-            } catch (OperationCanceledException) { }
+            } catch (RException) { }
             return Enumerable.Empty<string>();
         }
 

--- a/src/R/Support/Impl/Help/Packages/PackageInfo.cs
+++ b/src/R/Support/Impl/Help/Packages/PackageInfo.cs
@@ -77,8 +77,10 @@ namespace Microsoft.R.Support.Help.Packages {
         private async Task<IEnumerable<string>> GetFunctionNamesAsync() {
             var functions = TryRestoreFromCache();
             if (functions == null || !functions.Any()) {
-                var result = await _host.Session.PackagesFunctionsNamesAsync(Name, REvaluationKind.BaseEnv);
-                functions = result.Children<JValue>().Select(v => (string)v.Value);
+                try {
+                    var result = await _host.Session.PackagesFunctionsNamesAsync(Name, REvaluationKind.BaseEnv);
+                    functions = result.Children<JValue>().Select(v => (string)v.Value);
+                } catch (RException) { }
             } else {
                 _saved = true;
             }

--- a/src/R/Support/Impl/Help/Packages/PackageInfo.cs
+++ b/src/R/Support/Impl/Help/Packages/PackageInfo.cs
@@ -80,7 +80,7 @@ namespace Microsoft.R.Support.Help.Packages {
                 try {
                     var result = await _host.Session.PackagesFunctionsNamesAsync(Name, REvaluationKind.BaseEnv);
                     functions = result.Children<JValue>().Select(v => (string)v.Value);
-                } catch (OperationCanceledException) { } catch (REvaluationException) { }
+                } catch (RException) { }
             } else {
                 _saved = true;
             }

--- a/src/R/Support/Impl/Help/Packages/PackageInfo.cs
+++ b/src/R/Support/Impl/Help/Packages/PackageInfo.cs
@@ -77,10 +77,8 @@ namespace Microsoft.R.Support.Help.Packages {
         private async Task<IEnumerable<string>> GetFunctionNamesAsync() {
             var functions = TryRestoreFromCache();
             if (functions == null || !functions.Any()) {
-                try {
-                    var result = await _host.Session.PackagesFunctionsNamesAsync(Name, REvaluationKind.BaseEnv);
-                    functions = result.Children<JValue>().Select(v => (string)v.Value);
-                } catch (RException) { }
+                var result = await _host.Session.PackagesFunctionsNamesAsync(Name, REvaluationKind.BaseEnv);
+                functions = result.Children<JValue>().Select(v => (string)v.Value);
             } else {
                 _saved = true;
             }

--- a/src/R/Support/Impl/Help/Packages/PackageInfo.cs
+++ b/src/R/Support/Impl/Help/Packages/PackageInfo.cs
@@ -80,7 +80,7 @@ namespace Microsoft.R.Support.Help.Packages {
                 try {
                     var result = await _host.Session.PackagesFunctionsNamesAsync(Name, REvaluationKind.BaseEnv);
                     functions = result.Children<JValue>().Select(v => (string)v.Value);
-                } catch (TaskCanceledException) { } catch (REvaluationException) { }
+                } catch (OperationCanceledException) { } catch (REvaluationException) { }
             } else {
                 _saved = true;
             }


### PR DESCRIPTION
#3235 Can't view the table
- Removed typeface calculation and replaced with IDE fonts and fallback

CHS OS:
![image](https://cloud.githubusercontent.com/assets/12820357/23521336/6259a7cc-ff33-11e6-8bc7-c490224152e1.png)

#3248 Some autoformatting annoyances
- Added the requested options
- Range formatter should not use 'exact' version directly, only after it figures out correct range.

Hardened exception handling in the package and function index