### PR TITLE
Fix cancellationToken

### DIFF
--- a/src/Host/Client/Impl/Definitions/IRCallbacks.cs
+++ b/src/Host/Client/Impl/Definitions/IRCallbacks.cs
@@ -84,7 +84,7 @@ namespace Microsoft.R.Host.Client {
         /// <summary>
         /// Invoked when R calls 'edit()'
         /// </summary>
-        Task<string> EditFile(string content, string fileName, CancellationToken cancellationToken);
+        Task<string> EditFileAsync(string content, string fileName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Called when working directory has changed in R.

--- a/src/Host/Client/Impl/Definitions/IRSessionCallback.cs
+++ b/src/Host/Client/Impl/Definitions/IRSessionCallback.cs
@@ -79,7 +79,7 @@ namespace Microsoft.R.Host.Client {
         /// <summary>
         /// Edits file or deparsed object
         /// </summary>
-        Task<string> EditFile(string content, string fileName, CancellationToken cancellationToken = default(CancellationToken));
+        Task<string> EditFileAsync(string content, string fileName, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Saves data to file sent from RHost.

--- a/src/Host/Client/Impl/Host/NullRCallbacks.cs
+++ b/src/Host/Client/Impl/Host/NullRCallbacks.cs
@@ -34,7 +34,7 @@ namespace Microsoft.R.Host.Client.Host {
         public Task WebBrowser(string url, CancellationToken ct) => Task.CompletedTask;
         public Task ViewLibrary(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task ShowFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) => Task.CompletedTask;
-        public Task<string> EditFile(string expression, string fileName, CancellationToken cancellationToken) => Task.FromResult(string.Empty);
+        public Task<string> EditFileAsync(string expression, string fileName, CancellationToken cancellationToken) => Task.FromResult(string.Empty);
         public void DirectoryChanged() { }
         public Task ViewObject(string expression, string title, CancellationToken cancellationToken) => Task.CompletedTask;
         public void PackagesRemoved() {}

--- a/src/Host/Client/Impl/Host/RHost.cs
+++ b/src/Host/Client/Impl/Host/RHost.cs
@@ -526,7 +526,7 @@ namespace Microsoft.R.Host.Client {
                             case "?EditFile":
                                 message.ExpectArguments(2);
                                 // Opens file in editor and blocks until file is closed.
-                                var content = await _callbacks.EditFile(message.GetString(0, "name", allowNull: true), message.GetString(1, "file", allowNull: true), ct);
+                                var content = await _callbacks.EditFileAsync(message.GetString(0, "name", allowNull: true), message.GetString(1, "file", allowNull: true), ct);
                                 await RespondAsync(message, ct, content);
                                 break;
 

--- a/src/Host/Client/Impl/Program.cs
+++ b/src/Host/Client/Impl/Program.cs
@@ -125,7 +125,7 @@ namespace Microsoft.R.Host.Client {
         public async Task ShowFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) 
             => await Console.Error.WriteAsync(Invariant($"ShowFile({fileName}, {tabName}, {deleteFile})"));
 
-        public async Task<string> EditFile(string expression, string fileName, CancellationToken cancellationToken) { 
+        public async Task<string> EditFileAsync(string expression, string fileName, CancellationToken cancellationToken) { 
             await Console.Error.WriteAsync(Invariant($"EditFile({expression}, {fileName})"));
             return string.Empty;
         }

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -705,9 +705,9 @@ if (rtvs:::version != {rtvsPackageVersion}) {{
             return callback?.ViewFile(fileName, tabName, deleteFile, cancellationToken);
         }
 
-        Task<string> IRCallbacks.EditFile(string content, string fileName, CancellationToken cancellationToken) {
+        Task<string> IRCallbacks.EditFileAsync(string content, string fileName, CancellationToken cancellationToken) {
             var callback = _callback;
-            return callback?.EditFile(content, fileName, cancellationToken);
+            return callback?.EditFileAsync(content, fileName, cancellationToken);
         }
 
         void IRCallbacks.DirectoryChanged() {

--- a/src/Host/Client/Test/Script/RHostClientTestApp.cs
+++ b/src/Host/Client/Test/Script/RHostClientTestApp.cs
@@ -50,7 +50,7 @@ namespace Microsoft.R.Host.Client.Test.Script {
 
         public Task ViewFile(string fileName, string tabName, bool deleteFile, CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task<string> EditFile(string expression, string fileName, CancellationToken cancellationToken) => Task.FromResult(string.Empty);
+        public Task<string> EditFileAsync(string expression, string fileName, CancellationToken cancellationToken) => Task.FromResult(string.Empty);
 
         public Task<LocatorResult> Locator(Guid deviceId, CancellationToken ct) {
             if (LocatorHandler != null) {

--- a/src/Host/Client/Test/Stubs/RSessionCallbackStub.cs
+++ b/src/Host/Client/Test/Stubs/RSessionCallbackStub.cs
@@ -104,7 +104,7 @@ namespace Microsoft.R.Host.Client.Test.Stubs {
             return Task.CompletedTask;
         }
 
-        public Task<string> EditFile(string expression, string fileName, CancellationToken cancellationToken) {
+        public Task<string> EditFileAsync(string expression, string fileName, CancellationToken cancellationToken) {
             EditFileCalls.Add(new Tuple<string, string>(expression, fileName));
             EditFileHandler?.Invoke(expression, fileName);
             return Task.FromResult(string.Empty);

--- a/src/Package/Impl/DataInspect/Viewers/FileEditor.cs
+++ b/src/Package/Impl/DataInspect/Viewers/FileEditor.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core;
-using Microsoft.Common.Core.Shell;
+using Microsoft.Common.Core.Tasks;
 using Microsoft.R.Core.Formatting;
 using Microsoft.R.Editor.Settings;
 using Microsoft.R.Host.Client;
@@ -18,101 +18,114 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
     [Export(typeof(IFileEditor))]
-    internal sealed class FileEditor : IFileEditor, IVsWindowFrameEvents {
+    internal sealed class FileEditor : IFileEditor {
         private readonly IApplicationShell _appShell;
         private readonly IVsEditorAdaptersFactoryService _adapterService;
-        private IVsWindowFrame _editorFrame;
-        private ITextBuffer _textBuffer;
-        private IVsUIShell7 _uiShell;
-        private TaskCompletionSource<string> _tcs;
-        private uint _cookie;
 
         [ImportingConstructor]
         public FileEditor(IApplicationShell appShell, IVsEditorAdaptersFactoryService adapterService) {
             _appShell = appShell;
             _adapterService = adapterService;
-            _appShell.Terminating += OnAppTerminating;
         }
 
-        private void OnAppTerminating(object sender, EventArgs e) {
-            if (_cookie != 0) {
-                _uiShell?.UnadviseWindowFrameEvents(_cookie);
-                _cookie = 0;
-                _tcs?.SetCanceled();
-            }
-        }
+        public async Task<string> EditFileAsync(string content, string fileName, CancellationToken cancellationToken = default(CancellationToken)) {
+            await TaskUtilities.SwitchToBackgroundThread();
+            
+            if (!string.IsNullOrEmpty(content)) {
+                var formatter = new RFormatter(REditorSettings.FormatOptions);
+                content = formatter.Format(content);
 
-        public Task<string> EditFileAsync(string content, string fileName, CancellationToken cancellationToken = default(CancellationToken)) {
-            TaskUtilities.AssertIsOnBackgroundThread();
-            return Task.Run(async () => {
-                _tcs = new TaskCompletionSource<string>();
-
-                if (!string.IsNullOrEmpty(content)) {
-                    var formatter = new RFormatter(REditorSettings.FormatOptions);
-                    content = formatter.Format(content);
-
-                    var fs = _appShell.Services.FileSystem;
-                    fileName = Path.ChangeExtension(Path.GetTempFileName(), ".r");
-                    try {
-                        if (fs.FileExists(fileName)) {
-                            fs.DeleteFile(fileName);
-                        }
-                        using (var sw = new StreamWriter(fileName)) {
-                            sw.Write(content);
-                        }
-                    } catch (IOException) { } catch (UnauthorizedAccessException) { }
-                } else {
-                    fileName = fileName?.FromRPath();
-                }
-
-                if(!string.IsNullOrEmpty(fileName)) {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await _appShell.SwitchToMainThreadAsync(cancellationToken);
-
-                    IVsUIHierarchy hier;
-                    uint itemid;
-                    IVsTextView view;
-
-                    VsShellUtilities.OpenDocument(RPackage.Current, fileName, VSConstants.LOGVIEWID.Code_guid, out hier, out itemid, out _editorFrame, out view);
-                    if (view == null || _editorFrame == null) {
-                        return string.Empty;
+                var fs = _appShell.Services.FileSystem;
+                fileName = Path.ChangeExtension(Path.GetTempFileName(), ".r");
+                try {
+                    if (fs.FileExists(fileName)) {
+                        fs.DeleteFile(fileName);
                     }
-                    cancellationToken.ThrowIfCancellationRequested();
+                    using (var sw = new StreamWriter(fileName)) {
+                        sw.Write(content);
+                    }
+                } catch (IOException) { } catch (UnauthorizedAccessException) { }
+            } else {
+                fileName = fileName?.FromRPath();
+            }
 
-                    IVsTextLines vsTextLines;
-                    view.GetBuffer(out vsTextLines);
-                    _textBuffer = _adapterService.GetDataBuffer(vsTextLines as IVsTextBuffer);
+            if (!string.IsNullOrEmpty(fileName)) {
+                return await new FileEditorWindow(_appShell, _adapterService, fileName).ShowAsync(cancellationToken);
+            }
 
-                    _uiShell = _appShell.GetGlobalService<IVsUIShell7>(typeof(SVsUIShell));
-                    _cookie = _uiShell.AdviseWindowFrameEvents(this);
+            return string.Empty;
+        }
 
-                    await TaskUtilities.SwitchToBackgroundThread();
-                    cancellationToken.ThrowIfCancellationRequested();
+        private class FileEditorWindow : IVsWindowFrameEvents {
+            private readonly IApplicationShell _appShell;
+            private readonly IVsEditorAdaptersFactoryService _adapterService;
+            private readonly string _fileName;
+            private IVsWindowFrame _editorFrame;
+            private ITextBuffer _textBuffer;
+            private IVsUIShell7 _uiShell;
+            private TaskCompletionSource<string> _tcs;
+            private uint _cookie;
 
-                    return await _tcs.Task;
+            public FileEditorWindow(IApplicationShell appShell, IVsEditorAdaptersFactoryService adapterService, string fileName) {
+                _appShell = appShell;
+                _adapterService = adapterService;
+                _fileName = fileName;
+                _appShell.Terminating += OnAppTerminating;
+            }
+
+            public Task<string> ShowAsync(CancellationToken cancellationToken) {
+                _tcs = new TaskCompletionSource<string>();
+                _tcs.RegisterForCancellation(cancellationToken)
+                    .UnregisterOnCompletion(_tcs.Task);
+
+                _appShell.DispatchOnUIThread(Show);
+                return _tcs.Task;
+            }
+
+            private void Show() {
+                IVsUIHierarchy hier;
+                uint itemid;
+                IVsTextView view;
+
+                VsShellUtilities.OpenDocument(RPackage.Current, _fileName, VSConstants.LOGVIEWID.Code_guid, out hier, out itemid, out _editorFrame, out view);
+                if (view == null || _editorFrame == null) {
+                    _tcs.TrySetResult(string.Empty);
+                    return;
                 }
 
-                return string.Empty;
-            }, cancellationToken);
-        }
+                IVsTextLines vsTextLines;
+                view.GetBuffer(out vsTextLines);
+                _textBuffer = _adapterService.GetDataBuffer(vsTextLines);
 
-        #region IVsWindowFrameEvents
-        public void OnFrameDestroyed(IVsWindowFrame frame) {
-            if (frame == _editorFrame) {
-                _uiShell.UnadviseWindowFrameEvents(_cookie);
-                _cookie = 0;
-                _tcs?.SetResult(_textBuffer.CurrentSnapshot.GetText());
+                _uiShell = _appShell.GetGlobalService<IVsUIShell7>(typeof(SVsUIShell));
+                _cookie = _uiShell.AdviseWindowFrameEvents(this);
             }
-        }
 
-        public void OnFrameCreated(IVsWindowFrame frame) { }
-        public void OnFrameIsVisibleChanged(IVsWindowFrame frame, bool newIsVisible) { }
-        public void OnFrameIsOnScreenChanged(IVsWindowFrame frame, bool newIsOnScreen) { }
-        public void OnActiveFrameChanged(IVsWindowFrame oldFrame, IVsWindowFrame newFrame) { }
-        #endregion
+            private void OnAppTerminating(object sender, EventArgs e) {
+                if (_cookie != 0) {
+                    _uiShell?.UnadviseWindowFrameEvents(_cookie);
+                    _cookie = 0;
+                    _tcs?.TrySetCanceled();
+                }
+            }
+
+            #region IVsWindowFrameEvents
+            public void OnFrameDestroyed(IVsWindowFrame frame) {
+                if (frame == _editorFrame) {
+                    _uiShell.UnadviseWindowFrameEvents(_cookie);
+                    _cookie = 0;
+                    _tcs?.TrySetResult(_textBuffer.CurrentSnapshot.GetText());
+                }
+            }
+
+            public void OnFrameCreated(IVsWindowFrame frame) { }
+            public void OnFrameIsVisibleChanged(IVsWindowFrame frame, bool newIsVisible) { }
+            public void OnFrameIsOnScreenChanged(IVsWindowFrame frame, bool newIsOnScreen) { }
+            public void OnActiveFrameChanged(IVsWindowFrame oldFrame, IVsWindowFrame newFrame) { }
+            #endregion
+        }        
     }
 }

--- a/src/R/Components/Impl/InteractiveWorkflow/Implementation/RSessionCallback.cs
+++ b/src/R/Components/Impl/InteractiveWorkflow/Implementation/RSessionCallback.cs
@@ -125,7 +125,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             }
         }
 
-        public async Task<string> EditFile(string content, string fileName, CancellationToken cancellationToken = default(CancellationToken)) {
+        public async Task<string> EditFileAsync(string content, string fileName, CancellationToken cancellationToken = default(CancellationToken)) {
             TaskUtilities.AssertIsOnBackgroundThread();
             var editor = _coreShell.ExportProvider.GetExportedValue<IFileEditor>();
 


### PR DESCRIPTION
- Rename `EditFile` into `EditFileAsync`
- Extract `FileEditor. _cookie` and `FileEditor. _tcs` into separate class to avoid concurrent access
- Register `FileEditor. _tcs` for cancellation
- Remove unnecessary `Task.Run`