### PR TITLE
3260, 3261, 3262, 3264

### DIFF
--- a/src/Debugger/Impl/DebuggerConstants.cs
+++ b/src/Debugger/Impl/DebuggerConstants.cs
@@ -4,10 +4,6 @@
 using System;
 
 namespace Microsoft.R.Debugger {
-    public static class DebuggerSessionConstants {
-        public const string RSessionNamePrefix = "R session";
-    }
-
     internal static class DebuggerConstants {
         public const int S_GETPARENT_NO_PARENT = unchecked((int)0x40531);
         public const int E_WIN32_INVALID_NAME = ((282) & 0x0000FFFF) | (7 << 16) | unchecked((int)0x80000000);

--- a/src/Debugger/Impl/DebuggerConstants.cs
+++ b/src/Debugger/Impl/DebuggerConstants.cs
@@ -4,6 +4,10 @@
 using System;
 
 namespace Microsoft.R.Debugger {
+    public static class DebuggerSessionConstants {
+        public const string RSessionNamePrefix = "R session";
+    }
+
     internal static class DebuggerConstants {
         public const int S_GETPARENT_NO_PARENT = unchecked((int)0x40531);
         public const int E_WIN32_INVALID_NAME = ((282) & 0x0000FFFF) | (7 << 16) | unchecked((int)0x80000000);

--- a/src/Debugger/Impl/PortSupplier/RDebugPortSupplier.DebugProcess.cs
+++ b/src/Debugger/Impl/PortSupplier/RDebugPortSupplier.DebugProcess.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using Microsoft.Common.Core;
 using Microsoft.R.Host.Client;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Debugger.Interop;
-using static System.FormattableString;
 
 namespace Microsoft.R.Debugger.PortSupplier {
     partial class RDebugPortSupplier {
@@ -14,7 +14,7 @@ namespace Microsoft.R.Debugger.PortSupplier {
         internal const uint BaseProcessId = 1000000000;
 
         public static uint GetProcessId(int sessionId) {
-            if(sessionId < 0 || sessionId > 1000000000) {
+            if (sessionId < 0 || sessionId > 1000000000) {
                 throw new ArgumentOutOfRangeException(nameof(sessionId));
             }
             return (uint)sessionId + BaseProcessId;
@@ -28,7 +28,7 @@ namespace Microsoft.R.Debugger.PortSupplier {
 
             public uint ProcessId => RDebugPortSupplier.GetProcessId(_sessionId);
 
-            public string Name => Invariant($"{DebuggerSessionConstants.RSessionNamePrefix} {_sessionId}");
+            public string Name => Resources.RSessionNameFormat.FormatInvariant(_sessionId);
 
             public DebugProcess(DebugPort port, IRSession session) {
                 _port = port;

--- a/src/Debugger/Impl/PortSupplier/RDebugPortSupplier.DebugProcess.cs
+++ b/src/Debugger/Impl/PortSupplier/RDebugPortSupplier.DebugProcess.cs
@@ -28,7 +28,7 @@ namespace Microsoft.R.Debugger.PortSupplier {
 
             public uint ProcessId => RDebugPortSupplier.GetProcessId(_sessionId);
 
-            public string Name => Invariant($"R session {_sessionId}");
+            public string Name => Invariant($"{DebuggerSessionConstants.RSessionNamePrefix} {_sessionId}");
 
             public DebugProcess(DebugPort port, IRSession session) {
                 _port = port;

--- a/src/Debugger/Impl/PortSupplier/RDebugPortSupplier.cs
+++ b/src/Debugger/Impl/PortSupplier/RDebugPortSupplier.cs
@@ -60,7 +60,7 @@ namespace Microsoft.R.Debugger.PortSupplier {
         }
 
         public int GetDescription(enum_PORT_SUPPLIER_DESCRIPTION_FLAGS[] pdwFlags, out string pbstrText) {
-            pbstrText = "Allows attaching to an R Interactive window to debug the code executed in it.";
+            pbstrText = Resources.PortSupplierDescription;
             return VSConstants.S_OK;
         }
 

--- a/src/Debugger/Impl/Resources.Designer.cs
+++ b/src/Debugger/Impl/Resources.Designer.cs
@@ -68,5 +68,23 @@ namespace Microsoft.R.Debugger {
                 return ResourceManager.GetString("DebuggerInProgress", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allows attaching to an R Interactive window to debug the code executed in it..
+        /// </summary>
+        public static string PortSupplierDescription {
+            get {
+                return ResourceManager.GetString("PortSupplierDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to R session {0}.
+        /// </summary>
+        public static string RSessionNameFormat {
+            get {
+                return ResourceManager.GetString("RSessionNameFormat", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Debugger/Impl/Resources.resx
+++ b/src/Debugger/Impl/Resources.resx
@@ -120,5 +120,10 @@
   <data name="DebuggerInProgress" xml:space="preserve">
     <value>Debugger operation is in progress...</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="PortSupplierDescription" xml:space="preserve">
+    <value>Allows attaching to an R Interactive window to debug the code executed in it.</value>
+  </data>
+  <data name="RSessionNameFormat" xml:space="preserve">
+    <value>R session {0}</value>
+  </data>
 </root>

--- a/src/Package/Impl/Utilities/VsDebuggerModeTracker.cs
+++ b/src/Package/Impl/Utilities/VsDebuggerModeTracker.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.R.Package.Utilities {
 
         public bool IsRDebugger() {
             DTE dte = VsAppShell.Current.GetGlobalService<DTE>();
-            var processName = dte?.Debugger?.CurrentProcess.Name;
+            var processName = dte?.Debugger?.CurrentProcess?.Name;
             return !string.IsNullOrEmpty(processName) && processName.StartsWithOrdinal(DebuggerSessionConstants.RSessionNamePrefix);
         }
     }

--- a/src/Package/Impl/Utilities/VsDebuggerModeTracker.cs
+++ b/src/Package/Impl/Utilities/VsDebuggerModeTracker.cs
@@ -4,6 +4,8 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.R.Components.InteractiveWorkflow;
+using Microsoft.R.Debugger;
+using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.R.Package.Utilities {
@@ -39,5 +41,15 @@ namespace Microsoft.VisualStudio.R.Package.Utilities {
         public event EventHandler EnterBreakMode;
 
         public event EventHandler LeaveBreakMode;
+
+        public bool IsRDebugger() {
+            var debugger2 = VsAppShell.Current.GetGlobalService<IVsDebugger2>(typeof(IVsDebugger));
+            Guid engine = Guid.Empty;
+            string engineName;
+            if(VSConstants.S_OK == debugger2.GetEngineName(ref engine, out engineName)) {
+                return DebuggerGuids.DebugEngine == engine;
+            }
+            return false;
+        }
     }
 }

--- a/src/Package/Impl/Utilities/VsDebuggerModeTracker.cs
+++ b/src/Package/Impl/Utilities/VsDebuggerModeTracker.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.ComponentModel.Composition;
+using EnvDTE;
+using Microsoft.Common.Core;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Debugger;
 using Microsoft.VisualStudio.R.Package.Shell;
@@ -43,13 +45,9 @@ namespace Microsoft.VisualStudio.R.Package.Utilities {
         public event EventHandler LeaveBreakMode;
 
         public bool IsRDebugger() {
-            var debugger2 = VsAppShell.Current.GetGlobalService<IVsDebugger2>(typeof(IVsDebugger));
-            Guid engine = Guid.Empty;
-            string engineName;
-            if(VSConstants.S_OK == debugger2.GetEngineName(ref engine, out engineName)) {
-                return DebuggerGuids.DebugEngine == engine;
-            }
-            return false;
+            DTE dte = VsAppShell.Current.GetGlobalService<DTE>();
+            var processName = dte?.Debugger?.CurrentProcess.Name;
+            return !string.IsNullOrEmpty(processName) && processName.StartsWithOrdinal(DebuggerSessionConstants.RSessionNamePrefix);
         }
     }
 }

--- a/src/Package/Impl/Utilities/VsDebuggerModeTracker.cs
+++ b/src/Package/Impl/Utilities/VsDebuggerModeTracker.cs
@@ -9,6 +9,7 @@ using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Debugger;
 using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using static System.FormattableString;
 
 namespace Microsoft.VisualStudio.R.Package.Utilities {
     [Export]
@@ -46,8 +47,13 @@ namespace Microsoft.VisualStudio.R.Package.Utilities {
 
         public bool IsRDebugger() {
             DTE dte = VsAppShell.Current.GetGlobalService<DTE>();
-            var processName = dte?.Debugger?.CurrentProcess?.Name;
-            return !string.IsNullOrEmpty(processName) && processName.StartsWithOrdinal(DebuggerSessionConstants.RSessionNamePrefix);
+            var process2 = dte?.Debugger?.CurrentProcess as EnvDTE80.Process2;
+            var transportId = process2?.Transport?.ID;
+            Guid transportGuid;
+            if (!string.IsNullOrEmpty(transportId) && Guid.TryParse(transportId, out transportGuid)) {
+                return transportGuid == DebuggerGuids.PortSupplier;
+            }
+            return false;
         }
     }
 }

--- a/src/R/Components/Impl/InteractiveWorkflow/IDebuggerModeTracker.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/IDebuggerModeTracker.cs
@@ -17,5 +17,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow {
         event EventHandler EnterBreakMode;
 
         event EventHandler LeaveBreakMode;
+
+        bool IsRDebugger();
     }
 }

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
@@ -4,7 +4,6 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.Disposables;
@@ -17,7 +16,6 @@ using Microsoft.R.Components.PackageManager;
 using Microsoft.R.Components.Plots;
 using Microsoft.R.Components.Settings;
 using Microsoft.R.Components.Settings.Mirrors;
-using Microsoft.R.Components.Workspace;
 using Microsoft.R.Host.Client;
 using Microsoft.R.Host.Client.Session;
 using Microsoft.R.Interpreters;
@@ -127,7 +125,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
                 // i.e. user worked in the REPL and not in the editor. Pull 
                 // the focus back here. 
                 _replLostFocus = false;
-                if (IsRProjectActive()) {
+                if (_debuggerModeTracker.IsRDebugger()) {
                     ActiveWindow.Container.Show(focus: true, immediate: false);
                 }
 
@@ -139,11 +137,6 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
         private void RSessionDisconnected(object o, EventArgs eventArgs) {
             Operations.ClearPendingInputs();
             ActiveWindow?.Container.UpdateCommandStatus(false);
-        }
-
-        private bool IsRProjectActive() {
-            var wss = Shell.ExportProvider.GetExportedValue<IWorkspaceServices>();
-            return wss.IsRProjectActive;
         }
 
         public Task<IInteractiveWindowVisualComponent> GetOrCreateVisualComponentAsync(int instanceId = 0) {

--- a/src/R/Components/Test/Fakes/Trackers/TestDebuggerModeTracker.cs
+++ b/src/R/Components/Test/Fakes/Trackers/TestDebuggerModeTracker.cs
@@ -19,6 +19,8 @@ namespace Microsoft.R.Components.Test.Fakes.Trackers {
 
         public bool IsFocusStolenOnBreak => false;
 
+        public bool IsRDebugger() => true;
+
 #pragma warning disable 67
         public event EventHandler EnterBreakMode;
         public event EventHandler LeaveBreakMode;

--- a/src/R/Core/Impl/Formatting/RFormatter.cs
+++ b/src/R/Core/Impl/Formatting/RFormatter.cs
@@ -586,7 +586,7 @@ namespace Microsoft.R.Core.Formatting {
                 case "@":
                     return true;
                 case "=":
-                    return _braceHandler != null && _braceHandler.IsInArguments() && !_options.SpacesAroundEquals;
+                    return !_options.SpacesAroundEquals;
             }
 
             return false;

--- a/src/R/Core/Test/Formatting/FormatConditionalsTest.cs
+++ b/src/R/Core/Test/Formatting/FormatConditionalsTest.cs
@@ -72,6 +72,20 @@ namespace Microsoft.R.Core.Test.Formatting {
         }
 
         [CompositeTest]
+        [InlineData("if(TRUE){}", true, "if (TRUE) { }")]
+        [InlineData("if(TRUE){}", false, "if (TRUE){ }")]
+        [InlineData("if(TRUE){\n}", true, "if (TRUE) {\n}")]
+        [InlineData("if(TRUE){\n}", false, "if (TRUE){\n}")]
+        public void ConditionalTest06(string original, bool spaceBeforeCurly, string expected) {
+            var options = new RFormatOptions() {
+                SpaceBeforeCurly = spaceBeforeCurly
+            };
+            RFormatter f = new RFormatter(options);
+            string actual = f.Format(original);
+            actual.Should().Be(expected);
+        }
+
+        [CompositeTest]
         [InlineData("if(true) x<-2", "if (true) x <- 2")]
         [InlineData("if(true)\nx<-2", "if (true)\n  x <- 2")]
         [InlineData("if(true) x<-2 else x<-1", "if (true) x <- 2 else x <- 1")]

--- a/src/R/Core/Test/Formatting/FormatOperatorsTest.cs
+++ b/src/R/Core/Test/Formatting/FormatOperatorsTest.cs
@@ -9,9 +9,9 @@ using Xunit;
 
 namespace Microsoft.R.Core.Test.Formatting {
     [ExcludeFromCodeCoverage]
+    [Category.R.Formatting]
     public class FormatOperatorsTest {
         [CompositeTest]
-        [Category.R.Formatting]
         [InlineData("-1", "-1")]
         [InlineData("- 1", "-1")]
         [InlineData("x--1", "x - -1")]
@@ -29,5 +29,18 @@ namespace Microsoft.R.Core.Test.Formatting {
             actual.Should().Be(expected);
         }
 
+        [CompositeTest]
+        [InlineData("x=1", true, "x = 1")]
+        [InlineData("x=1", false, "x=1")]
+        [InlineData("x <- function(a=1,b=2)", true, "x <- function(a = 1, b = 2)")]
+        [InlineData("x <- function(a=1,b=2)", false, "x <- function(a=1, b=2)")]
+        public void Formatter_FormatEquals(string original, bool spaceAroundEquals, string expected) {
+            var options = new RFormatOptions() {
+                SpacesAroundEquals = spaceAroundEquals
+            };
+            RFormatter f = new RFormatter(options);
+            string actual = f.Format(original);
+            actual.Should().Be(expected);
+        }
     }
 }

--- a/src/R/Core/Test/Formatting/FormatOperatorsTest.cs
+++ b/src/R/Core/Test/Formatting/FormatOperatorsTest.cs
@@ -32,6 +32,9 @@ namespace Microsoft.R.Core.Test.Formatting {
         [CompositeTest]
         [InlineData("x=1", true, "x = 1")]
         [InlineData("x=1", false, "x=1")]
+        [InlineData("y <- 'x=1'", false, "y <- 'x=1'")]
+        [InlineData("y <- 'x=1'", true, "y <- 'x=1'")]
+        [InlineData("x=1", false, "x=1")]
         [InlineData("x <- function(a=1,b=2)", true, "x <- function(a = 1, b = 2)")]
         [InlineData("x <- function(a=1,b=2)", false, "x <- function(a=1, b=2)")]
         public void Formatter_FormatEquals(string original, bool spaceAroundEquals, string expected) {

--- a/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
+++ b/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
@@ -505,6 +505,21 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
             }
         }
 
+        [Test]
+        public async Task R_PackageMemberCompletion() {
+            using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType, Workflow.RSessions)) {
+                PrimeIntellisenseProviders(script);
+                script.DoIdle(500);
+
+                script.Type("AIC");
+                script.MoveLeft(3);
+                script.Type("stats:::");
+                script.DoIdle(100);
+                script.EditorText.Should().Be("stats:::AIC");
+                script.View.Caret.Position.BufferPosition.Position.Should().Be(8);
+            }
+        }
+
         private void PrimeIntellisenseProviders(IEditorScript script) {
             // Prime variable provider
             UIThreadHelper.Instance.Invoke(() => {

--- a/src/R/Editor/Impl/Completion/RCompletionController.cs
+++ b/src/R/Editor/Impl/Completion/RCompletionController.cs
@@ -141,6 +141,7 @@ namespace Microsoft.R.Editor.Completion {
                     rset?.SelectBestMatch();
                 }
 
+                bool unique = completionSet.SelectionStatus.IsUnique;
                 switch (typedChar) {
                     case '=':
                     case '<':
@@ -153,7 +154,6 @@ namespace Microsoft.R.Editor.Completion {
                     case '|':
                     case '&':
                     case '!':
-                    case ':':
                     case '@':
                     case '$':
                     case '(':
@@ -163,7 +163,16 @@ namespace Microsoft.R.Editor.Completion {
                     case ']':
                     case '}':
                     case ';':
-                        return completionSet.SelectionStatus.IsUnique;
+                        return unique;
+
+                    case ':':
+                        // : completes only if not preceded by another :
+                        // so we can avoid false positive when user is typing stats:::
+                        var caretPosition = TextView.Caret.Position.BufferPosition;
+                        if (caretPosition > 0) {
+                            unique &= TextView.TextBuffer.CurrentSnapshot[caretPosition - 1] != ':';
+                        }
+                        return unique;
                 }
 
                 if (typedChar == ' ' && !REditorSettings.CommitOnSpace) {

--- a/src/R/Editor/Impl/Formatting/RangeFormatter.cs
+++ b/src/R/Editor/Impl/Formatting/RangeFormatter.cs
@@ -165,14 +165,15 @@ namespace Microsoft.R.Editor.Formatting {
             bool nextLineStartsWithOperator = tokens.Count > 0 && tokens[0].TokenType == RTokenType.Operator;
 
             for (int i = lineNum - 1; i >= 0; i--) {
-                text = textBuffer.CurrentSnapshot.GetLineFromLineNumber(i).GetText();
+                var line = textBuffer.CurrentSnapshot.GetLineFromLineNumber(i);
+                text = line.GetText();
                 tokens = tokenizer.Tokenize(text);
 
                 if (tokens.Count > 0) {
                     if (!nextLineStartsWithOperator && tokens[tokens.Count - 1].TokenType != RTokenType.Operator) {
                         break;
                     }
-                    position = tokens[0].Start;
+                    position = tokens[0].Start + line.Start;
                     nextLineStartsWithOperator = tokens[0].TokenType == RTokenType.Operator;
                 }
             }


### PR DESCRIPTION
#3264 R Interactive steals focus when debugging Python.
- add explicit check for R debugger session

#3260 Making a pipeline marks other code sections as touched
- start of expression locator returned relative position rather than absolute

#3262 Typing ::: sometimes gets messed up
- in case of typing `stats:::` in front of the existing member last `:`completed to the member and then `:` appeared after the member name. ':` should only complete right after the package name and not after another `:`.

#3261 Inconsistent formatting of spaces around = 
- brace handler is not active for partial formatting so we have to always use option for spaces around `=`, not just in arguments. However, using `=` instead of `<-` is highly discouraged and if someone does want to use it, default is to put spaces around `=` so it will work.