### PR TITLE
Fixing build of Release/1_0 in VS 2017.

### DIFF
--- a/src/Host/API/Impl/Microsoft.R.Host.Client.API.nuspec
+++ b/src/Host/API/Impl/Microsoft.R.Host.Client.API.nuspec
@@ -144,7 +144,7 @@
     <file src="System.Xml.XPath.dll" target="build" />
     <file src="System.Xml.XPath.XDocument.dll" target="build" />
     <file src="libuv.dll" target="build" />
-    <file src="zip.dll" target="build" />
+    <!--<file src="zip.dll" target="build" />-->
     <file src="zlib$ConfigSuffix$.dll" target="build" />
     <file src="NewtonSoft.Json.dll" target="build" />
     <file src="rtvs\**\*" target="build\rtvs" />

--- a/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
+++ b/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
@@ -1116,11 +1116,6 @@
       <Project>{E09D3BDA-2E6B-47B5-87AC-B6FC2D33DFAB}</Project>
       <Name>Microsoft.R.Host.Client</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\Host\Process\src\Microsoft.R.Host.vcxproj">
-      <SetPlatform>Platform=x64</SetPlatform>
-      <Project>{131842ce-daf9-4c0e-8409-4a26ef7961a7}</Project>
-      <Name>Microsoft.R.Host</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\Languages\Core\Impl\Microsoft.Languages.Core.csproj">
       <Project>{25cd8690-6208-4740-b123-6dbce6b9444a}</Project>
       <Name>Microsoft.Languages.Core</Name>
@@ -1604,7 +1599,7 @@
       <VSIXSourceItem Include="$(OutputPath)\Microsoft.CodeAnalysis.CSharp.dll" />
       <VSIXSourceItem Include="$(OutputPath)\Microsoft.CodeAnalysis.dll" />
       <VSIXSourceItem Include="$(OutputPath)\libuv.dll" />
-      <VSIXSourceItem Include="$(OutputPath)\zip.dll" />
+      <!--<VSIXSourceItem Include="$(OutputPath)\zip.dll" />-->
       <VSIXSourceItem Include="$(OutputPath)\ItemTemplates\**\*.*">
         <VSIXSubPath>ItemTemplates</VSIXSubPath>
       </VSIXSourceItem>
@@ -1612,12 +1607,12 @@
         <VSIXSubPath>ProjectTemplates</VSIXSubPath>
       </VSIXSourceItem>
     </ItemGroup>
-    <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <!--<ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
       <VSIXSourceItem Include="$(OutputPath)\zlibd.dll" />
     </ItemGroup>
     <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
       <VSIXSourceItem Include="$(OutputPath)\zlib.dll" />
-    </ItemGroup>
+    </ItemGroup>-->
   </Target>
   <Target Name="AfterBuild">
     <ItemGroup>

--- a/src/R.sln
+++ b/src/R.sln
@@ -72,8 +72,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.R.Debugger", "Deb
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Common.Wpf", "Common\Wpf\Impl\Microsoft.Common.Wpf.csproj", "{9DE5E0B5-C8BD-482C-85C3-B8E20F08453B}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.R.Host", "Host\Process\src\Microsoft.R.Host.vcxproj", "{131842CE-DAF9-4C0E-8409-4A26EF7961A7}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.R.Interactive.Test", "Package\TestApp\Microsoft.VisualStudio.R.Interactive.Test.csproj", "{0D80F608-CF60-42F8-A5E1-4E0ACFA384AF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.R.Components.Test", "R\Components\Test\Microsoft.R.Components.Test.csproj", "{2AA8762F-3A84-4CD5-9AA0-77829A766769}"
@@ -500,18 +498,6 @@ Global
 		{9DE5E0B5-C8BD-482C-85C3-B8E20F08453B}.Release|x64.Build.0 = Release|Any CPU
 		{9DE5E0B5-C8BD-482C-85C3-B8E20F08453B}.Release|x86.ActiveCfg = Release|Any CPU
 		{9DE5E0B5-C8BD-482C-85C3-B8E20F08453B}.Release|x86.Build.0 = Release|Any CPU
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Debug|Any CPU.Build.0 = Debug|x64
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Debug|x64.ActiveCfg = Debug|x64
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Debug|x64.Build.0 = Debug|x64
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Debug|x86.ActiveCfg = Debug|Win32
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Debug|x86.Build.0 = Debug|Win32
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Release|Any CPU.ActiveCfg = Release|x64
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Release|Any CPU.Build.0 = Release|x64
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Release|x64.ActiveCfg = Release|x64
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Release|x64.Build.0 = Release|x64
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Release|x86.ActiveCfg = Release|Win32
-		{131842CE-DAF9-4C0E-8409-4A26EF7961A7}.Release|x86.Build.0 = Release|Win32
 		{0D80F608-CF60-42F8-A5E1-4E0ACFA384AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0D80F608-CF60-42F8-A5E1-4E0ACFA384AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0D80F608-CF60-42F8-A5E1-4E0ACFA384AF}.Debug|x64.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
1. The Microsoft.R.Host.vcxproj is missing from the repo, but referenced in Microsoft.VisualStudio.R.Package.csproj.
2. And the dlls: zip.dll and zlib.dll are also just referenced, but nowhere to be found.
Both of these make the build in VS 2017 fail.