### PR TITLE
#3337 On localized VS and OS messages in rtvs package are converted incorrectly 

### DIFF
--- a/loc/lcl/CHS/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/CHS/Microsoft.R.Components.dll.lcl
@@ -1818,54 +1818,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[正在将工作区自动保存到图像“%s”...]]></Val>
+            <Val><![CDATA[正在将工作区自动保存到图像 '{0}'...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[是否要删除自动保存的工作区图像“%s”?]]></Val>
+            <Val><![CDATA[是否要删除自动保存的工作区图像 '{0}'?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[正在删除自动保存的工作区图像“%s”。]]></Val>
+            <Val><![CDATA[正在删除自动保存的工作区图像 '{0}'。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[未能从自动保存的图像“%s”加载工作区。]]></Val>
+            <Val><![CDATA[未能从自动保存的图像 '{0}' 加载工作区。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[已从自动保存的图像“%s”加载工作区。]]></Val>
+            <Val><![CDATA[已从自动保存的图像 '{0}' 加载工作区。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[已终止上一个 R 会话，并且已将它的全局工作区保存到图像“%s”。是否要重新加载它?]]></Val>
+            <Val><![CDATA[已终止上一个 R 会话，并且已将它的全局工作区保存到图像 '{0}'。是否要重新加载它?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/CHT/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/CHT/Microsoft.R.Components.dll.lcl
@@ -1818,54 +1818,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[正在將工作區自動儲存為影像 "%s"...]]></Val>
+            <Val><![CDATA[正在將工作區自動儲存為影像 '{0}'...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[要刪除自動儲存的工作區影像 "%s" 嗎?]]></Val>
+            <Val><![CDATA[要刪除自動儲存的工作區影像 '{0}' 嗎?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[正在刪除自動儲存的工作區影像 "%s"。]]></Val>
+            <Val><![CDATA[正在刪除自動儲存的工作區影像 '{0}'。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[無法從自動儲存的影像 "%s" 載入工作區。]]></Val>
+            <Val><![CDATA[無法從自動儲存的影像 '{0}' 載入工作區。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[已從自動儲存的影像 "%s" 載入工作區。]]></Val>
+            <Val><![CDATA[已從自動儲存的影像 '{0}' 載入工作區。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[上一個 R 工作階段已終止，而且其全域工作區已儲存為影像 "%s"。要將其重新載入嗎?]]></Val>
+            <Val><![CDATA[上一個 R 工作階段已終止，而且其全域工作區已儲存為影像 '{0}'。要將其重新載入嗎?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/CSY/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/CSY/Microsoft.R.Components.dll.lcl
@@ -1824,54 +1824,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Automatické ukládání pracovního prostoru do image %s...]]></Val>
+            <Val><![CDATA[Automatické ukládání pracovního prostoru do image '{0}'...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Odstranit automaticky uloženou image pracovního prostoru %s?]]></Val>
+            <Val><![CDATA[Odstranit automaticky uloženou image pracovního prostoru '{0}'?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Odstraňuje se automaticky uložená image pracovního prostoru %s.]]></Val>
+            <Val><![CDATA[Odstraňuje se automaticky uložená image pracovního prostoru '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Nepovedlo se načíst pracovní prostor z automaticky uložené image %s.]]></Val>
+            <Val><![CDATA[Nepovedlo se načíst pracovní prostor z automaticky uložené image '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Načetl se pracovní prostor z automaticky uložené image %s.]]></Val>
+            <Val><![CDATA[Načetl se pracovní prostor z automaticky uložené image '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Předchozí relace jazyka R byla ukončena a její globální pracovní prostor byl uložen do image %s. Chcete ho znovu načíst?]]></Val>
+            <Val><![CDATA[Předchozí relace jazyka R byla ukončena a její globální pracovní prostor byl uložen do image '{0}'. Chcete ho znovu načíst?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/DEU/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/DEU/Microsoft.R.Components.dll.lcl
@@ -1824,54 +1824,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Arbeitsbereich wird automatisch in Image "%s" gespeichert...]]></Val>
+            <Val><![CDATA[Arbeitsbereich wird automatisch in Image '{0}' gespeichert...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Soll das automatisch gespeicherte Arbeitsbereichsimage "%s" gelöscht werden?]]></Val>
+            <Val><![CDATA[Soll das automatisch gespeicherte Arbeitsbereichsimage '{0}' gelöscht werden?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Das automatisch gespeicherte Arbeitsbereichsimage "%s" wird gelöscht.]]></Val>
+            <Val><![CDATA[Das automatisch gespeicherte Arbeitsbereichsimage '{0}' wird gelöscht.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Fehler beim Laden des Arbeitsbereichs aus dem automatisch gespeicherten Image "%s".]]></Val>
+            <Val><![CDATA[Fehler beim Laden des Arbeitsbereichs aus dem automatisch gespeicherten Image '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Der Arbeitsbereich wurde aus dem automatisch gespeicherten Image "%s" geladen.]]></Val>
+            <Val><![CDATA[Der Arbeitsbereich wurde aus dem automatisch gespeicherten Image '{0}' geladen.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Die vorherige R-Sitzung wurde beendet, und der zugehörige globale Arbeitsbereich wurde in das Image "%s" gespeichert. Möchten Sie den Arbeitsbereich erneut laden?]]></Val>
+            <Val><![CDATA[Die vorherige R-Sitzung wurde beendet, und der zugehörige globale Arbeitsbereich wurde in das Image '{0}' gespeichert. Möchten Sie den Arbeitsbereich erneut laden?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/ESN/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/ESN/Microsoft.R.Components.dll.lcl
@@ -1824,54 +1824,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Guardando automáticamente el área de trabajo en la imagen "%s"...]]></Val>
+            <Val><![CDATA[Guardando automáticamente el área de trabajo en la imagen '{0}'...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[¿Quiere eliminar la imagen de área de trabajo autoguardada "%s"?]]></Val>
+            <Val><![CDATA[¿Quiere eliminar la imagen de área de trabajo autoguardada '{0}'?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Eliminando la imagen del área de trabajo autoguardada "%s".]]></Val>
+            <Val><![CDATA[Eliminando la imagen del área de trabajo autoguardada '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[No se pudo cargar el área de trabajo desde la imagen autoguardada "%s".]]></Val>
+            <Val><![CDATA[No se pudo cargar el área de trabajo desde la imagen autoguardada '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Área de trabajo guardada a partir de la imagen autoguardada "%s".]]></Val>
+            <Val><![CDATA[Área de trabajo guardada a partir de la imagen autoguardada '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[La sesión anterior de R ha finalizado y su área de trabajo global se ha guardado en la imagen "%s". ¿Quiere volver a cargarla?]]></Val>
+            <Val><![CDATA[La sesión anterior de R ha finalizado y su área de trabajo global se ha guardado en la imagen '{0}'. ¿Quiere volver a cargarla?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/FRA/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/FRA/Microsoft.R.Components.dll.lcl
@@ -1824,54 +1824,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Enregistrement automatique de l'espace de travail dans l'image "%s"...]]></Val>
+            <Val><![CDATA[Enregistrement automatique de l'espace de travail dans l'image '{0}'...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Supprimer l'image d'espace de travail enregistrée automatiquement "%s" ?]]></Val>
+            <Val><![CDATA[Supprimer l'image d'espace de travail enregistrée automatiquement '{0}' ?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Suppression de l'image d'espace de travail enregistrée automatiquement "%s".]]></Val>
+            <Val><![CDATA[Suppression de l'image d'espace de travail enregistrée automatiquement '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Échec du chargement de l'espace de travail à partir de l'image enregistrée automatiquement "%s".]]></Val>
+            <Val><![CDATA[Échec du chargement de l'espace de travail à partir de l'image enregistrée automatiquement '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Espace de travail chargé à partir de l'image enregistrée automatiquement "%s".]]></Val>
+            <Val><![CDATA[Espace de travail chargé à partir de l'image enregistrée automatiquement '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[La session R précédente a été terminée, et son espace de travail global a été enregistré dans l'image "%s". Voulez-vous le recharger ?]]></Val>
+            <Val><![CDATA[La session R précédente a été terminée, et son espace de travail global a été enregistré dans l'image '{0}'. Voulez-vous le recharger ?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/ITA/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/ITA/Microsoft.R.Components.dll.lcl
@@ -1824,54 +1824,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Salvataggio automatico dell'area di lavoro nell'immagine "%s"...]]></Val>
+            <Val><![CDATA[Salvataggio automatico dell'area di lavoro nell'immagine '{0}'...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Eliminare l'immagine dell'area di lavoro "%s" salvata automaticamente?]]></Val>
+            <Val><![CDATA[Eliminare l'immagine dell'area di lavoro '{0}' salvata automaticamente?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Eliminazione dell'immagine dell'area di lavoro "%s" salvata automaticamente.]]></Val>
+            <Val><![CDATA[Eliminazione dell'immagine dell'area di lavoro '{0}' salvata automaticamente.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Non è stato possibile caricare l'area di lavoro dall'immagine "%s" salvata automaticamente.]]></Val>
+            <Val><![CDATA[Non è stato possibile caricare l'area di lavoro dall'immagine '{0}' salvata automaticamente.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[L'area di lavoro è stata caricata dall'immagine "%s" salvata automaticamente.]]></Val>
+            <Val><![CDATA[L'area di lavoro è stata caricata dall'immagine '{0}' salvata automaticamente.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[La sessione precedente di R è stata terminata e la relativa area di lavoro globale è stata salvata nell'immagine "%s". Ricaricarla?]]></Val>
+            <Val><![CDATA[La sessione precedente di R è stata terminata e la relativa area di lavoro globale è stata salvata nell'immagine '{0}'. Ricaricarla?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/JPN/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/JPN/Microsoft.R.Components.dll.lcl
@@ -1824,54 +1824,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[ワークスペースをイメージ "%s" に自動保存しています...]]></Val>
+            <Val><![CDATA[ワークスペースをイメージ '{0}' に自動保存しています...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[自動保存したワークスペース イメージ "%s" を削除しますか?]]></Val>
+            <Val><![CDATA[自動保存したワークスペース イメージ '{0}' を削除しますか?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[自動保存したワークスペース イメージ "%s" を削除しています。]]></Val>
+            <Val><![CDATA[自動保存したワークスペース イメージ '{0}' を削除しています。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[自動保存されたイメージ "%s" からワークスペースを読み込めませんでした。]]></Val>
+            <Val><![CDATA[自動保存されたイメージ '{0}' からワークスペースを読み込めませんでした。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[自動保存されたイメージ "%s" からワークスペースが読み込まれました。]]></Val>
+            <Val><![CDATA[自動保存されたイメージ '{0}' からワークスペースが読み込まれました。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[前の R セッションが終了し、グローバル ワークスペースがイメージ "%s" に保存されています。このワークスペースを再度読み込みますか?]]></Val>
+            <Val><![CDATA[前の R セッションが終了し、グローバル ワークスペースがイメージ '{0}' に保存されています。このワークスペースを再度読み込みますか?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/KOR/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/KOR/Microsoft.R.Components.dll.lcl
@@ -1818,54 +1818,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[작업 영역을 "%s" 이미지로 자동 저장하는 중...]]></Val>
+            <Val><![CDATA[작업 영역을 '{0}' 이미지로 자동 저장하는 중...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[자동 저장된 작업 영역 이미지 "%s"을(를) 삭제하시겠습니까?]]></Val>
+            <Val><![CDATA[자동 저장된 작업 영역 이미지 '{0}'을(를) 삭제하시겠습니까?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[자동 저장된 작업 영역 이미지 "%s"을(를) 삭제하는 중입니다.]]></Val>
+            <Val><![CDATA[자동 저장된 작업 영역 이미지 '{0}'을(를) 삭제하는 중입니다.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[자동 저장된 이미지 "%s"에서 작업 영역을 로드하지 못했습니다.]]></Val>
+            <Val><![CDATA[자동 저장된 이미지 '{0}'에서 작업 영역을 로드하지 못했습니다.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[자동 저장된 이미지 "%s"에서 작업 영역을 로드했습니다.]]></Val>
+            <Val><![CDATA[자동 저장된 이미지 '{0}'에서 작업 영역을 로드했습니다.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[이전 R 세션이 종료되고 해당 전역 작업 영역이 "%s" 이미지로 저장되었습니다. 다시 로드하시겠습니까?]]></Val>
+            <Val><![CDATA[이전 R 세션이 종료되고 해당 전역 작업 영역이 '{0}' 이미지로 저장되었습니다. 다시 로드하시겠습니까?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/PLK/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/PLK/Microsoft.R.Components.dll.lcl
@@ -1824,54 +1824,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Trwa automatyczne zapisywanie obszaru roboczego do obrazu „%s”...]]></Val>
+            <Val><![CDATA[Trwa automatyczne zapisywanie obszaru roboczego do obrazu '{0}'...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Usunąć automatycznie zapisany obraz obszaru roboczego „%s”?]]></Val>
+            <Val><![CDATA[Usunąć automatycznie zapisany obraz obszaru roboczego '{0}'?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Usuwanie automatycznie zapisanego obrazu obszaru roboczego „%s”.]]></Val>
+            <Val><![CDATA[Usuwanie automatycznie zapisanego obrazu obszaru roboczego '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Nie można załadować obszaru roboczego z automatycznie zapisanego obrazu „%s”.]]></Val>
+            <Val><![CDATA[Nie można załadować obszaru roboczego z automatycznie zapisanego obrazu '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Załadowano obszar roboczy z automatycznie zapisanego obrazu „%s”.]]></Val>
+            <Val><![CDATA[Załadowano obszar roboczy z automatycznie zapisanego obrazu '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Poprzednia sesja języka została przerwana, a jej globalny obszar roboczy został zapisany do obrazu „%s”. Czy chcesz ją ponownie załadować?]]></Val>
+            <Val><![CDATA[Poprzednia sesja języka została przerwana, a jej globalny obszar roboczy został zapisany do obrazu '{0}'. Czy chcesz ją ponownie załadować?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/PTB/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/PTB/Microsoft.R.Components.dll.lcl
@@ -1824,54 +1824,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Salvando automaticamente o espaço de trabalho para a imagem "%s" ...]]></Val>
+            <Val><![CDATA[Salvando automaticamente o espaço de trabalho para a imagem '{0}' ...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Excluir imagem do espaço de trabalho salvo automaticamente "%s"?]]></Val>
+            <Val><![CDATA[Excluir imagem do espaço de trabalho salvo automaticamente '{0}'?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Excluindo imagem do espaço de trabalho salvo automaticamente "%s".]]></Val>
+            <Val><![CDATA[Excluindo imagem do espaço de trabalho salvo automaticamente '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Falha ao carregar o espaço de trabalho da imagem salva automaticamente "%s".]]></Val>
+            <Val><![CDATA[Falha ao carregar o espaço de trabalho da imagem salva automaticamente '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Espaço de trabalho carregado da imagem salva automaticamente "%s".]]></Val>
+            <Val><![CDATA[Espaço de trabalho carregado da imagem salva automaticamente '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[A sessão de R anterior foi encerrada e seu espaço de trabalho global foi salvo para a imagem "%s". Deseja recarregá-la?]]></Val>
+            <Val><![CDATA[A sessão de R anterior foi encerrada e seu espaço de trabalho global foi salvo para a imagem '{0}'. Deseja recarregá-la?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/RUS/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/RUS/Microsoft.R.Components.dll.lcl
@@ -1824,54 +1824,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Автоматическое сохранение рабочей области в образе "%s"...]]></Val>
+            <Val><![CDATA[Автоматическое сохранение рабочей области в образе '{0}'...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Удалить автоматически сохраненный образ рабочей области "%s"?]]></Val>
+            <Val><![CDATA[Удалить автоматически сохраненный образ рабочей области '{0}'?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Выполняется удаление автоматически сохраненного образа рабочей области "%s".]]></Val>
+            <Val><![CDATA[Выполняется удаление автоматически сохраненного образа рабочей области '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Не удалось загрузить рабочую область из автоматически сохраненного образа "%s".]]></Val>
+            <Val><![CDATA[Не удалось загрузить рабочую область из автоматически сохраненного образа '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Рабочая область загружена из автоматически сохраненного образа "%s".]]></Val>
+            <Val><![CDATA[Рабочая область загружена из автоматически сохраненного образа '{0}'.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Предыдущий сеанс R завершен, а его глобальная рабочая область была сохранена в образе "%s". Вы хотите перезагрузить ее?]]></Val>
+            <Val><![CDATA[Предыдущий сеанс R завершен, а его глобальная рабочая область была сохранена в образе '{0}'. Вы хотите перезагрузить ее?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/loc/lcl/TRK/Microsoft.R.Components.dll.lcl
+++ b/loc/lcl/TRK/Microsoft.R.Components.dll.lcl
@@ -1824,54 +1824,54 @@
       </Item>
       <Item ItemId=";rtvs_AutosavingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Autosaving workspace to image "%s" ...]]></Val>
+          <Val><![CDATA[Autosaving workspace to image '{0}' ...]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Çalışma alanı "%s" görüntüsüne otomatik olarak kaydediliyor...]]></Val>
+            <Val><![CDATA[Çalışma alanı '{0}' görüntüsüne otomatik olarak kaydediliyor...]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_ConfirmDeleteWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Delete autosaved workspace image "%s"?]]></Val>
+          <Val><![CDATA[Delete autosaved workspace image '{0}'?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Otomatik olarak kaydedilmiş çalışma alanı görüntüsü "%s" silinsin mi?]]></Val>
+            <Val><![CDATA[Otomatik olarak kaydedilmiş çalışma alanı görüntüsü '{0}' silinsin mi?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_DeletingWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Deleting autosaved workspace image "%s".]]></Val>
+          <Val><![CDATA[Deleting autosaved workspace image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Otomatik olarak kaydedilmiş çalışma alanı görüntüsü "%s" siliniyor.]]></Val>
+            <Val><![CDATA[Otomatik olarak kaydedilmiş çalışma alanı görüntüsü '{0}' siliniyor.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_FailedToLoadWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Failed to load workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Failed to load workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Çalışma alanı otomatik olarak kaydedilmiş "%s" görüntüsünden yüklenemedi.]]></Val>
+            <Val><![CDATA[Çalışma alanı otomatik olarak kaydedilmiş '{0}' görüntüsünden yüklenemedi.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_LoadedWorkspace" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Loaded workspace from autosaved image "%s".]]></Val>
+          <Val><![CDATA[Loaded workspace from autosaved image '{0}'.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Çalışma alanı otomatik olarak kaydedilmiş "%s" görüntüsünden yüklendi.]]></Val>
+            <Val><![CDATA[Çalışma alanı otomatik olarak kaydedilmiş '{0}' görüntüsünden yüklendi.]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />
       </Item>
       <Item ItemId=";rtvs_SessionTerminatedUnexpectedly" ItemType="0" PsrId="211" Leaf="true">
         <Str Cat="Text">
-          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?]]></Val>
+          <Val><![CDATA[Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[Önceki R oturumu sonlandırıldı ve genel çalışma alanı "%s" görüntüsüne kaydedildi. Yeniden yüklemek istiyor musunuz?]]></Val>
+            <Val><![CDATA[Önceki R oturumu sonlandırıldı ve genel çalışma alanı '{0}' görüntüsüne kaydedildi. Yeniden yüklemek istiyor musunuz?]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -571,7 +572,7 @@ namespace Microsoft.R.Host.Client {
                                 break;
 
                             case "?LocStr":
-                                await RespondAsync(message, ct, _callbacks.GetLocalizedString(message.GetString(0, "id")));
+                                await RespondAsync(message, ct, GetLocalizedString(message));
                                 break;
 
                             default:
@@ -594,6 +595,15 @@ namespace Microsoft.R.Host.Client {
             }
 
             return null;
+        }
+
+        private string GetLocalizedString(Message message) {
+            var s = _callbacks.GetLocalizedString(message.GetString(0, "id"));
+            if (message.ArgumentCount == 2) {
+                var args = message.GetArgument(1, "a", JTokenType.Array).Select(o => o.Value<object>()).ToArray();
+                s = string.Format(CultureInfo.CurrentCulture, s, args);
+            }
+            return s;
         }
 
         private CancellationToken UpdateCancelAllCtsLink(ref CancellationTokenSource cancelAllCtsLink, CancellationToken loopCt) {

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -590,10 +590,6 @@ namespace Microsoft.R.Host.Client {
                                 }).DoNotWait();
                                 break;
 
-                            case "?LocStr":
-                                await RespondAsync(message, ct, GetLocalizedString(message));
-                                break;
-
                             case "!LocMessage":
                                 _callbacks.WriteConsoleEx(GetLocalizedString(message) + Environment.NewLine, OutputType.Output, ct).DoNotWait();
                                 break;

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -149,11 +149,23 @@ namespace Microsoft.R.Host.Client {
 
         private async Task ShowDialog(Message request, MessageButtons buttons, CancellationToken ct) {
             TaskUtilities.AssertIsOnBackgroundThread();
-            request.ExpectArguments(2);
-            var contexts = GetContexts(request);
-            var s = request.GetString(1, "s", allowNull: true);
 
-            MessageButtons input = await _callbacks.ShowDialog(contexts, s, buttons, ct);
+            RContext[] contexts;
+            string message;
+            switch (request.ArgumentCount) {
+                case 1:
+                    contexts = new RContext[0];
+                    message = request.GetString(0, "s", allowNull: true);
+                    break;
+                case 2:
+                    contexts = GetContexts(request);
+                    message = request.GetString(1, "s", allowNull: true);
+                    break;
+                default:
+                    throw new InvalidOperationException("Invalid number of argument in ShowDialog");
+            }
+
+            MessageButtons input = await _callbacks.ShowDialog(contexts, message, buttons, ct);
             ct.ThrowIfCancellationRequested();
 
             string response;

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -23,8 +23,16 @@ locstr <- function(id, ...) {
     send_request_and_get_response('?LocStr', id, list(...))[[1]]
 }
 
-askYesNo <- function(message) {
-    send_request_and_get_response('?YesNo', message)[[1]]
+loc_message <- function(id, ...) {
+    send_notification("!LocMessage", id, list(...))
+}
+
+loc_warning <- function(id, ...) {
+    send_notification("!LocWarning", id, list(...))
+}
+
+loc_askYesNo <- function(id, ...) {
+    send_request_and_get_response('?LocYesNo', id, list(...))[[1]]
 }
 
 memory_connection <- function(max_length = NA, expected_length = NA, overflow_suffix = '', eof_marker = '') {
@@ -275,8 +283,7 @@ query_reload_autosave <- function() {
         return(FALSE);
     }
 
-    msg <- locstr('rtvs_SessionTerminatedUnexpectedly', autosave_filename);
-    res <- askYesNo(msg)[[1]];
+    res <- loc_askYesNo('rtvs_SessionTerminatedUnexpectedly', autosave_filename)[[1]];
 
     if (identical(res, 'Y')) {
         # Use try instead of tryCatch, so that any errors are printed as usual.
@@ -287,17 +294,16 @@ query_reload_autosave <- function() {
         });
 
         if (loaded) {
-            message(locstr('rtvs_LoadedWorkspace', autosave_filename));
+            loc_warning('rtvs_LoadedWorkspace', autosave_filename);
             # If we loaded the file successfully, it's safe to delete it - this session contains the reloaded
             # state now, and if there's another disconnect, it will be autosaved again.
             return(TRUE);
         } else {
-            warning(locstr('rtvs_FailedToLoadWorkspace', autosave_filename), call. = FALSE, immediate. = TRUE);
+            loc_warning('rtvs_FailedToLoadWorkspace', autosave_filename);
             return(FALSE);
         }
     } else {
-        msg <- locstr('rtvs_ConfirmDeleteWorkspace', autosave_filename);
-        res <-askYesNo(msg)[[1]];
+        res <-loc_askYesNo('rtvs_ConfirmDeleteWorkspace', autosave_filename)[[1]];
         return(identical(res, 'Y'));
     }
 }
@@ -316,7 +322,7 @@ enable_autosave <- function(delete_existing) {
         set_disconnect_callback(save_state);
 
         if (delete_existing) {
-            message(locstr('rtvs_DeletingWorkspace', autosave_filename));
+            loc_warning('rtvs_DeletingWorkspace', autosave_filename);
             unlink(autosave_filename);
         }
     });

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -19,10 +19,6 @@ send_request_and_get_response <- function(name, ...) {
     call_embedded('send_request_and_get_response', name, list(...))
 }
 
-locstr <- function(id, ...) {
-    send_request_and_get_response('?LocStr', id, list(...))[[1]]
-}
-
 loc_message <- function(id, ...) {
     send_notification("!LocMessage", id, list(...))
 }
@@ -309,7 +305,7 @@ query_reload_autosave <- function() {
 }
 
 save_state <- function() {
-    # This function runs when client is already disconnected, so locstr() cannot be used, since it requires
+    # This function runs when client is already disconnected, so loc_message() cannot be used, since it requires
     # a connected client to provide translated strings. However, since messages are not user-visible and are
     # here for logging purposes only, they don't need to be localized in the first place.
     #message(sprintf('Autosaving workspace to image "%s" ...', autosave_filename), appendLF = FALSE);

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -307,10 +307,12 @@ query_reload_autosave <- function() {
 save_state <- function() {
     # This function runs when client is already disconnected, so loc_message() cannot be used, since it requires
     # a connected client to provide translated strings. However, since messages are not user-visible and are
-    # here for logging purposes only, they don't need to be localized in the first place.
-    #message(sprintf('Autosaving workspace to image "%s" ...', autosave_filename), appendLF = FALSE);
+    # here for logging purposes only, they don't need to be localized in the first place. Also, they 
+    # cannot be localized since 'message' and 'sprintf' depend on currely set R locale which may or 
+    # may not be the same as current client UI locale (VS UI language is set indedendently from OS and R).
+    message(sprintf('Autosaving workspace to image "%s" ...', autosave_filename), appendLF = FALSE);
     save.image(autosave_filename);
-    #message(' workspace saved successfully.');
+    message(' workspace saved successfully.');
 }
 
 enable_autosave <- function(delete_existing) {

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -23,6 +23,10 @@ locstr <- function(id) {
     send_request_and_get_response('?LocStr', id)[[1]]
 }
 
+askYesNo <- function(message) {
+    send_request_and_get_response('?YesNo', message)[[1]]
+}
+
 memory_connection <- function(max_length = NA, expected_length = NA, overflow_suffix = '', eof_marker = '') {
     call_embedded('memory_connection', max_length, expected_length, overflow_suffix, eof_marker)
 }
@@ -272,9 +276,9 @@ query_reload_autosave <- function() {
     }
 
     msg <- locstr('rtvs_SessionTerminatedUnexpectedly');
-    res <- winDialog('yesno', sprintf(msg, autosave_filename));
+    res <- askYesNo(sprintf(msg, autosave_filename))[[1]];
 
-    if (identical(res, 'YES')) {
+    if (identical(res, 'Y')) {
         # Use try instead of tryCatch, so that any errors are printed as usual.
         loaded <- FALSE;
         try({
@@ -293,8 +297,8 @@ query_reload_autosave <- function() {
         }
     } else {
         msg <- locstr('rtvs_ConfirmDeleteWorkspace');
-        res <- winDialog('yesno', sprintf(msg, autosave_filename));
-        return(identical(res, 'YES'));
+        res <-askYesNo(sprintf(msg, autosave_filename))[[1]];
+        return(identical(res, 'Y'));
     }
 }
 

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -19,8 +19,8 @@ send_request_and_get_response <- function(name, ...) {
     call_embedded('send_request_and_get_response', name, list(...))
 }
 
-locstr <- function(id) {
-    send_request_and_get_response('?LocStr', id)[[1]]
+locstr <- function(id, ...) {
+    send_request_and_get_response('?LocStr', id, list(...))[[1]]
 }
 
 askYesNo <- function(message) {
@@ -275,8 +275,8 @@ query_reload_autosave <- function() {
         return(FALSE);
     }
 
-    msg <- locstr('rtvs_SessionTerminatedUnexpectedly');
-    res <- askYesNo(sprintf(msg, autosave_filename))[[1]];
+    msg <- locstr('rtvs_SessionTerminatedUnexpectedly', autosave_filename);
+    res <- askYesNo(msg)[[1]];
 
     if (identical(res, 'Y')) {
         # Use try instead of tryCatch, so that any errors are printed as usual.
@@ -287,17 +287,17 @@ query_reload_autosave <- function() {
         });
 
         if (loaded) {
-            message(sprintf(locstr('rtvs_LoadedWorkspace'), autosave_filename));
+            message(locstr('rtvs_LoadedWorkspace', autosave_filename));
             # If we loaded the file successfully, it's safe to delete it - this session contains the reloaded
             # state now, and if there's another disconnect, it will be autosaved again.
             return(TRUE);
         } else {
-            warning(sprintf(locstr('rtvs_FailedToLoadWorkspace'), autosave_filename), call. = FALSE, immediate. = TRUE);
+            warning(locstr('rtvs_FailedToLoadWorkspace', autosave_filename), call. = FALSE, immediate. = TRUE);
             return(FALSE);
         }
     } else {
-        msg <- locstr('rtvs_ConfirmDeleteWorkspace');
-        res <-askYesNo(sprintf(msg, autosave_filename))[[1]];
+        msg <- locstr('rtvs_ConfirmDeleteWorkspace', autosave_filename);
+        res <-askYesNo(msg)[[1]];
         return(identical(res, 'Y'));
     }
 }
@@ -306,9 +306,9 @@ save_state <- function() {
     # This function runs when client is already disconnected, so locstr() cannot be used, since it requires
     # a connected client to provide translated strings. However, since messages are not user-visible and are
     # here for logging purposes only, they don't need to be localized in the first place.
-    message(sprintf('Autosaving workspace to image "%s" ...', autosave_filename), appendLF = FALSE);
+    #message(sprintf('Autosaving workspace to image "%s" ...', autosave_filename), appendLF = FALSE);
     save.image(autosave_filename);
-    message(' workspace saved successfully.');
+    #message(' workspace saved successfully.');
 }
 
 enable_autosave <- function(delete_existing) {
@@ -316,7 +316,7 @@ enable_autosave <- function(delete_existing) {
         set_disconnect_callback(save_state);
 
         if (delete_existing) {
-            message(sprintf(locstr('rtvs_DeletingWorkspace'), autosave_filename));
+            message(locstr('rtvs_DeletingWorkspace', autosave_filename));
             unlink(autosave_filename);
         }
     });

--- a/src/R/Components/Impl/Resources.Designer.cs
+++ b/src/R/Components/Impl/Resources.Designer.cs
@@ -1525,7 +1525,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Autosaving workspace to image &quot;%s&quot; ....
+        ///   Looks up a localized string similar to Autosaving workspace to image &apos;{0}&apos; ....
         /// </summary>
         public static string rtvs_AutosavingWorkspace {
             get {
@@ -1534,7 +1534,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete autosaved workspace image &quot;%s&quot;?.
+        ///   Looks up a localized string similar to Delete autosaved workspace image &apos;{0}&apos;?.
         /// </summary>
         public static string rtvs_ConfirmDeleteWorkspace {
             get {
@@ -1543,7 +1543,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deleting autosaved workspace image &quot;%s&quot;..
+        ///   Looks up a localized string similar to Deleting autosaved workspace image &apos;{0}&apos;..
         /// </summary>
         public static string rtvs_DeletingWorkspace {
             get {
@@ -1552,7 +1552,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to load workspace from autosaved image &quot;%s&quot;..
+        ///   Looks up a localized string similar to Failed to load workspace from autosaved image &apos;{0}&apos;..
         /// </summary>
         public static string rtvs_FailedToLoadWorkspace {
             get {
@@ -1561,7 +1561,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Loaded workspace from autosaved image &quot;%s&quot;..
+        ///   Looks up a localized string similar to Loaded workspace from autosaved image &apos;{0}&apos;..
         /// </summary>
         public static string rtvs_LoadedWorkspace {
             get {
@@ -1570,7 +1570,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Previous R session terminated, and its global workspace has been saved to image &quot;%s&quot;. Would you like to reload it?.
+        ///   Looks up a localized string similar to Previous R session terminated, and its global workspace has been saved to image &apos;{0}&apos;. Would you like to reload it?.
         /// </summary>
         public static string rtvs_SessionTerminatedUnexpectedly {
             get {

--- a/src/R/Components/Impl/Resources.resx
+++ b/src/R/Components/Impl/Resources.resx
@@ -655,22 +655,22 @@ This prompt can be suppressed in R Tools | Options.
     <value>Run plotting command in R Interactive Window</value>
   </data>
   <data name="rtvs_AutosavingWorkspace" xml:space="preserve">
-    <value>Autosaving workspace to image "%s" ...</value>
+    <value>Autosaving workspace to image '{0}' ...</value>
   </data>
   <data name="rtvs_ConfirmDeleteWorkspace" xml:space="preserve">
-    <value>Delete autosaved workspace image "%s"?</value>
+    <value>Delete autosaved workspace image '{0}'?</value>
   </data>
   <data name="rtvs_DeletingWorkspace" xml:space="preserve">
-    <value>Deleting autosaved workspace image "%s".</value>
+    <value>Deleting autosaved workspace image '{0}'.</value>
   </data>
   <data name="rtvs_FailedToLoadWorkspace" xml:space="preserve">
-    <value>Failed to load workspace from autosaved image "%s".</value>
+    <value>Failed to load workspace from autosaved image '{0}'.</value>
   </data>
   <data name="rtvs_LoadedWorkspace" xml:space="preserve">
-    <value>Loaded workspace from autosaved image "%s".</value>
+    <value>Loaded workspace from autosaved image '{0}'.</value>
   </data>
   <data name="rtvs_SessionTerminatedUnexpectedly" xml:space="preserve">
-    <value>Previous R session terminated, and its global workspace has been saved to image "%s". Would you like to reload it?</value>
+    <value>Previous R session terminated, and its global workspace has been saved to image '{0}'. Would you like to reload it?</value>
   </data>
   <data name="rtvs_WorkspaceSavedSuccessfully" xml:space="preserve">
     <value> workspace saved successfully.</value>


### PR DESCRIPTION
**Fix for VS 2017 1.0**

Long story in #3337. 

Basically we can't be using `message`, `warning`, `sprintf`, `winDialog` and friends in R to output localized content. They depend on currently set R locale. `winDialog` doesn't seem to be able to handle UTF-8 and tries to convert to OEM. `sprintf` appears to need proper C++ locale set (probably cp65001) to be able to handle UTF-8.

So the fix is to handle everything at the client.
- locstr removed
- added `loc_message`, `loc_warning`, `loc_yesno` and the respective parts in host
- host now supports `string.format` like functionality
- patched lcl files since `%s` changed to .NET formatting `{0}`

![image](https://cloud.githubusercontent.com/assets/12820357/24333210/aa779f9a-1208-11e7-818a-4f0a770dac75.png)

![image](https://cloud.githubusercontent.com/assets/12820357/24333214/b63b539e-1208-11e7-9e27-749b5d2cae3c.png)
