### PR TITLE
Fix #3231: View() does not show row names for ts and zoo

### DIFF
--- a/src/Package/TestApp/Data/GridDataTest.cs
+++ b/src/Package/TestApp/Data/GridDataTest.cs
@@ -335,5 +335,43 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Data {
             { "[1,]",   "1",                "3" },
             { "[2,]",   "<externalptr> ",    "4" },
         });
+
+        [Test]
+        [Category.R.DataGrid]
+        public Task TimeseriesVectorGrid() => Test("ts(c(1,2,3,4,5,6), start=2000, frequency=4)", 1, 1, new[,] {
+            { null,      "[]" },
+            { "2000.00", "1" },
+            { "2000.25", "2" },
+            { "2000.50", "3" },
+            { "2000.75", "4" },
+            { "2001.00", "5" },
+            { "2001.25", "6" },
+        });
+
+        [Test]
+        [Category.R.DataGrid]
+        public Task TimeseriesMatrixGrid() => Test("ts(matrix(c(1,2,3,4,5,6), ncol=2), start=2000, frequency=4)", 1, 1, new[,] {
+            { null,      "Series 1", "Series 2" },
+            { "2000.00", "1",    "4" },
+            { "2000.25", "2",    "5" },
+            { "2000.50", "3",    "6" },
+        });
+
+        [Test]
+        [Category.R.DataGrid]
+        public async Task QuantmodGrid() {
+            try {
+                await _session.EvaluateAsync("quantmod::getSymbols", REvaluationKind.NoResult);
+            } catch (REvaluationException) {
+                Assert.True(false, "quantmod package is not installed");
+            }
+
+            await Test("quantmod::getSymbols('MSFT', auto.assign=FALSE)['2016-03-23::2016-03-28']", 1, 1, new[,] {
+                { null,         "MSFT.Open", "MSFT.High", "MSFT.Low", "MSFT.Close", "MSFT.Volume", "MSFT.Adjusted" },
+                { "2016-03-23", "54.11",     "54.24",     "53.74",    "53.97",      "20129000",    "52.58695" },
+                { "2016-03-24", "53.84",     "54.33",     "53.73",    "54.21",      "19950000",    "52.82079" },
+                { "2016-03-28", "54.21",     "54.29",     "53.33",    "53.54",      "17025100",    "52.16797" },
+            });
+        }
     }
 }


### PR DESCRIPTION
Use time() for ts, and zoo::index() for zoo, in lieu of row.names() when the latter is absent.