### PR TITLE
#2610 #3356

### DIFF
--- a/src/Common/Core/Impl/Security/CredentialHandle.cs
+++ b/src/Common/Core/Impl/Security/CredentialHandle.cs
@@ -4,6 +4,8 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using Microsoft.Common.Core.OS;
+using Microsoft.Common.Core.Shell;
 using Microsoft.Win32.SafeHandles;
 using static Microsoft.Common.Core.NativeMethods;
 
@@ -31,7 +33,7 @@ namespace Microsoft.Common.Core {
             throw new InvalidOperationException(Resources.Error_CredentialHandleInvalid);
         }
 
-        public static CredentialHandle ReadFromCredentialManager(string authority) {
+        public static CredentialHandle ReadFromCredentialManager(string authority, ICoreShell coreShell) {
             IntPtr creds;
             if (CredRead(authority, CRED_TYPE.GENERIC, 0, out creds)) {
                 return new CredentialHandle(creds);
@@ -40,7 +42,7 @@ namespace Microsoft.Common.Core {
                 // if credentials were not found then continue to prompt user for credentials.
                 // otherwise there was an error while reading credentials. 
                 if (error != ERROR_NOT_FOUND) {
-                    throw new Win32Exception(error, Resources.Error_CredReadFailed);
+                    coreShell.ShowErrorMessage(Resources.Error_CredReadFailed + " " + ErrorCodeConverter.MessageFromErrorCode(error));
                 }
             }
 

--- a/src/Common/Core/Impl/Security/CredentialHandle.cs
+++ b/src/Common/Core/Impl/Security/CredentialHandle.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.ComponentModel;
 using System.Runtime.InteropServices;
 using Microsoft.Common.Core.OS;
-using Microsoft.Common.Core.Shell;
 using Microsoft.Win32.SafeHandles;
 using static Microsoft.Common.Core.NativeMethods;
+using static System.FormattableString;
 
 namespace Microsoft.Common.Core {
     internal sealed class CredentialHandle : CriticalHandleZeroOrMinusOneIsInvalid {
@@ -33,7 +32,7 @@ namespace Microsoft.Common.Core {
             throw new InvalidOperationException(Resources.Error_CredentialHandleInvalid);
         }
 
-        public static CredentialHandle ReadFromCredentialManager(string authority, ICoreShell coreShell) {
+        internal static CredentialHandle ReadFromCredentialManager(string authority) {
             IntPtr creds;
             if (CredRead(authority, CRED_TYPE.GENERIC, 0, out creds)) {
                 return new CredentialHandle(creds);
@@ -42,10 +41,10 @@ namespace Microsoft.Common.Core {
                 // if credentials were not found then continue to prompt user for credentials.
                 // otherwise there was an error while reading credentials. 
                 if (error != ERROR_NOT_FOUND) {
-                    coreShell.ShowErrorMessage(Resources.Error_CredReadFailed + " " + ErrorCodeConverter.MessageFromErrorCode(error));
+                    Win32MessageBox.Show(IntPtr.Zero, Invariant($"{Common.Core.Resources.Error_CredReadFailed} {ErrorCodeConverter.MessageFromErrorCode(error)}"), 
+                         Win32MessageBox.Flags.OkOnly | Win32MessageBox.Flags.Topmost | Win32MessageBox.Flags.TaskModal);
                 }
             }
-
             return null;
         }
     }

--- a/src/Common/Core/Impl/Security/SecurityService.cs
+++ b/src/Common/Core/Impl/Security/SecurityService.cs
@@ -23,9 +23,7 @@ namespace Microsoft.Common.Core.Security {
 
         public Credentials GetUserCredentials(string authority, string workspaceName, CancellationToken cancellationToken = default(CancellationToken)) {
             _coreShell.AssertIsOnMainThread();
-
-            var credentials = Credentials.ReadSavedCredentials(authority) ?? GetUserCredentials(workspaceName, cancellationToken);
-            return credentials;
+            return Credentials.ReadSavedCredentials(authority) ?? GetUserCredentials(workspaceName, cancellationToken);
         }
 
         private Credentials GetUserCredentials(string workspaceName, CancellationToken cancellationToken) {
@@ -90,7 +88,7 @@ namespace Microsoft.Common.Core.Security {
                 // is in modal state due to the progress dialog. Note that native message
                 // box appearance is a bit different from VS dialogs and matches OS theme
                 // rather than VS fonts and colors.
-                if (Win32MessageBox.Show(_coreShell.AppConstants.ApplicationWindowHandle, message, 
+                if (Win32MessageBox.Show(_coreShell.AppConstants.ApplicationWindowHandle, message,
                     Win32MessageBox.Flags.YesNo | Win32MessageBox.Flags.IconWarning) == Win32MessageBox.Result.Yes) {
                     certificate2.Reset();
                     return true;

--- a/src/Host/Client/Impl/Host/RemoteBrokerClient.cs
+++ b/src/Host/Client/Impl/Host/RemoteBrokerClient.cs
@@ -31,7 +31,7 @@ namespace Microsoft.R.Host.Client.Host {
         }
 
         public RemoteBrokerClient(string name, BrokerConnectionInfo connectionInfo, ICoreServices services, IConsole console, CancellationToken cancellationToken)
-            : base(name, connectionInfo, new RemoteCredentialsDecorator(connectionInfo.CredentialAuthority, connectionInfo.Name, services.Security, services.MainThread), services.Log, console) {
+            : base(name, connectionInfo, new RemoteCredentialsDecorator(connectionInfo.CredentialAuthority, connectionInfo.Name, services.Security, services.MainThread, console), services.Log, console) {
             _console = console;
             _services = services;
             _cancellationToken = cancellationToken;

--- a/src/Package/Impl/Expansions/ExpansionClient.cs
+++ b/src/Package/Impl/Expansions/ExpansionClient.cs
@@ -5,7 +5,12 @@ using System.Collections.Generic;
 using Microsoft.Common.Core;
 using Microsoft.Languages.Core.Text;
 using Microsoft.Languages.Editor.Extensions;
+using Microsoft.Languages.Editor.Text;
 using Microsoft.R.Components.Extensions;
+using Microsoft.R.Core.AST.Expressions;
+using Microsoft.R.Core.AST.Scopes;
+using Microsoft.R.Core.Parser;
+using Microsoft.R.Core.Tokens;
 using Microsoft.R.Editor;
 using Microsoft.R.Editor.Document;
 using Microsoft.R.Editor.Formatting;
@@ -171,10 +176,20 @@ namespace Microsoft.VisualStudio.R.Package.Expansions {
             if (ErrorHandler.Succeeded(vsTextLines.GetPositionOfLineIndex(ts[0].iStartLine, ts[0].iStartIndex, out startPos)) &&
                 ErrorHandler.Succeeded(vsTextLines.GetPositionOfLineIndex(ts[0].iEndLine, ts[0].iEndIndex, out endPos))) {
                 var textBuffer = vsTextLines.ToITextBuffer();
-                RangeFormatter.FormatRange(TextView, textBuffer, TextRange.FromBounds(startPos, endPos), REditorSettings.FormatOptions, VsAppShell.Current);
+                var range = TextRange.FromBounds(startPos, endPos);
+                // Do not format standalone operators
+                var text = textBuffer.CurrentSnapshot.GetText(range.ToSpan());
+                if (CanFormat(text)) {
+                    RangeFormatter.FormatRange(TextView, textBuffer, range, REditorSettings.FormatOptions, VsAppShell.Current);
+                }
             }
             return hr;
         }
+
+        private bool CanFormat(string text) {
+            var tokens = (new RTokenizer()).Tokenize(text);
+            return tokens.Count != 1 || tokens[0].TokenType != RTokenType.Operator;
+       }
 
         public int GetExpansionFunction(MSXML.IXMLDOMNode xmlFunctionNode, string bstrFieldName, out IVsExpansionFunction pFunc) {
             pFunc = null;

--- a/src/Package/Impl/Expansions/ExpansionClient.cs
+++ b/src/Package/Impl/Expansions/ExpansionClient.cs
@@ -2,14 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.Common.Core;
 using Microsoft.Languages.Core.Text;
 using Microsoft.Languages.Editor.Extensions;
 using Microsoft.Languages.Editor.Text;
 using Microsoft.R.Components.Extensions;
-using Microsoft.R.Core.AST.Expressions;
-using Microsoft.R.Core.AST.Scopes;
-using Microsoft.R.Core.Parser;
 using Microsoft.R.Core.Tokens;
 using Microsoft.R.Editor;
 using Microsoft.R.Editor.Document;

--- a/src/Package/Impl/ProjectSystem/PropertyPages/Run/RunPageControl.xaml
+++ b/src/Package/Impl/ProjectSystem/PropertyPages/Run/RunPageControl.xaml
@@ -46,7 +46,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition />
             </Grid.ColumnDefinitions>
-            <Label Grid.Column="0" x:Uid="StartupFileLabel" Content="Startup file" Target="{Binding ElementName=txtStartupFile}" />
+            <Label Grid.Column="0" x:Uid="StartupFileLabel" Content="Startup file" Target="{Binding ElementName=txtStartupFile, Mode=OneWay}" />
             <TextBlock Grid.Column="1" Text=":"/>
             <ComboBox Grid.Column="2" SelectedItem="{Binding Path=StartupFile, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ItemsSource="{Binding Path=RFilePaths}"/>
         </Grid>
@@ -69,12 +69,12 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <Label Grid.Column="0" x:Uid="RemoteProjectPathLabel" Content="Remote Project Path" Target="{Binding ElementName=txtRemoteProjectPath}" />
+            <Label Grid.Column="0" x:Uid="RemoteProjectPathLabel" Content="Remote Project Path" Target="{Binding ElementName=txtRemoteProjectPath, Mode=OneWay}" />
             <TextBlock Grid.Column="1" Text=":" />
             <TextBox Grid.Column="2" x:Name="txtRemoteProjectPath" Text="{Binding Path=RemoteProjectPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             <TextBlock Grid.Row="1" Grid.Column="2" >
-                <Run Text="{Binding ElementName=txtRemoteProjectPath, Path=Text, UpdateSourceTrigger=PropertyChanged}"/>
-                <Run Text="{Binding Path=ProjectName}"/>
+                <Run Text="{Binding ElementName=txtRemoteProjectPath, Path=Text, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"/>
+                <Run Text="{Binding Path=ProjectName, Mode=OneWay}"/>
             </TextBlock>
         </Grid>
 
@@ -92,7 +92,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition />
             </Grid.ColumnDefinitions>
-            <Label Grid.Column="0" x:Uid="TransferFilesFilterLabel" Content="Files to transfer" Target="{Binding ElementName=txtTransferFilesFilter}" />
+            <Label Grid.Column="0" x:Uid="TransferFilesFilterLabel" Content="Files to transfer" Target="{Binding ElementName=txtTransferFilesFilter, Mode=OneWay}" />
             <Label Grid.Column="1" Content=":" />
             <TextBox Grid.Column="2" x:Name="txtTransferFilesFilter" Text="{Binding Path=TransferFilesFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         </Grid>

--- a/src/Package/Impl/ProjectSystem/PropertyPages/Run/RunPageViewModel.cs
+++ b/src/Package/Impl/ProjectSystem/PropertyPages/Run/RunPageViewModel.cs
@@ -54,12 +54,12 @@ namespace Microsoft.VisualStudio.R.Package.ProjectSystem.PropertyPages {
 
         public IEnumerable<string> RFilePaths {
             get { return _rFilePaths; }
-            private set { OnPropertyChanged(ref _rFilePaths, value); }
+            set { OnPropertyChanged(ref _rFilePaths, value); }
         }
 
         public string ProjectName {
             get { return _projectName; }
-            private set { OnPropertyChanged(ref _projectName, value); }
+            set { OnPropertyChanged(ref _projectName, value); }
         }
 
         public async override Task Initialize() {


### PR DESCRIPTION
#3356 Crash on create new remote workspace 
- We really should not be throwing Win32 exceptions. Complete rework is out of question in Release/1_0 so I plumbed console output in one place and direct message box in another. Unfortunately, passing down ICoreShell is way too big change. Also, UI is frozen for localization, so reusing message from Core.

#2610 Snippets are not respecting trailing spaces 
- just check for standalone operator and bypass formatting