### PR TITLE
3325 (Release 1.0)

### DIFF
--- a/src/Package/Impl/RClient/MicrosoftRClientInstaller.cs
+++ b/src/Package/Impl/RClient/MicrosoftRClientInstaller.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.R.Package.RClient {
                 new LongAction() {
                     Name = Resources.DownloadingRClientInstaller,
                     Action = (o, ct) => {
-                        downloadError = downloader.Download("http://go.microsoft.com/fwlink/?LinkId=800048", rClientExe, ct);
+                        downloadError = downloader.Download("https://aka.ms/rclient/download", rClientExe, ct);
                     },
                 }, 
             }, coreShell.Services.Log);

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
@@ -213,7 +213,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
         }
 
         private Dictionary<string, IConnection> GetConnectionsFromSettings() {
-            if(_settings.Connections == null) {
+            if (_settings.Connections == null) {
                 return new Dictionary<string, IConnection>();
             }
 
@@ -224,7 +224,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
 
         private void SaveConnectionsToSettings() {
             _settings.Connections = RecentConnections
-                .Select(c => new ConnectionInfo (c))
+                .Select(c => new ConnectionInfo(c))
                 .ToArray();
             _settings.SaveSettingsAsync().DoNotWait();
         }
@@ -250,11 +250,15 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
                 }
             }
 
-            // Add newly installed engines
+            // Remove automatically created local connections and replace them
+            // with the actual detected ones.
+            foreach (var kvp in connections.Where(c => !c.Value.IsRemote && !c.Value.IsUserCreated).ToList()) {
+                connections.Remove(kvp.Key);
+            }
+
+            // Add detected local engines
             foreach (var e in localEngines) {
-                if (!connections.Values.Any(x => x.Path.PathEquals(e.InstallPath))) {
-                    connections[e.Name] = new Connection(e.Name, e.InstallPath, string.Empty, isUserCreated: false);
-                }
+                connections[e.Name] = new Connection(e.Name, e.InstallPath, string.Empty, isUserCreated: false);
             }
 
             // Verify that most recently used connection is still valid

--- a/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
@@ -213,7 +213,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
         }
 
         private Dictionary<string, IConnection> GetConnectionsFromSettings() {
-            if (_settings.Connections == null) {
+            if(_settings.Connections == null) {
                 return new Dictionary<string, IConnection>();
             }
 
@@ -224,7 +224,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
 
         private void SaveConnectionsToSettings() {
             _settings.Connections = RecentConnections
-                .Select(c => new ConnectionInfo(c))
+                .Select(c => new ConnectionInfo (c))
                 .ToArray();
             _settings.SaveSettingsAsync().DoNotWait();
         }
@@ -250,15 +250,18 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
                 }
             }
 
