### PR TITLE
#3426 VS2015+RTVS on Win 10 not setting working directory of a project 

### DIFF
--- a/src/Common/Core/Impl/Diagnostics/Check.cs
+++ b/src/Common/Core/Impl/Diagnostics/Check.cs
@@ -25,6 +25,15 @@ namespace Microsoft.Common.Core.Diagnostics {
             }
         }
 
+        public static void Argument(string argumentName, Func<bool> predicate, string message = null) {
+            if (predicate()) {
+                if (string.IsNullOrEmpty(message)) {
+                    throw new ArgumentException(argumentName);
+                }
+                throw new ArgumentException(argumentName, message);
+            }
+        }
+
         public static void InvalidOperation(Func<bool> predicate) {
             if (predicate()) {
                 throw new InvalidOperationException();

--- a/src/Common/Core/Impl/Extensions/IOExtensions.cs
+++ b/src/Common/Core/Impl/Extensions/IOExtensions.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Security.AccessControl;
 using System.Security.Principal;
+using Microsoft.Common.Core.Diagnostics;
 using Microsoft.Common.Core.IO;
 
 namespace Microsoft.Common.Core {
@@ -20,6 +21,20 @@ namespace Microsoft.Common.Core {
                 return string.Empty;
             }
             return path.StartsWithIgnoreCase(bp) ? path.Substring(bp.Length) : path;
+        }
+
+        // TODO: merge with above
+        public static string MakeCompleteRelativePath(this string path, string basePath) {
+            Check.Argument(nameof(path), () => !Path.IsPathRooted(path), "Path must be rooted");
+            Check.Argument(nameof(basePath), () => !Path.IsPathRooted(basePath), "Path must be rooted");
+
+            var baseUri = new Uri(basePath.EnsureTrailingSlash());
+            var destinationUri = new Uri(path.EnsureTrailingSlash());
+            var relativeFolderPath = Uri.UnescapeDataString(baseUri.MakeRelativeUri(destinationUri).ToString());
+            if (string.IsNullOrEmpty(relativeFolderPath)) {
+                return @".";
+            }
+            return relativeFolderPath.Replace('/', '\\').TrimEnd('\\');
         }
 
         public static bool ExistsOnPath(string fileName) {

--- a/src/Common/Core/Test/Extensions/IOExtensionsTest.cs
+++ b/src/Common/Core/Test/Extensions/IOExtensionsTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using Microsoft.UnitTests.Core.XUnit;
@@ -25,6 +26,33 @@ namespace Microsoft.Common.Core.Test.Extensions {
         [InlineData("", "", "")]
         public void MakeRelativePath(string path, string basePath, string expected) {
             path.MakeRelativePath(basePath).Should().Be(expected);
+        }
+
+        [CompositeTest]
+        [InlineData(@"C:\foo", @"C:\", "foo")]
+        [InlineData(@"C:\foo", @"C:\foo", ".")]
+        [InlineData(@"C:\foo", @"C:\foo\", ".")]
+        [InlineData(@"C:\foo\", @"C:\foo", ".")]
+        [InlineData(@"C:\", @"c:\foo", "..")]
+        [InlineData(@"C:\foo", @"c:\bar", @"..\foo")]
+        [InlineData(@"C:\abc\def.x", @"c:\abc\", @"def.x")]
+        [InlineData(@"C:\abc\def.x\", @"c:\abc\", @"def.x")]
+        [InlineData(@"c:\abc\def", @"c:\a\b", @"..\..\abc\def")]
+        public void MakeCompleteRelativePath01(string path, string basePath, string expected) {
+            path.MakeCompleteRelativePath(basePath).Should().Be(expected);
+        }
+        [CompositeTest]
+        [InlineData("", "")]
+        [InlineData(".", "")]
+        [InlineData(".", ".")]
+        [InlineData(@".\", ".")]
+        [InlineData(".", @".\")]
+        [InlineData(@".\", @".\")]
+        [InlineData("", @"C:\\")]
+        [InlineData(@"C:\", "")]
+        public void MakeCompleteRelativePath02(string path, string basePath) {
+            Action a = () => path.MakeCompleteRelativePath(basePath);
+            a.ShouldThrow<ArgumentException>();
         }
     }
 }

--- a/src/Host/Client/Impl/Blobs/DataTransferSession.cs
+++ b/src/Host/Client/Impl/Blobs/DataTransferSession.cs
@@ -37,7 +37,7 @@ namespace Microsoft.R.Host.Client {
         /// </param>
         public async Task<IRBlobInfo> SendBytesAsync(byte[] data, bool doCleanUp, IProgress<long> progress, CancellationToken cancellationToken) {
             IRBlobInfo blob = null;
-            using (RBlobStream blobStream = await RBlobStream.CreateAsync(_blobService))
+            using (RBlobStream blobStream = await RBlobStream.CreateAsync(_blobService, cancellationToken))
             using (Stream ms = new MemoryStream(data)) {
                 await ms.CopyToAsync(blobStream, progress, cancellationToken);
                 blob = blobStream.GetBlobInfo();
@@ -58,7 +58,7 @@ namespace Microsoft.R.Host.Client {
         /// </param>
         public async Task<IRBlobInfo> SendFileAsync(string filePath, bool doCleanUp, IProgress<long> progress, CancellationToken cancellationToken) {
             IRBlobInfo blob = null;
-            using (RBlobStream blobStream = await RBlobStream.CreateAsync(_blobService))
+            using (RBlobStream blobStream = await RBlobStream.CreateAsync(_blobService, cancellationToken))
             using (Stream fileStream = _fs.FileOpen(filePath, FileMode.Open)){
                 await fileStream.CopyToAsync(blobStream, progress, cancellationToken);
                 blob = blobStream.GetBlobInfo();
@@ -78,7 +78,7 @@ namespace Microsoft.R.Host.Client {
         /// <param name="filePath">Path to the file where the retrieved data will be written.</param>
         /// <param name="doCleanUp">true to add blob upon transfer for cleanup on dispose, false to ignore it after transfer.</param>
         public async Task FetchFileAsync(IRBlobInfo blob, string filePath, bool doCleanUp, IProgress<long> progress, CancellationToken cancellationToken) {
-            using (RBlobStream blobStream = await RBlobStream.OpenAsync(blob, _blobService))
+            using (RBlobStream blobStream = await RBlobStream.OpenAsync(blob, _blobService, cancellationToken))
             using (Stream fileStream = _fs.CreateFile(filePath)) {
                 await blobStream.CopyToAsync(fileStream, progress, cancellationToken);
             }

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -204,10 +204,13 @@ export_to_pdf <- function(device_id, plot_id, width, height) {
 }
 
 # Helper to publish rmarkdown files remotely
-rmarkdown_publish <- function(blob_id, output_format, encoding) {
+rmarkdown_publish <- function(work_folder, blob_id, output_format, encoding) {
     # Create temp file to store the rmarkdown file
-    rmdpath <- tempfile('rmd_', fileext = '.rmd');
-    on.exit(unlink(rmdpath));
+    work_folder <- normalizePath(work_folder);
+    rmdpath <- tempfile('rmd_', tmpdir = work_folder, fileext = '.rmd');
+    message(paste0('Input: ', rmdpath));
+
+    on.exit(file.remove(rmdpath));
     writeBin(get_blob(blob_id), rmdpath);
 
     # Get file extension from format
@@ -222,10 +225,11 @@ rmarkdown_publish <- function(blob_id, output_format, encoding) {
     }
 
     # Create temp file to store the markdown render output
-    output_filepath <- tempfile('rmd_', fileext = fileext);
-    on.exit(unlink(output_filepath));
+    output_filepath <- tempfile('rmd_', tmpdir = work_folder, fileext = fileext);
+    message(paste0('Output: ', output_filepath));
+    on.exit(file.remove(output_filepath));
 
-    rmarkdown::render(rmdpath, output_format = output_format, output_file = output_filepath, output_dir = tempdir(), encoding = encoding);
+    rmarkdown::render(rmdpath, output_format = output_format, output_file = output_filepath, output_dir = work_folder, encoding = encoding);
     create_blob(readBin(output_filepath, 'raw', file.info(output_filepath)$size));
 }
 

--- a/src/Host/Client/Impl/rtvs/R/util.R
+++ b/src/Host/Client/Impl/rtvs/R/util.R
@@ -206,9 +206,15 @@ export_to_pdf <- function(device_id, plot_id, width, height) {
 # Helper to publish rmarkdown files remotely
 rmarkdown_publish <- function(work_folder, blob_id, output_format, encoding) {
     # Create temp file to store the rmarkdown file
-    work_folder <- normalizePath(work_folder);
+    if(identical(work_folder, '')) {
+        work_folder <- tempdir();
+    } else {
+        work_folder <- normalizePath(work_folder);
+    }
+
     input_path <- tempfile('rmd_', tmpdir = work_folder, fileext = '.rmd');
     writeBin(get_blob(blob_id), input_path);
+    on.exit(file.remove(input_path), add = TRUE);
 
     # Get file extension from format
     fileext <- if (identical(output_format, 'html_document')) {
@@ -223,14 +229,10 @@ rmarkdown_publish <- function(work_folder, blob_id, output_format, encoding) {
 
     # Create temp file to store the markdown render output
     output_filepath <- tempfile('rmd_', tmpdir = work_folder, fileext = fileext);
+    on.exit(file.remove(output_filepath), add = TRUE);
 
     rmarkdown::render(input_path, output_format = output_format, output_file = output_filepath, output_dir = work_folder, encoding = encoding);
-    blob_id <- create_blob(readBin(output_filepath, 'raw', file.info(output_filepath)$size));
-
-    file.remove(input_path);
-    file.remove(output_filepath);
-
-    return(blob_id);
+    create_blob(readBin(output_filepath, 'raw', file.info(output_filepath)$size));
 }
 
 as.lock_state <- function(x) {

--- a/src/Package/Impl/Publishing/Handlers/RmdPublishHandler.cs
+++ b/src/Package/Impl/Publishing/Handlers/RmdPublishHandler.cs
@@ -13,8 +13,10 @@ using Microsoft.Common.Core.Shell;
 using Microsoft.Markdown.Editor.Flavor;
 using Microsoft.R.Host.Client;
 using Microsoft.R.Host.Client.Session;
+using Microsoft.VisualStudio.R.Package.ProjectSystem;
 using Microsoft.VisualStudio.R.Package.Publishing.Definitions;
 using Microsoft.VisualStudio.R.Package.Shell;
+using Microsoft.VisualStudio.R.Package.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.R.Package.Publishing {
@@ -33,7 +35,7 @@ namespace Microsoft.VisualStudio.R.Package.Publishing {
             return true;
         }
 
-        public async Task PublishAsync(IRSession session, IApplicationShell appShell,  IFileSystem fs, string inputFilePath, string outputFilePath, PublishFormat publishFormat, Encoding encoding) {
+        public async Task PublishAsync(IRSession session, IApplicationShell appShell, IFileSystem fs, string inputFilePath, string outputFilePath, PublishFormat publishFormat, Encoding encoding) {
             try {
                 await RMarkdownRenderAsync(session, fs, inputFilePath, outputFilePath, GetDocumentTypeString(publishFormat), encoding.CodePage, appShell);
             } catch (IOException ex) {
@@ -41,7 +43,7 @@ namespace Microsoft.VisualStudio.R.Package.Publishing {
             } catch (RException ex) {
                 await appShell.ShowErrorMessageAsync(ex.Message);
             } catch (OperationCanceledException) {
-            } 
+            }
         }
 
         private async Task RMarkdownRenderAsync(IRSession session, IFileSystem fs, string inputFilePath, string outputFilePath, string format, int codePage, IApplicationShell appShell) {
@@ -49,12 +51,10 @@ namespace Microsoft.VisualStudio.R.Package.Publishing {
             // folder in local and remote. Pass resolved path down to R so it can create
             // files from blobs in the appropriate folder.
             // See also https://github.com/Microsoft/RTVS/issues/3426
-            var wd = await session.GetWorkingDirectoryAsync();
-            var inputFileFolder = Path.GetDirectoryName(inputFilePath);
-            var relativeFolderPath = inputFileFolder.MakeCompleteRelativePath(wd).ToRPath();
+            var workFolderPath = await GetWorkFolderAsync(inputFilePath, session, appShell);
 
             using (var fts = new DataTransferSession(session, fs)) {
-                string currentStatusText = string.Empty;
+                var currentStatusText = string.Empty;
                 uint cookie = 0;
                 IVsStatusbar statusBar = null;
                 appShell.DispatchOnUIThread(() => {
@@ -62,13 +62,13 @@ namespace Microsoft.VisualStudio.R.Package.Publishing {
                     statusBar.GetText(out currentStatusText);
                     statusBar.Progress(ref cookie, 1, "", 0, 0);
                 });
-                
+
                 try {
                     // TODO: progress and cancellation handling
                     appShell.DispatchOnUIThread(() => { statusBar?.Progress(ref cookie, 1, Resources.Info_MarkdownSendingInputFile.FormatInvariant(Path.GetFileName(inputFilePath)), 0, 3); });
                     var rmd = await fts.SendFileAsync(inputFilePath, true, null, CancellationToken.None);
                     appShell.DispatchOnUIThread(() => { statusBar?.Progress(ref cookie, 1, Resources.Info_MarkdownPublishingFile.FormatInvariant(Path.GetFileName(inputFilePath)), 1, 3); });
-                    var publishResult = await session.EvaluateAsync<ulong>($"rtvs:::rmarkdown_publish(work_folder = {relativeFolderPath.ToRStringLiteral()}, blob_id = {rmd.Id}, output_format = {format.ToRStringLiteral()}, encoding = 'cp{codePage}')", REvaluationKind.Normal);
+                    var publishResult = await session.EvaluateAsync<ulong>($"rtvs:::rmarkdown_publish(work_folder = {workFolderPath.ToRStringLiteral()}, blob_id = {rmd.Id}, output_format = {format.ToRStringLiteral()}, encoding = 'cp{codePage}')", REvaluationKind.Normal);
                     appShell.DispatchOnUIThread(() => { statusBar?.Progress(ref cookie, 1, Resources.Info_MarkdownGetOutputFile.FormatInvariant(Path.GetFileName(outputFilePath)), 2, 3); });
                     await fts.FetchFileAsync(new RBlobInfo(publishResult), outputFilePath, true, null, CancellationToken.None);
                     appShell.DispatchOnUIThread(() => { statusBar?.Progress(ref cookie, 1, Resources.Info_MarkdownPublishComplete.FormatInvariant(Path.GetFileName(outputFilePath)), 3, 3); });
@@ -91,6 +91,27 @@ namespace Microsoft.VisualStudio.R.Package.Publishing {
             }
 
             return "html_document";
+        }
+
+        private async Task<string> GetWorkFolderAsync(string inputFilePath, IRSession session, IApplicationShell shell) {
+            await shell.SwitchToMainThreadAsync();
+
+            string workFolderPath = string.Empty;
+            var localFolderPath = Path.GetDirectoryName(inputFilePath);
+
+            if (session.IsRemote) {
+                IVsHierarchy hier;
+                uint itemid;
+                if (ProjectUtilities.TryGetHierarchy(inputFilePath, out hier, out itemid)) {
+                    var configuredProject = hier.GetConfiguredProject();
+                    workFolderPath = await configuredProject.GetRemotePathAsync(localFolderPath);
+                }
+            } else {
+                var wd = await session.GetWorkingDirectoryAsync();
+                workFolderPath = localFolderPath.MakeCompleteRelativePath(wd);
+            }
+
+            return workFolderPath.ToRPath().Trim('/');
         }
     }
 }

--- a/src/Package/Impl/Publishing/Handlers/RmdPublishHandler.cs
+++ b/src/Package/Impl/Publishing/Handlers/RmdPublishHandler.cs
@@ -12,6 +12,7 @@ using Microsoft.Common.Core.IO;
 using Microsoft.Common.Core.Shell;
 using Microsoft.Markdown.Editor.Flavor;
 using Microsoft.R.Host.Client;
+using Microsoft.R.Host.Client.Session;
 using Microsoft.VisualStudio.R.Package.Publishing.Definitions;
 using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -44,6 +45,14 @@ namespace Microsoft.VisualStudio.R.Package.Publishing {
         }
 
         private async Task RMarkdownRenderAsync(IRSession session, IFileSystem fs, string inputFilePath, string outputFilePath, string format, int codePage, IApplicationShell appShell) {
+            // Resolve path to ~/ so files created via blobs are saved in the same relative
+            // folder in local and remote. Pass resolved path down to R so it can create
+            // files from blobs in the appropriate folder.
+            // See also https://github.com/Microsoft/RTVS/issues/3426
+            var wd = await session.GetWorkingDirectoryAsync();
+            var inputFileFolder = Path.GetDirectoryName(inputFilePath);
+            var relativeFolderPath = inputFileFolder.MakeCompleteRelativePath(wd).ToRPath();
+
             using (var fts = new DataTransferSession(session, fs)) {
                 string currentStatusText = string.Empty;
                 uint cookie = 0;
@@ -59,7 +68,7 @@ namespace Microsoft.VisualStudio.R.Package.Publishing {
                     appShell.DispatchOnUIThread(() => { statusBar?.Progress(ref cookie, 1, Resources.Info_MarkdownSendingInputFile.FormatInvariant(Path.GetFileName(inputFilePath)), 0, 3); });
                     var rmd = await fts.SendFileAsync(inputFilePath, true, null, CancellationToken.None);
                     appShell.DispatchOnUIThread(() => { statusBar?.Progress(ref cookie, 1, Resources.Info_MarkdownPublishingFile.FormatInvariant(Path.GetFileName(inputFilePath)), 1, 3); });
-                    var publishResult = await session.EvaluateAsync<ulong>($"rtvs:::rmarkdown_publish(blob_id = {rmd.Id}, output_format = {format.ToRStringLiteral()}, encoding = 'cp{codePage}')", REvaluationKind.Normal);
+                    var publishResult = await session.EvaluateAsync<ulong>($"rtvs:::rmarkdown_publish(work_folder = {relativeFolderPath.ToRStringLiteral()}, blob_id = {rmd.Id}, output_format = {format.ToRStringLiteral()}, encoding = 'cp{codePage}')", REvaluationKind.Normal);
                     appShell.DispatchOnUIThread(() => { statusBar?.Progress(ref cookie, 1, Resources.Info_MarkdownGetOutputFile.FormatInvariant(Path.GetFileName(outputFilePath)), 2, 3); });
                     await fts.FetchFileAsync(new RBlobInfo(publishResult), outputFilePath, true, null, CancellationToken.None);
                     appShell.DispatchOnUIThread(() => { statusBar?.Progress(ref cookie, 1, Resources.Info_MarkdownPublishComplete.FormatInvariant(Path.GetFileName(outputFilePath)), 3, 3); });

--- a/src/Package/Impl/Utilities/VsUIShellExtensions.cs
+++ b/src/Package/Impl/Utilities/VsUIShellExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.R.Package.Utilities {
         public static bool TryGetUiHierarchy(this IVsUIShellOpenDocument shellDoc, string filePath, out IVsUIHierarchy uiHier, out uint vsItemId, out OLE.Interop.IServiceProvider sp) {
             int docInProject;
             var hr = shellDoc.IsDocumentInAProject(filePath, out uiHier, out vsItemId, out sp, out docInProject);
-            return ErrorHandler.Succeeded(hr) && uiHier != null;
+            return ErrorHandler.Succeeded(hr) && uiHier != null && docInProject == (int)__VSDOCINPROJECT.DOCINPROJ_DocInProject;
         }
 
         /// <summary>


### PR DESCRIPTION
The problem: we use TEMP path in local and remote. This breaks workflow when markdown has R code that sources files or reads CSV - basically any operation that involves paths.

Fix: provide work folder to the publishing code. 

1. Standalone file: use TEMP as before.
2. Project: work folder path is relative to the current working directory. Handle remote mapping as well.

```
source('./script.R') # x <- c(1:10)
```

```
plot(x)
```

work correctly in local and remote as long as file is in project.