### PR TITLE
Fix Variable Explorer accessibility

### DIFF
--- a/src/Common/Wpf/Impl/Extensions/VisualTreeExtensions.cs
+++ b/src/Common/Wpf/Impl/Extensions/VisualTreeExtensions.cs
@@ -26,6 +26,34 @@ namespace Microsoft.Common.Wpf.Extensions {
             return null;
         }
 
+        public static T GetParentOfType<T>(this DependencyObject o) where T : DependencyObject {
+            while (o != null) {
+                var parent = VisualTreeHelper.GetParent(o);
+                var typedParent = parent as T;
+                if (typedParent != null) {
+                    return typedParent;
+                }
+                o = parent;
+            }
+
+            return null;
+        }
+
+        public static IEnumerable<T> GetChildrenOfType<T>(this DependencyObject o) where T : DependencyObject {
+            var queue = new Queue<DependencyObject>();
+            queue.Enqueue(o);
+            while (queue.Count > 0) {
+                foreach (var child in EnumerateVisualChildren(queue.Dequeue())) {
+                    var typedChild = child as T;
+                    if (typedChild != null) {
+                        yield return typedChild;
+                    } else {
+                        queue.Enqueue(child);
+                    }
+                }
+            }
+        }
+
         public static T FindNextVisualSiblingOfType<T>(DependencyObject o) where T : DependencyObject {
             var parent = VisualTreeHelper.GetParent(o);
             int childrenCount = VisualTreeHelper.GetChildrenCount(parent);

--- a/src/Common/Wpf/Impl/LambdaConverter/StyleSetterExtension.cs
+++ b/src/Common/Wpf/Impl/LambdaConverter/StyleSetterExtension.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Markup;
+
+namespace Microsoft.Common.Wpf {
+    public class StyleSetterExtension : MarkupExtension {
+        public object Style { get; set; }
+        public DependencyProperty Property { get; set; }
+
+        public override object ProvideValue(IServiceProvider serviceProvider) {
+            var styleMarkupExtension = Style as MarkupExtension;
+            var style = (styleMarkupExtension?.ProvideValue(serviceProvider) ?? Style) as Style;
+            while (style != null) {
+                var propertySetter = style.Setters
+                    .OfType<Setter>()
+                    .FirstOrDefault(s => Equals(Property, s.Property));
+                if (propertySetter != null) {
+                    return propertySetter.Value;
+                }
+
+                style = style.BasedOn;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Common/Wpf/Impl/Microsoft.Common.Wpf.csproj
+++ b/src/Common/Wpf/Impl/Microsoft.Common.Wpf.csproj
@@ -48,6 +48,7 @@
     <Compile Include="LambdaConverter\LambdaConverter.cs" />
     <Compile Include="LambdaConverter\LambdaExtension.cs" />
     <Compile Include="LambdaConverter\LambdaProperties.cs" />
+    <Compile Include="LambdaConverter\StyleSetterExtension.cs" />
     <Compile Include="Selectors\TypeDataTemplateSelector.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Package/Impl/DataInspect/Commands/CopyVariableCommand.cs
+++ b/src/Package/Impl/DataInspect/Commands/CopyVariableCommand.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.R.Package.DataInspect.Commands {
+    internal class CopyVariableCommand : VariableCommandBase {
+        public CopyVariableCommand(VariableView variableView) : base(variableView) {}
+
+        protected override bool IsEnabled(VariableViewModel variable) => true;
+
+        protected override Task InvokeAsync(VariableViewModel variable) {
+            VariableView.CopyEntry(variable);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Package/Impl/DataInspect/Commands/CopyVariableValueCommand.cs
+++ b/src/Package/Impl/DataInspect/Commands/CopyVariableValueCommand.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.R.Package.DataInspect.Commands {
+    internal class CopyVariableValueCommand : VariableCommandBase {
+        public CopyVariableValueCommand(VariableView variableView) : base(variableView) {}
+
+        protected override bool IsEnabled(VariableViewModel variable) => true;
+
+        protected override Task InvokeAsync(VariableViewModel variable) {
+            VariableView.CopyValue(variable);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Package/Impl/DataInspect/Commands/DeleteVariableCommand.cs
+++ b/src/Package/Impl/DataInspect/Commands/DeleteVariableCommand.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.R.Package.DataInspect.Commands {
+    internal class DeleteVariableCommand : VariableCommandBase {
+        public DeleteVariableCommand(VariableView variableView) : base(variableView) {}
+
+        protected override bool IsEnabled(VariableViewModel variable) => true;
+
+        protected override Task InvokeAsync(VariableViewModel variable) => VariableView.DeleteCurrentVariableAsync();
+    }
+}

--- a/src/Package/Impl/DataInspect/Commands/OpenVariableInCsvCommand.cs
+++ b/src/Package/Impl/DataInspect/Commands/OpenVariableInCsvCommand.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.R.Package.DataInspect.Commands {
+    internal class OpenVariableInCsvCommand : VariableCommandBase {
+        public OpenVariableInCsvCommand(VariableView variableView) : base(variableView) {}
+
+        protected override bool IsEnabled(VariableViewModel variable) => variable.CanShowOpenCsv;
+
+        protected override Task InvokeAsync(VariableViewModel variable) {
+            variable.OpenInCsvAppCommand.Execute(variable);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Package/Impl/DataInspect/Commands/ShowVariableDetailsCommand.cs
+++ b/src/Package/Impl/DataInspect/Commands/ShowVariableDetailsCommand.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.R.Package.DataInspect.Commands {
+    internal class ShowVariableDetailsCommand : VariableCommandBase {
+        public ShowVariableDetailsCommand(VariableView variableView) : base(variableView) {}
+
+        protected override bool IsEnabled(VariableViewModel variable) => variable.CanShowDetail;
+
+        protected override Task InvokeAsync(VariableViewModel variable) {
+            variable.ShowDetailCommand.Execute(variable);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Package/Impl/DataInspect/Commands/VariableCommandBase.cs
+++ b/src/Package/Impl/DataInspect/Commands/VariableCommandBase.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Common.Core.UI.Commands;
+
+namespace Microsoft.VisualStudio.R.Package.DataInspect.Commands {
+    internal abstract class VariableCommandBase : IAsyncCommand {
+        protected VariableView VariableView { get; }
+
+        protected VariableCommandBase(VariableView variableView) {
+            VariableView = variableView;
+        }
+
+        public CommandStatus Status {
+            get {
+                var variable = VariableView.GetCurrentSelectedModel();
+                return variable != null && IsEnabled(variable) 
+                    ? CommandStatus.SupportedAndEnabled 
+                    : CommandStatus.Supported;
+            }
+        }
+
+        public Task InvokeAsync() {
+            var variable = VariableView.GetCurrentSelectedModel();
+            return variable == null ? Task.CompletedTask : InvokeAsync(variable);
+        }
+
+        protected abstract bool IsEnabled(VariableViewModel variable);
+
+        protected abstract Task InvokeAsync(VariableViewModel variable);
+    }
+}

--- a/src/Package/Impl/DataInspect/DataGridStyle.xaml
+++ b/src/Package/Impl/DataInspect/DataGridStyle.xaml
@@ -6,9 +6,10 @@
 
     <!-- Data grid cell -->
     <Style x:Uid="Style_1" TargetType="{x:Type DataGridCell}">
-        <Setter x:Uid="Setter_1" Property="Background" Value="{DynamicResource {x:Static rwpf:Brushes.TreeViewBackgroundBrushKey}}" />
-        <Setter x:Uid="Setter_2" Property="TextElement.Foreground" Value="{DynamicResource {x:Static rwpf:Brushes.TreeViewBackgroundTextBrushKey}}" />
-        <Setter x:Uid="Setter_3" Property="BorderThickness" Value="0" />
+        <Setter Property="Background" Value="{DynamicResource {x:Static rwpf:Brushes.TreeViewBackgroundBrushKey}}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static rwpf:Brushes.TreeViewBackgroundTextBrushKey}}" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="local:TreeGrid.IsCellFocused" Value="{Binding Path=IsFocused, RelativeSource={RelativeSource Self}}" />
         <!-- Disable cell selection color -->
         <Setter x:Uid="Setter_4" Property="Padding" Value="1" />
         <!-- 1px of vertical padding between rows, including selection, 1px of internal padding -->
@@ -28,9 +29,7 @@
                     <Setter Property="Control.Template">
                         <Setter.Value>
                             <ControlTemplate>
-                                <Border>
-                                    <Rectangle StrokeThickness="0" Stroke="#00000000" StrokeDashArray="1 2" />
-                                </Border>
+                                <Border />
                             </ControlTemplate>
                         </Setter.Value>
                     </Setter>
@@ -38,10 +37,22 @@
             </Setter.Value>
         </Setter>
         <Style.Triggers>
-            <Trigger x:Uid="Trigger_1" Property="IsSelected" Value="True">
-                <Setter x:Uid="Setter_6" Property="Background" Value="{DynamicResource {x:Static rwpf:Brushes.TreeViewSelectedItemActiveBrushKey}}" />
-                <Setter x:Uid="Setter_7" Property="TextElement.Foreground" Value="{DynamicResource {x:Static rwpf:Brushes.TreeViewSelectedItemActiveTextBrushKey}}" />
-            </Trigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsSelected" Value="True" />
+                    <Condition Property="local:TreeGrid.IsFocusInRow" Value="True" />
+                </MultiTrigger.Conditions>
+                <Setter Property="Background" Value="{DynamicResource {x:Static rwpf:Brushes.TreeViewSelectedItemActiveBrushKey}}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static rwpf:Brushes.TreeViewSelectedItemActiveTextBrushKey}}" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsSelected" Value="True" />
+                    <Condition Property="local:TreeGrid.IsFocusInRow" Value="False" />
+                </MultiTrigger.Conditions>
+                <Setter Property="Background" Value="{DynamicResource {x:Static rwpf:Brushes.TreeViewSelectedItemInactiveBrushKey}}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static rwpf:Brushes.TreeViewSelectedItemInactiveTextBrushKey}}" />
+            </MultiTrigger>
         </Style.Triggers>
     </Style>
     

--- a/src/Package/Impl/DataInspect/VariableView.xaml
+++ b/src/Package/Impl/DataInspect/VariableView.xaml
@@ -20,7 +20,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/Microsoft.VisualStudio.R.Package;component/Wpf/Controls.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Microsoft.R.Wpf;component/CommonResources.xaml " />
                 <ResourceDictionary Source="DataGridStyle.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
@@ -137,7 +137,7 @@
                             Command="{Binding Model.Content.ShowDetailCommand}" ToolTip="{Binding Model.Content.ShowDetailCommandTooltip}"
                             AutomationProperties.Name="{Binding Path=Model.Content.Name, StringFormat={x:Static pkg:Resources.ShowDetailCommandAutomationName}}"
                             AutomationProperties.HelpText="{Binding Path=Model.Content.Name, StringFormat={x:Static pkg:Resources.ShowDetailCommandAutomationHelpText}}"
-                            VerticalAlignment="Center">
+                            VerticalAlignment="Center" Focusable="False">
                             <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.Zoom}"/>
                         </Button>
                         <Button
@@ -145,7 +145,7 @@
                             Command="{Binding Model.Content.OpenInCsvAppCommand}" ToolTip="{Binding Model.Content.OpenInCsvAppCommandTooltip}"
                             AutomationProperties.Name="{Binding Path=Model.Content.Name, StringFormat={x:Static pkg:Resources.OpenCsvAppCommandAutomationName}}"
                             AutomationProperties.HelpText="{Binding Path=Model.Content.Name, StringFormat={x:Static pkg:Resources.OpenCsvAppCommandAutomationHelpText}}"
-                            VerticalAlignment="Center">
+                            VerticalAlignment="Center" Focusable="False">
                             <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.OfficeExcel2013}"/>
                         </Button>
                     </StackPanel>
@@ -154,16 +154,14 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Grid>
+    <Grid KeyboardNavigation.TabNavigation="Cycle">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <ComboBox x:Name="EnvironmentComboBox"
-                  Margin="4"
-                  ItemsSource="{Binding Environments}"
-                  SelectedItem="{Binding SelectedEnvironment}"
+        <ComboBox x:Name="EnvironmentComboBox" Margin="4" TabIndex="1"
+                  ItemsSource="{Binding Environments}" SelectedItem="{Binding SelectedEnvironment}"
                   SelectionChanged="EnvironmentComboBox_SelectionChanged"
                   AutomationProperties.Name="{x:Static pkg:Resources.VariableExplorer_EnvironmentsCombo_AccessibleName}">
             <ComboBox.ItemTemplate>
@@ -175,7 +173,7 @@
                 </DataTemplate>
             </ComboBox.ItemTemplate>
             <ComboBox.ItemContainerStyle>
-                <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
+                <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{wpf:StyleSetter Style={StaticResource {x:Type ComboBox}}, Property=ItemsControl.ItemContainerStyle}">
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding Name}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
@@ -194,10 +192,19 @@
         </ComboBox>
 
         <local:TreeGrid x:Name="RootTreeGrid" Grid.Row="1"
-                  AutoGenerateColumns="False"
-                  ScrollViewer.VerticalScrollBarVisibility="Visible"
-                  IsReadOnly="True"
-                  RowHeight="{Binding Path=FontSize, ElementName=Self, Converter={x:Static rwpf:Converters.Scale190}}">
+                        AutoGenerateColumns="False" TabIndex="0" 
+                        ScrollViewer.VerticalScrollBarVisibility="Visible"
+                        IsReadOnly="True" PreviewKeyDown="OnPreviewKeyDown" PreviewKeyUp="OnPreviewKeyUp" ItemsChanged="OnItemsChanged"
+                        RowHeight="{Binding Path=FontSize, ElementName=Self, Converter={x:Static rwpf:Converters.Scale190}}">
+            <DataGrid.Resources>
+                <Style x:Key="SelectableCellStyle" TargetType="{x:Type DataGridCell}" BasedOn="{StaticResource {x:Type DataGridCell}}">
+                    <Setter Property="KeyboardNavigation.IsTabStop" Value="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" />
+                </Style>
+
+                <Style TargetType="{x:Type DataGridCell}" BasedOn="{StaticResource {x:Type DataGridCell}}">
+                    <Setter Property="KeyboardNavigation.IsTabStop" Value="False" />
+                </Style>
+            </DataGrid.Resources>
             <DataGrid.RowStyle>
                 <Style TargetType="{x:Type DataGridRow}">
                     <EventSetter Event="MouseDoubleClick" Handler="GridRow_MouseDoubleClick" />
@@ -206,7 +213,7 @@
             </DataGrid.RowStyle>
             <DataGrid.Columns>
                 <DataGridTemplateColumn x:Name="NameColumn" Header="{x:Static pkg:Resources.VariableExplorer_NameHeader}" CellTemplate="{StaticResource NameCellTemplate}"
-                                        Width="2*" 
+                                        Width="2*" CellStyle="{StaticResource SelectableCellStyle}"
                                         CanUserSort="True" SortMemberPath="DummyValue" />
                 <DataGridTemplateColumn x:Name="ValueColumn" Header="{x:Static pkg:Resources.VariableExplorer_ValueHeader}" CellTemplate="{StaticResource ValueCellTemplate}"
                                         Width="3*" CanUserSort="False" />

--- a/src/Package/Impl/DataInspect/VariableView.xaml.cs
+++ b/src/Package/Impl/DataInspect/VariableView.xaml.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Linq;
@@ -13,19 +14,15 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.Shell;
-using Microsoft.Common.Core.UI.Commands;
 using Microsoft.Common.Wpf.Extensions;
-using Microsoft.R.Components.Controller;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.DataInspection;
 using Microsoft.R.Host.Client;
 using Microsoft.R.Host.Client.Host;
-using Microsoft.R.StackTracing;
 using Microsoft.R.Support.Settings;
 using Microsoft.R.Wpf.Themes;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
-using Microsoft.VisualStudio.R.Package.Commands;
 using Microsoft.VisualStudio.R.Package.Commands.R;
 using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.R.Packages.R;
@@ -34,7 +31,7 @@ using static Microsoft.R.DataInspection.REvaluationResultProperties;
 using Brushes = Microsoft.R.Wpf.Brushes;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect {
-    public partial class VariableView : UserControl, ICommandTarget, IDisposable {
+    public partial class VariableView : IDisposable {
         private readonly IRToolsSettings _settings;
         private readonly ICoreShell _shell;
         private readonly IRSession _session;
@@ -59,6 +56,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
             SortDirection = ListSortDirection.Ascending;
             RootTreeGrid.Sorting += RootTreeGrid_Sorting;
+            RootTreeGrid.SelectionChanged += RootTreeGrid_SelectionChanged;
 
             var workflow = VsAppShell.Current.ExportProvider.GetExportedValue<IRInteractiveWorkflowProvider>().GetOrCreate();
             _session = workflow.RSession;
@@ -80,6 +78,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         public void Dispose() {
             RootTreeGrid.Sorting -= RootTreeGrid_Sorting;
+            RootTreeGrid.SelectionChanged -= RootTreeGrid_SelectionChanged;
             _environmentProvider?.Dispose();
         }
 
@@ -98,6 +97,10 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
             _rootNode.Sort();
             e.Handled = true;
+        }
+
+        private void RootTreeGrid_SelectionChanged(object sender, SelectionChangedEventArgs selectionChangedEventArgs) {
+            VsAppShell.Current.UpdateCommandStatus();
         }
 
         private void EnvironmentComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e) {
@@ -172,7 +175,13 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             cell.Focus();
         }
 
-        protected override void OnPreviewKeyDown(KeyEventArgs e) {
+        private void OnItemsChanged(object sender, NotifyCollectionChangedEventArgs e) {
+            if (RootTreeGrid.Items.Count > 0 && RootTreeGrid.SelectedIndex == -1) {
+                RootTreeGrid.SetCurrentItem(0);
+            }
+        }
+
+        private void OnPreviewKeyDown(object sender, KeyEventArgs e) {
             switch (e.Key) {
                 case Key.Enter:
                     // Track that we've seen key down here so when key up
@@ -198,19 +207,9 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                     }
                     break;
             }
-            base.OnPreviewKeyDown(e);
         }
 
-        private void ShowContextMenu() {
-            var focus = Keyboard.FocusedElement as FrameworkElement;
-            if (focus != null) {
-                var pt = focus.PointToScreen(new Point(1, 1));
-                _shell.ShowContextMenu(
-                    new CommandID(RGuidList.RCmdSetGuid, (int)RContextMenuId.VariableExplorer), (int)pt.X, (int)pt.Y, this);
-            }
-        }
-
-        protected override void OnPreviewKeyUp(KeyEventArgs e) {
+        private void OnPreviewKeyUp(object sender, KeyEventArgs e) {
             // Prevent Enter from being passed to WPF control
             // when user hits it in the context menu
             if (e.Key == Key.Enter && _keyDownSeen) {
@@ -228,7 +227,15 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                     selection.IsExpanded = !selection.IsExpanded;
                 }
             }
-            base.OnPreviewKeyUp(e);
+        }
+
+        private void ShowContextMenu() {
+            var focus = Keyboard.FocusedElement as FrameworkElement;
+            if (focus != null) {
+                var pt = focus.PointToScreen(new Point(1, 1));
+                _shell.ShowContextMenu(
+                    new CommandID(RGuidList.RCmdSetGuid, (int)RContextMenuId.VariableExplorer), (int)pt.X, (int)pt.Y, this);
+            }
         }
 
         protected override void OnKeyDown(KeyEventArgs e) {
@@ -253,7 +260,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
         }
 
-        private Task DeleteCurrentVariableAsync() {
+        public Task DeleteCurrentVariableAsync() {
             var env = EnvironmentComboBox.SelectedItem as REnvironment;
             var model = GetCurrentSelectedModel();
             return model != null ? model.DeleteAsync(env?.EnvironmentExpression) : Task.CompletedTask;
@@ -315,77 +322,20 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
         }
         #endregion
-
-        #region ICommandTarget
-        public CommandStatus Status(Guid group, int id) {
-            if (group == VSConstants.GUID_VSStandardCommandSet97) {
-                switch ((VSConstants.VSStd97CmdID)id) {
-                    case VSConstants.VSStd97CmdID.Copy:
-                    case VSConstants.VSStd97CmdID.Delete:
-                        return CommandStatus.SupportedAndEnabled;
-                }
-            } else if (group == RGuidList.RCmdSetGuid) {
-                var model = GetCurrentSelectedModel();
-                if (model != null) {
-                    switch (id) {
-                        case (int)RContextMenuId.VariableExplorer:
-                        case RPackageCommandId.icmdCopyValue:
-                            return CommandStatus.SupportedAndEnabled;
-                        case RPackageCommandId.icmdShowDetails:
-                            return model.CanShowDetail ? CommandStatus.SupportedAndEnabled : CommandStatus.Invisible;
-                        case RPackageCommandId.icmdOpenInCsvApp:
-                            return model.CanShowOpenCsv ? CommandStatus.SupportedAndEnabled : CommandStatus.Invisible;
-                    }
-                }
-            }
-            return CommandStatus.Invisible;
-        }
-
-        public CommandResult Invoke(Guid group, int id, object inputArg, ref object outputArg) {
-            var model = GetCurrentSelectedModel();
-            if (model != null) {
-                if (group == VSConstants.GUID_VSStandardCommandSet97) {
-                    switch ((VSConstants.VSStd97CmdID)id) {
-                        case VSConstants.VSStd97CmdID.Copy:
-                            CopyEntry(model);
-                            break;
-                        case VSConstants.VSStd97CmdID.Delete:
-                            DeleteCurrentVariableAsync().DoNotWait();
-                            break;
-                    }
-                } else if (group == RGuidList.RCmdSetGuid) {
-                    switch (id) {
-                        case RPackageCommandId.icmdCopyValue:
-                            CopyValue(model);
-                            break;
-                        case RPackageCommandId.icmdShowDetails:
-                            model?.ShowDetailCommand.Execute(model);
-                            break;
-                        case RPackageCommandId.icmdOpenInCsvApp:
-                            model?.OpenInCsvAppCommand.Execute(model);
-                            break;
-                    }
-                }
-            }
-            return CommandResult.Executed;
-        }
-
-        public void PostProcessInvoke(CommandResult result, Guid group, int id, object inputArg, ref object outputArg) { }
-        #endregion
-
-        private VariableViewModel GetCurrentSelectedModel() {
-            var selection = RootTreeGrid?.SelectedItem as ObservableTreeNode;
+        
+        public VariableViewModel GetCurrentSelectedModel() {
+            var selection = RootTreeGrid.SelectedItem as ObservableTreeNode;
             return selection?.Model?.Content as VariableViewModel;
         }
 
-        private void CopyEntry(VariableViewModel model) {
+        public void CopyEntry(VariableViewModel model) {
             if (model != null) {
                 string data = Invariant($"{model.Name} {model.Value} {model.Class} {model.TypeName}");
                 SetClipboardData(data);
             }
         }
 
-        private void CopyValue(VariableViewModel model) {
+        public void CopyValue(VariableViewModel model) {
             if (model != null) {
                 SetClipboardData(model.Value);
             }

--- a/src/Package/Impl/DataInspect/VariableWindowPane.cs
+++ b/src/Package/Impl/DataInspect/VariableWindowPane.cs
@@ -1,12 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using Microsoft.R.Support.Settings;
 using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.R.Package.Commands;
+using Microsoft.VisualStudio.R.Package.DataInspect.Commands;
+using Microsoft.VisualStudio.R.Package.Interop;
 using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.R.Package.Windows;
 using Microsoft.VisualStudio.R.Packages.R;
@@ -14,7 +18,9 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect {
     [Guid("99d2ea62-72f2-33be-afc8-b8ce6e43b5d0")]
-    internal sealed class VariableWindowPane : RToolWindowPane {
+    internal sealed class VariableWindowPane : RToolWindowPane, IOleCommandTarget {
+        private CommandTargetToOleShim _commandTarget;
+
         public VariableWindowPane() {
             Caption = Resources.VariableWindowCaption;
             Content = new VariableView(RToolsSettings.Current, VsAppShell.Current);
@@ -23,6 +29,32 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             BitmapImageMoniker = KnownMonikers.VariableProperty;
 
             ToolBar = new CommandID(RGuidList.RCmdSetGuid, RPackageCommandId.variableWindowToolBarId);
+        }
+
+        protected override void OnCreate() {
+            var variableView = (VariableView) Content;
+            var controller = new AsyncCommandController()
+                .AddCommand(VSConstants.GUID_VSStandardCommandSet97, (int)VSConstants.VSStd97CmdID.Copy, new CopyVariableCommand(variableView))
+                .AddCommand(VSConstants.GUID_VSStandardCommandSet97, (int)VSConstants.VSStd97CmdID.Delete, new DeleteVariableCommand(variableView))
+                .AddCommand(RGuidList.RCmdSetGuid, RPackageCommandId.icmdCopyValue, new CopyVariableValueCommand(variableView))
+                .AddCommand(RGuidList.RCmdSetGuid, RPackageCommandId.icmdShowDetails, new ShowVariableDetailsCommand(variableView))
+                .AddCommand(RGuidList.RCmdSetGuid, RPackageCommandId.icmdOpenInCsvApp, new OpenVariableInCsvCommand(variableView));
+              
+            _commandTarget = new CommandTargetToOleShim(null, controller);
+            base.OnCreate();
+        }
+        
+        public int QueryStatus(ref Guid pguidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText) 
+            => _commandTarget.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
+
+        public int Exec(ref Guid pguidCmdGroup, uint nCmdId, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut) 
+            => _commandTarget.Exec(ref pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut);
+        
+        protected override void Dispose(bool disposing) {
+            if (disposing) {
+                _commandTarget = null;
+            }
+            base.Dispose(disposing);
         }
 
         public bool IsGlobalREnvironment() {

--- a/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
+++ b/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
@@ -85,6 +85,9 @@
     <Compile Include="Commands\SessionCommand.cs" />
     <Compile Include="DataInspect\Commands\DeleteAllVariablesCommand.cs" />
     <Compile Include="DataInspect\Commands\SessionCommand.cs" />
+    <Compile Include="DataInspect\Commands\CopyVariableCommand.cs" />
+    <Compile Include="DataInspect\Commands\CopyVariableValueCommand.cs" />
+    <Compile Include="DataInspect\Commands\VariableCommandBase.cs" />
     <Compile Include="DataInspect\DataImport\EnterUrl.xaml.cs">
       <DependentUpon>EnterUrl.xaml</DependentUpon>
     </Compile>
@@ -109,14 +112,17 @@
     <Compile Include="DataInspect\DataSource\GridRange.cs" />
     <Compile Include="DataInspect\Definitions\ViewerCapabilities.cs" />
     <Compile Include="DataInspect\Definitions\REnvironmentKind.cs" />
+    <Compile Include="DataInspect\Commands\DeleteVariableCommand.cs" />
     <Compile Include="DataInspect\Office\CsvAppFileIO.cs" />
     <Compile Include="DataInspect\Definitions\IREnvironment.cs" />
+    <Compile Include="DataInspect\Commands\OpenVariableInCsvCommand.cs" />
     <Compile Include="DataInspect\REnvironment.cs" />
     <Compile Include="DataInspect\REnvironmentsChangedEventArgs.cs" />
     <Compile Include="DataInspect\REnvironmentProvider.cs" />
     <Compile Include="DataInspect\GridData.cs" />
     <Compile Include="DataInspect\GridHeader.cs" />
     <Compile Include="DataInspect\GridDataProvider.cs" />
+    <Compile Include="DataInspect\Commands\ShowVariableDetailsCommand.cs" />
     <Compile Include="DataInspect\TreeGrid\TreeGrid.cs" />
     <Compile Include="DataInspect\VariableSearchTask.cs" />
     <Compile Include="DataInspect\Viewers\DebugObjectEvaluator.cs" />

--- a/src/Package/Impl/Package.vsct
+++ b/src/Package/Impl/Package.vsct
@@ -2411,6 +2411,9 @@
     <CommandPlacement guid="guidRToolsCmdSet" id="dataSubMenuEditGroup" priority="0x0200">
       <Parent guid="guidRToolsCmdSet" id="variableWindowToolBarId"/>
     </CommandPlacement>
+    <CommandPlacement guid="guidRToolsCmdSet" id="veCommandGroup" priority="0x0300">
+      <Parent guid="guidRToolsCmdSet" id="variableWindowToolBarId"/>
+    </CommandPlacement>
 
     <CommandPlacement guid="guidRToolsCmdSet" id="icmdSetDirectoryToSourceCommand" priority="0x0100">
       <Parent guid="guidRToolsCmdSet" id="directorySubMenuGroup"/>

--- a/src/Package/Impl/Wpf/VsWpfOverrides.cs
+++ b/src/Package/Impl/Wpf/VsWpfOverrides.cs
@@ -30,12 +30,7 @@ namespace Microsoft.VisualStudio.R.Package.Wpf
             OverrideStyleKeys();
         }
 
-        private static void OverrideBrushes()
-        {
-            if (SystemParameters.HighContrast) {
-                return; // Use system theme colors
-            }
-
+        private static void OverrideBrushes() {
             Brushes.ActiveBorderKey = VsBrushes.ActiveBorderKey;
             Brushes.BorderBrushKey = VsBrushes.BrandedUIBorderKey;
             Brushes.ButtonFaceBrushKey = EnvironmentColors.SystemButtonFaceBrushKey;
@@ -134,6 +129,8 @@ namespace Microsoft.VisualStudio.R.Package.Wpf
             Brushes.TreeViewBackgroundTextBrushKey = TreeViewColors.BackgroundTextBrushKey;
             Brushes.TreeViewSelectedItemActiveBrushKey = TreeViewColors.SelectedItemActiveBrushKey;
             Brushes.TreeViewSelectedItemActiveTextBrushKey = TreeViewColors.SelectedItemActiveTextBrushKey;
+            Brushes.TreeViewSelectedItemInactiveBrushKey = TreeViewColors.SelectedItemInactiveBrushKey;
+            Brushes.TreeViewSelectedItemInactiveTextBrushKey = TreeViewColors.SelectedItemInactiveTextBrushKey;
             Brushes.TreeViewGlyphBrushKey = TreeViewColors.GlyphBrushKey;
             Brushes.TreeViewGlyphMouseOverBrushKey = TreeViewColors.GlyphMouseOverBrushKey;
 

--- a/src/R/Wpf/Impl/Brushes.cs
+++ b/src/R/Wpf/Impl/Brushes.cs
@@ -18,8 +18,8 @@ namespace Microsoft.R.Wpf {
         public static object ContentInactiveSelectedTextBrushKey { get; set; } = SystemColors.InactiveSelectionHighlightTextBrushKey;
         public static object ContentMouseOverBrushKey { get; set; } = SystemColors.ControlBrushKey;
         public static object ContentMouseOverTextBrushKey { get; set; } = SystemColors.HotTrackBrushKey;
-        public static object ContentSelectedBrushKey { get; set; } = SystemColors.HighlightBrushKey;
-        public static object ContentSelectedTextBrushKey { get; set; } = SystemColors.HighlightTextBrushKey;
+        public static object ContentSelectedBrushKey { get; set; } = SystemColors.ActiveCaptionBrushKey;
+        public static object ContentSelectedTextBrushKey { get; set; } = SystemColors.ActiveCaptionTextBrushKey;
         public static object ControlKey { get; set; } = SystemColors.ControlBrushKey;
         public static object ControlDarkKey { get; set; } = SystemColors.ControlDarkBrushKey;
         public static object ControlLightKey { get; set; } = SystemColors.ControlLightBrushKey;
@@ -100,8 +100,10 @@ namespace Microsoft.R.Wpf {
 
         public static object TreeViewBackgroundBrushKey { get; set; } = SystemColors.WindowBrushKey;
         public static object TreeViewBackgroundTextBrushKey { get; set; } = SystemColors.WindowTextBrushKey;
-        public static object TreeViewSelectedItemActiveBrushKey { get; set; } = SystemColors.HighlightBrushKey;
-        public static object TreeViewSelectedItemActiveTextBrushKey { get; set; } = SystemColors.HighlightTextBrushKey;
+        public static object TreeViewSelectedItemActiveBrushKey { get; set; } = SystemColors.ActiveCaptionBrushKey;
+        public static object TreeViewSelectedItemActiveTextBrushKey { get; set; } = SystemColors.ActiveCaptionTextBrushKey;
+        public static object TreeViewSelectedItemInactiveBrushKey { get; set; } = SystemColors.InactiveCaptionBrushKey;
+        public static object TreeViewSelectedItemInactiveTextBrushKey { get; set; } = SystemColors.InactiveCaptionTextBrushKey;
         public static object TreeViewGlyphBrushKey { get; set; } = SystemColors.WindowTextBrushKey;
         public static object TreeViewGlyphMouseOverBrushKey { get; set; } = SystemColors.HotTrackBrushKey;
 


### PR DESCRIPTION
- Variable tree view is accessible by tab navigation, but inside it can be navigated only by arrows (left/right arrow expands/collapses the record). This is a common behavior for many tree views across windows and VS. Tab navigation switches between environments combobox and list of variables
- Buttons on variable records aren't accessible by keyboard anymore. Making them a tab stop creates an additional mess and makes it really hard to get out of the list. Buttons are available on the toolbar, which is accessible by Shift+Alt. Also, "Show details" can be invoked by hitting "Enter"
- Variable explorer focus is preserved when user switches to the toolbar or to the environments combobox