### PR TITLE
3292, 3293, 3294

### DIFF
--- a/src/Languages/Editor/Impl/Projection/ProjectionBufferManager.cs
+++ b/src/Languages/Editor/Impl/Projection/ProjectionBufferManager.cs
@@ -146,9 +146,7 @@ namespace Microsoft.Languages.Editor.Projection {
             }
             // Add the final section after the last span
             span = Span.FromBounds(primaryIndex, diskSnapshot.Length);
-            if (!span.IsEmpty) {
-                spans.Add(new CustomTrackingSpan(diskSnapshot, span, PointTrackingMode.Positive, PointTrackingMode.Positive)); // Markdown
-            }
+            spans.Add(new CustomTrackingSpan(diskSnapshot, span, PointTrackingMode.Positive, PointTrackingMode.Positive)); // Markdown
             return spans;
         }
 

--- a/src/Markdown/Editor/Impl/Tokens/MdTokenizer.cs
+++ b/src/Markdown/Editor/Impl/Tokens/MdTokenizer.cs
@@ -180,19 +180,17 @@ namespace Microsoft.Markdown.Editor.Tokens {
                 }
 
                 if (endOfBlock || endOfInline || eof) {
-                    _cs.Advance(trailingSeparatorLength); // past the end of block now
+                    if (eof) {
+                        // At the end of the file current position if one less. 
+                        // since end is not included, we want end to be at the buffer length;
+                        _cs.MoveToNextChar();
+                    } else {
+                        _cs.Advance(trailingSeparatorLength); // past the end of block now
+                    }
 
                     // Opening ticks
                     if (rLanguage) {
-                        // Code is inside ``` and after the language name.
-                        // We still want to colorize numbers in ```{r, x = 1.0, ...}
-                        int length = _cs.Position - ticksStart;
-                        if (eof) {
-                            // At the end of the file current position if one less. 
-                            // since end is not included, we want end to be at the buffer length;
-                            length++;
-                        }
-                        AddCodeToken(ticksStart, length, leadingSeparatorLength, trailingSeparatorLength);
+                        AddCodeToken(ticksStart, _cs.Position - ticksStart, leadingSeparatorLength, trailingSeparatorLength);
                     } else {
                         AddToken(MarkdownTokenType.Monospace, ticksStart, _cs.Position - ticksStart);
                     }

--- a/src/Markdown/Editor/Impl/Tokens/MdTokenizer.cs
+++ b/src/Markdown/Editor/Impl/Tokens/MdTokenizer.cs
@@ -186,7 +186,13 @@ namespace Microsoft.Markdown.Editor.Tokens {
                     if (rLanguage) {
                         // Code is inside ``` and after the language name.
                         // We still want to colorize numbers in ```{r, x = 1.0, ...}
-                        AddCodeToken(ticksStart, _cs.Position - ticksStart, leadingSeparatorLength, trailingSeparatorLength);
+                        int length = _cs.Position - ticksStart;
+                        if (eof) {
+                            // At the end of the file current position if one less. 
+                            // since end is not included, we want end to be at the buffer length;
+                            length++;
+                        }
+                        AddCodeToken(ticksStart, length, leadingSeparatorLength, trailingSeparatorLength);
                     } else {
                         AddToken(MarkdownTokenType.Monospace, ticksStart, _cs.Position - ticksStart);
                     }

--- a/src/Markdown/Editor/Test/Tokens/TokenizeBlockTest.cs
+++ b/src/Markdown/Editor/Test/Tokens/TokenizeBlockTest.cs
@@ -40,14 +40,18 @@ block
 @"```{r}
 #comment
 ```
-")]
+", 21)]
+        [InlineData(
+@"```{r}
+
+", 10)]
         [Category.Md.Tokenizer]
-        public void CodeBlock02(string text) {
+        public void CodeBlock02(string text, int length) {
             var tokens = Tokenize(text, new MdTokenizer());
             tokens.Should().HaveCount(1);
             tokens[0].Should().HaveType(MarkdownTokenType.Code);
             tokens[0].Should().BeOfType(typeof(MarkdownCodeToken));
-            tokens[0].Length.Should().Be(21);
+            tokens[0].Length.Should().Be(length);
         }
 
         [CompositeTest]
@@ -68,13 +72,17 @@ block
         }
 
         [CompositeTest]
-        [InlineData(@"```block```")]
-        [InlineData(@"```block")]
-        [InlineData(@"```block` ```")]
+        [InlineData("```block```", 11)]
+        [InlineData("```block", 8)]
+        [InlineData("```block\n", 9)]
+        [InlineData("```block\r", 9)]
+        [InlineData("```block\r\n", 10)]
+        [InlineData("```block` ```", 13)]
         [Category.Md.Tokenizer]
-        public void CodeBlock04(string text) {
+        public void CodeBlock04(string text, int length) {
             var tokens = Tokenize(text, new MdTokenizer());
             tokens.Should().HaveCount(1);
+            tokens[0].Length.Should().Be(length);
 
             var mdct = tokens[0] as MarkdownCodeToken;
             mdct.Should().BeNull();

--- a/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
+++ b/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
@@ -528,18 +528,30 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
                 await ExecuteRCode(_editorHost.HostScript.Session,
 @"
 d <- list(A = c(1:10), B = c(1:10))
-e <- list(A=d, B=d)
+e <- list(D=d, E=d)
 ");
                 PrimeIntellisenseProviders(script);
                 script.DoIdle(500);
 
-                script.Type("e$A$");
+                script.Type("e$");
 
                 var session = script.GetCompletionSession();
                 session.Should().NotBeNull();
                 script.DoIdle(1000);
 
                 var comps = session.SelectedCompletionSet.Completions;
+                comps.Should().HaveCount(2).And
+                    .Contain(x => x.DisplayText == "D").And
+                    .Contain(x => x.DisplayText == "E");
+                script.DoIdle(100);
+
+                script.Type("D$");
+
+                session = script.GetCompletionSession();
+                session.Should().NotBeNull();
+                script.DoIdle(1000);
+
+                comps = session.SelectedCompletionSet.Completions;
                 comps.Should().HaveCount(2).And
                     .Contain(x => x.DisplayText == "A").And
                     .Contain(x => x.DisplayText == "B");

--- a/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
+++ b/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
@@ -15,6 +15,7 @@ using Microsoft.R.Editor.Settings;
 using Microsoft.R.Editor.Snippets;
 using Microsoft.R.Editor.Test.Utility;
 using Microsoft.R.Host.Client;
+using Microsoft.R.Host.Client.Session;
 using Microsoft.R.Support.Settings;
 using Microsoft.UnitTests.Core.Mef;
 using Microsoft.UnitTests.Core.Threading;
@@ -188,6 +189,41 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
 
                 var list = session.SelectedCompletionSet.Completions.ToList();
                 var item = list.FirstOrDefault(x => x.DisplayText == "_rtvs_test_");
+                item.Should().NotBeNull();
+
+                if (Directory.Exists(testFolder)) {
+                    Directory.Delete(testFolder);
+                }
+            }
+        }
+
+        [Test]
+        public async Task R_CompletionFilesWorkingDirectory() {
+            using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType, Workflow.RSessions)) {
+                var myDocs = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                var folder = "_rtvs_test2_";
+
+                var testFolder = Path.Combine(myDocs, folder);
+                if (!Directory.Exists(testFolder)) {
+                    Directory.CreateDirectory(testFolder);
+                }
+
+                await _editorHost.HostScript.Session.ExecuteAsync(Invariant($"setwd('{myDocs.ToRPath()}')"));
+                var wd = await _editorHost.HostScript.Session.GetWorkingDirectoryAsync();
+                wd.Should().Be(myDocs);
+
+                script.DoIdle(100);
+                script.Type("x <- \"./");
+                script.DoIdle(1000);
+                script.Type("{TAB}");
+                script.DoIdle(500);
+
+                var session = script.GetCompletionSession();
+                session.Should().NotBeNull();
+                script.DoIdle(200);
+
+                var list = session.SelectedCompletionSet.Completions.ToList();
+                var item = list.FirstOrDefault(x => x.DisplayText == folder);
                 item.Should().NotBeNull();
 
                 if (Directory.Exists(testFolder)) {

--- a/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
+++ b/src/R/Editor/Application.Test/Completion/IntellisenseTest.cs
@@ -487,6 +487,31 @@ namespace Microsoft.R.Editor.Application.Test.Completion {
         }
 
         [Test]
+        public async Task R_VariablesIndexerMemberCompletion03() {
+            using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType, Workflow.RSessions)) {
+                await ExecuteRCode(_editorHost.HostScript.Session,
+@"
+d <- list(A = c(1:10), B = c(1:10))
+e <- list(A=d, B=d)
+");
+                PrimeIntellisenseProviders(script);
+                script.DoIdle(500);
+
+                script.Type("e$A$");
+
+                var session = script.GetCompletionSession();
+                session.Should().NotBeNull();
+                script.DoIdle(1000);
+
+                var comps = session.SelectedCompletionSet.Completions;
+                comps.Should().HaveCount(2).And
+                    .Contain(x => x.DisplayText == "A").And
+                    .Contain(x => x.DisplayText == "B");
+                script.DoIdle(100);
+            }
+        }
+
+        [Test]
         public async Task R_VariablesIndexerMemberCompletion02() {
             using (var script = await _editorHost.StartScript(ExportProvider, RContentTypeDefinition.ContentType, Workflow.RSessions)) {
                 await ExecuteRCode(_editorHost.HostScript.Session, "d1 <- mtcars\r\n");

--- a/src/R/Editor/Impl/Completion/Providers/FilesCompletionProvider.cs
+++ b/src/R/Editor/Impl/Completion/Providers/FilesCompletionProvider.cs
@@ -22,14 +22,22 @@ namespace Microsoft.R.Editor.Completion.Providers {
     /// Provides list of files and folder in the current directory
     /// </summary>
     internal sealed class FilesCompletionProvider : IRCompletionListProvider {
+        enum Mode {
+            WorkingDirectory,
+            UserDirectory,
+            Other
+        }
+
         private readonly IImagesProvider _imagesProvider;
         private readonly IRInteractiveWorkflow _workflow;
         private readonly IGlyphService _glyphService;
 
-        private Task<string> _userDirectoryFetchingTask;
-        private string _directory;
-        private string _cachedUserDirectory;
-        private bool _forceR; // for tests
+        private readonly string _enteredDirectory;
+        private readonly bool _forceR; // for tests
+
+        private readonly Task<string> _task;
+        private readonly Mode _mode = Mode.Other;
+        private volatile string _rootDirectory;
 
         public FilesCompletionProvider(string directoryCandidate, IRInteractiveWorkflow workflow, IImagesProvider imagesProvider, IGlyphService glyphService, bool forceR = false) {
             if (directoryCandidate == null) {
@@ -41,35 +49,42 @@ namespace Microsoft.R.Editor.Completion.Providers {
             _glyphService = glyphService;
             _forceR = forceR;
 
-            _directory = ExtractDirectory(directoryCandidate);
-
-            if (_directory.Length == 0 || _directory.StartsWithOrdinal("~\\")) {
-                _directory = _directory.Length > 1 ? _directory.Substring(2) : _directory;
-                _userDirectoryFetchingTask = _workflow.RSession.GetRUserDirectoryAsync();
+            _enteredDirectory = ExtractDirectory(directoryCandidate);
+            if (_enteredDirectory.Length == 0 || _enteredDirectory.StartsWithOrdinal(".")) {
+                _mode = Mode.WorkingDirectory;
+                _task = Task.Run(async () => _rootDirectory = await _workflow.RSession.GetWorkingDirectoryAsync());
+            } else if (_enteredDirectory.StartsWithOrdinal("~\\")) {
+                _mode = Mode.UserDirectory;
+                _task = Task.Run(async () => _rootDirectory = await _workflow.RSession.GetRUserDirectoryAsync());
             }
+            _task?.DoNotWait();
         }
 
         #region IRCompletionListProvider
         public bool AllowSorting { get; } = false;
 
         public IReadOnlyCollection<RCompletion> GetEntries(RCompletionContext context) {
-            List<RCompletion> completions = new List<RCompletion>();
-            string directory = null;
-            string userDirectory = null;
-
-            if (_userDirectoryFetchingTask != null) {
-                userDirectory = _userDirectoryFetchingTask.WaitTimeout(500);
-                userDirectory = userDirectory ?? _cachedUserDirectory;
-            }
+            var completions = new List<RCompletion>();
+            string directory = _enteredDirectory;
 
             try {
-                if (!string.IsNullOrEmpty(userDirectory)) {
-                    _cachedUserDirectory = userDirectory;
-                    directory = Path.Combine(userDirectory, _directory);
-                } else {
-                    directory = _directory;
-                }
+                // If we are running async directory fetching, wait a bit
+                _task?.Wait(500);
+            } catch (OperationCanceledException) { }
 
+            try {
+                // If directory is set, then the async task did complete
+                if (!string.IsNullOrEmpty(_rootDirectory)) {
+                    if (_mode == Mode.WorkingDirectory) {
+                        directory = Path.Combine(_rootDirectory, _enteredDirectory);
+                    } else if (_mode == Mode.UserDirectory) {
+                        var subDirectory = _enteredDirectory.Length > 1 ? _enteredDirectory.Substring(2) : _enteredDirectory;
+                        directory = Path.Combine(_rootDirectory, subDirectory);
+                    }
+                }
+            } catch (ArgumentException) { }
+
+            try {
                 if (!string.IsNullOrEmpty(directory)) {
                     IEnumerable<RCompletion> entries = null;
 
@@ -81,7 +96,7 @@ namespace Microsoft.R.Editor.Completion.Providers {
                     }
                     completions.AddRange(entries);
                 }
-            } catch (IOException) { } catch (UnauthorizedAccessException) { }
+            } catch (IOException) { } catch (UnauthorizedAccessException) { } catch (ArgumentException) { }
 
             return completions;
         }
@@ -111,16 +126,7 @@ namespace Microsoft.R.Editor.Completion.Providers {
             });
         }
 
-        private IEnumerable<RCompletion> GetLocalDirectoryItems(string userDirectory) {
-            string directory;
-
-            if (!string.IsNullOrEmpty(userDirectory)) {
-                _cachedUserDirectory = userDirectory;
-                directory = Path.Combine(userDirectory, _directory);
-            } else {
-                directory = Path.Combine(RToolsSettings.Current.WorkingDirectory, _directory);
-            }
-
+        private IEnumerable<RCompletion> GetLocalDirectoryItems(string directory) {
             if (Directory.Exists(directory)) {
                 var folderGlyph = _glyphService.GetGlyphThreadSafe(StandardGlyphGroup.GlyphClosedFolder, StandardGlyphItem.GlyphItemPublic);
 

--- a/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
+++ b/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                 }
 
                 // May be a package object line mtcars$
-                variableName = TrimToTrailingSelector(variableName);
+                variableName = TrimToFirstSelector(variableName);
                 var session = Workflow.RSession;
 
                 IReadOnlyList<IREvaluationResultInfo> infoList = null;
@@ -115,14 +115,9 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         }
         #endregion
 
-        private static string TrimToTrailingSelector(string name) {
-            int i = name.Length - 1;
-            for (; i >= 0; i--) {
-                if (_selectors.Contains(name[i])) {
-                    return name.Substring(0, i);
-                }
-            }
-            return string.Empty;
+        private static string TrimToFirstSelector(string name) {
+            var index = name.IndexOfAny(_selectors);
+            return index >= 0 ? name.Substring(0, index) : name;
         }
 
         private static string TrimLeadingSelector(string name) {

--- a/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
+++ b/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
@@ -85,16 +85,17 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                 }
 
                 // May be a package object line mtcars$
-                variableName = TrimToFirstSelector(variableName);
+                var rootVariableName = TrimToFirstSelector(variableName);
+                var memberName = TrimToLastSelector(variableName);
                 var session = Workflow.RSession;
 
                 IReadOnlyList<IREvaluationResultInfo> infoList = null;
                 Task.Run(async () => {
                     try {
-                        var exists = await session.EvaluateAsync<bool>(Invariant($"exists('{variableName}')"), REvaluationKind.Normal);
+                        var exists = await session.EvaluateAsync<bool>(Invariant($"exists('{rootVariableName}')"), REvaluationKind.Normal);
                         if (exists) {
                             infoList = await session.DescribeChildrenAsync(REnvironments.GlobalEnv,
-                                           variableName, HasChildrenProperty | AccessorKindProperty,
+                                           memberName, HasChildrenProperty | AccessorKindProperty,
                                            null, _maxResults);
                         }
                     } catch (Exception) { }
@@ -117,6 +118,11 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         private static string TrimToFirstSelector(string name) {
             var index = name.IndexOfAny(_selectors);
+            return index >= 0 ? name.Substring(0, index) : name;
+        }
+
+        private static string TrimToLastSelector(string name) {
+            var index = name.LastIndexOfAny(_selectors);
             return index >= 0 ? name.Substring(0, index) : name;
         }
 

--- a/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
+++ b/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
@@ -92,11 +92,10 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                 IReadOnlyList<IREvaluationResultInfo> infoList = null;
                 Task.Run(async () => {
                     try {
-                        var exists = await session.EvaluateAsync<bool>(Invariant($"exists('{rootVariableName}')"), REvaluationKind.Normal);
-                        if (exists) {
+                        var result = await session.TryEvaluateAndDescribeAsync(memberName, REvaluationResultProperties.None, null);
+                        if (!(result is IRErrorInfo)) {
                             infoList = await session.DescribeChildrenAsync(REnvironments.GlobalEnv,
-                                           memberName, HasChildrenProperty | AccessorKindProperty,
-                                           null, _maxResults);
+                                memberName, HasChildrenProperty | AccessorKindProperty, null, _maxResults);
                         }
                     } catch (Exception) { }
                 }).Wait(_maxWaitTime);


### PR DESCRIPTION
#3292 Brace matcher exception
 - off by one error in markdown tokenizer. Fixed, added test.

#3293 Multiple nesting in a$b$c does not bring completion
- incorrect check for `exists`. Fixed, added test.

#3294 File completion resolves ./ incorrectly
- added support for `./` + test.