-            // Remove automatically created local connections and replace them
-            // with the actual detected ones.
-            foreach (var kvp in connections.Where(c => !c.Value.IsRemote && !c.Value.IsUserCreated).ToList()) {
+            // For MRS and MRC always use generated name. These upgrade in place
+            // so keeping old name with old version doesn't make sense.
+            // TODO: handle this better in the future by storing version.
+            foreach (var kvp in connections.Where(c => c.Value.Path.ContainsIgnoreCase("R_SERVER")).ToList()) {
                 connections.Remove(kvp.Key);
             }
 
-            // Add detected local engines
+            // Add newly installed engines
             foreach (var e in localEngines) {
-                connections[e.Name] = new Connection(e.Name, e.InstallPath, string.Empty, isUserCreated: false);
+                if (!connections.Values.Any(x => x.Path.PathEquals(e.InstallPath))) {
+                    connections[e.Name] = new Connection(e.Name, e.InstallPath, string.Empty, isUserCreated: false);
+                }
             }
 
             // Verify that most recently used connection is still valid

--- a/src/R/Interpreters/Impl/Implementation/RInstallation.cs
+++ b/src/R/Interpreters/Impl/Implementation/RInstallation.cs
@@ -68,7 +68,11 @@ namespace Microsoft.R.Interpreters {
             var list = new List<IRInterpreterInfo>();
 
             foreach (var path in installLocations) {
-                var value = microsoftEngines.Where(e => e.InstallPath.EqualsIgnoreCase(path)).OrderByDescending(e => e.Version).First();
+                var value = microsoftEngines
+                    .Where(e => e.InstallPath.TrimTrailingSlash().EqualsIgnoreCase(path))
+                    .OrderByDescending(e => e.Version)
+                    .First();
+
                 list.Add(value);
             }
 

--- a/src/R/Interpreters/Impl/Implementation/RInstallation.cs
+++ b/src/R/Interpreters/Impl/Implementation/RInstallation.cs
@@ -77,21 +77,6 @@ namespace Microsoft.R.Interpreters {
         }
 
         /// <summary>
-        /// Attempts to extract version from registry key.For example '3.3.2 Microsoft R Client'. 
-        /// Returns null if first part of the key name does not appear to be the version.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns>Version or null if key doesn't represent version</returns>
-        private Version VersionFromKey(string key) {
-            var index = key.IndexOf(' ');
-            var versionString = index > 0 ? key.Substring(0, index) : key;
-            try {
-                return new Version(versionString);
-            } catch (ArgumentException) { }
-            return null;
-        }
-
-        /// <summary>
         /// Retrieves information on installed R versions in registry.
         /// </summary>
         private IEnumerable<IRInterpreterInfo> GetInstalledEnginesFromRegistry() {

--- a/src/R/Interpreters/Impl/Implementation/RInstallation.cs
+++ b/src/R/Interpreters/Impl/Implementation/RInstallation.cs
@@ -64,7 +64,7 @@ namespace Microsoft.R.Interpreters {
             var engines = GetInstalledEnginesFromRegistry().Where(e => svr.IsCompatibleVersion(e.Version));
             // Among duplicates by path (MRC registers under multiple keys) take the highest version
             var microsoftEngines = engines.Where(e => e.Name.Contains("Microsoft") || e.InstallPath.Contains("Microsoft"));
-            var installLocations = microsoftEngines.Select(e => e.InstallPath).Distinct();
+            var installLocations = microsoftEngines.Select(e => e.InstallPath.TrimTrailingSlash()).Distinct();
             var list = new List<IRInterpreterInfo>();
 
             foreach (var path in installLocations) {

--- a/src/R/Interpreters/Impl/Implementation/SqlRClientInstallation.cs
+++ b/src/R/Interpreters/Impl/Implementation/SqlRClientInstallation.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.IO;
-using Microsoft.Common.Core.IO;
 using Microsoft.Common.Core.OS;
 using Microsoft.Win32;
-using static System.FormattableString;
 
 namespace Microsoft.R.Interpreters {
     public static class SqlRClientInstallation {
@@ -27,52 +25,6 @@ namespace Microsoft.R.Interpreters {
             } catch (Exception) { }
 
             return string.Empty;
-        }
-
-        public static IRInterpreterInfo GetMicrosoftRClientInfo(IRegistry registry = null, IFileSystem fileSystem = null) {
-            registry = registry ?? new RegistryImpl();
-            fileSystem = fileSystem ?? new FileSystem();
-
-            // If yes, check 32-bit registry for R engine installed by the R Server.
-            // TODO: remove this when MRS starts writing 64-bit keys.
-            if (IsMRCInstalledInSql(registry)) {
-                using (IRegistryKey hklm = registry.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)) {
-                    try {
-                        using (var key = hklm.OpenSubKey(@"SOFTWARE\R-core\R64")) {
-                            foreach (var keyName in key.GetSubKeyNames()) {
-                                using (var rsKey = key.OpenSubKey(keyName)) {
-                                    try {
-                                        var path = (string)rsKey?.GetValue("InstallPath");
-                                        if (!string.IsNullOrEmpty(path) && path.Contains(_rServer)) {
-                                            var info = new RInterpreterInfo(string.Empty, path);
-                                            if (info.VerifyInstallation(new SupportedRVersionRange(), fileSystem)) {
-                                                return new RInterpreterInfo(Invariant($"Microsoft R Client (SQL) {info.Version.Major}.{info.Version.Minor}.{info.Version.Build}"), info.InstallPath);
-                                            }
-                                        }
-                                    } catch (Exception) { }
-                                }
-                            }
-                        }
-                    } catch (Exception) { }
-                }
-            }
-
-            return null;
-        }
-
-        private static bool IsMRCInstalledInSql(IRegistry registry = null) {
-            bool mrsInstalled = false;
-            try {
-                using (var hklm = registry.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64)) {
-                    using (var key = hklm.OpenSubKey(@"SOFTWARE\Microsoft\Microsoft SQL Server\130\sql_shared_mr")) {
-                        var path = (string)key?.GetValue("Path");
-                        if (!string.IsNullOrEmpty(path) && path.Contains(_rServer)) {
-                            mrsInstalled = true;
-                        }
-                    }
-                }
-            } catch (Exception) { }
-            return mrsInstalled;
         }
     }
 }


### PR DESCRIPTION
The problem is that MRC installs over existing bits but does not remove old registry keys. So we end up seeing 3.2.2 and 3.3.2 pointing to the same path. Fetching first from the set take 3.2.2. Fixes

a) Stop special casing SQL. It is already in the registry anyway.
b). Take all found engines, select Microsoft ones, de-duplicate by install location and take highest version.
c). In connection manager always replace automatically detected engines since path can be the same but name can change after the upgrade.
d) Fix MRC download link.