### PR TITLE
Attempt to fix #3468: Can't open Variable Explorer in 2017.2

### DIFF
--- a/src/Package/Impl/DataInspect/VariableView.xaml
+++ b/src/Package/Impl/DataInspect/VariableView.xaml
@@ -19,7 +19,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/Microsoft.R.Wpf;component/CommonResources.xaml " />
+                <rwpf:CommonResources />
                 <ResourceDictionary Source="DataGridStyle.xaml" />
             </ResourceDictionary.MergedDictionaries>
 


### PR DESCRIPTION
Here is one of the things that is different in `VariableView`