### PR TITLE
Fix #3533: RSessionTest+ReadInput.ConcurrentRequests fails

### DIFF
--- a/src/Common/Core/Impl/Extensions/TaskExtensions.cs
+++ b/src/Common/Core/Impl/Extensions/TaskExtensions.cs
@@ -64,8 +64,7 @@ namespace Microsoft.Common.Core {
                 return;
             }
 
-            if (TestEnvironment.Current != null) {
-                TestEnvironment.Current.AddTaskToWait(task);
+            if (TestEnvironment.Current != null && TestEnvironment.Current.TryAddTaskToWait(task)) {
                 return;
             }
 

--- a/src/Common/Core/Impl/Testing/ITestEnvironment.cs
+++ b/src/Common/Core/Impl/Testing/ITestEnvironment.cs
@@ -5,6 +5,6 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Common.Core.Testing {
     public interface ITestEnvironment {
-        void AddTaskToWait(Task task);
+        bool TryAddTaskToWait(Task task);
     }
 }

--- a/src/UnitTests/Core/Impl/Threading/ParallelTools.cs
+++ b/src/UnitTests/Core/Impl/Threading/ParallelTools.cs
@@ -21,21 +21,21 @@ namespace Microsoft.UnitTests.Core.Threading {
         public static async Task<Task<T>[]> InvokeAsync<T>(int count, Func<int, Task<T>> method, int delayMs = 10000) {
             var results = Invoke(count, method);
             var tasks = results.ToArray();
-            await Task.WhenAny(Task.WhenAll(tasks).SilenceException<Exception>(), Task.Delay(delayMs));
+            await When(Task.WhenAll(tasks).SilenceException<Exception>(), delayMs);
             return tasks.ToArray();
         }
 
         public static async Task<TResult[]> InvokeAsync<TResult>(int count, Func<int, TResult> method, Func<TResult, Task> taskSelector, int delayMs = 10000) {
             var results = Invoke(count, method).ToArray();
             var tasks = results.Select(taskSelector).ToArray();
-            await Task.WhenAny(Task.WhenAll(tasks).SilenceException<Exception>(), Task.Delay(delayMs));
+            await When(Task.WhenAll(tasks).SilenceException<Exception>(), delayMs);
             return results;
         }
 
         public static async Task<Task[]> InvokeAsync(int count, Func<int, Task> method, int delayMs = 10000) {
             var results = Invoke(count, method);
             var tasks = results.ToArray();
-            await Task.WhenAny(Task.WhenAll(tasks).SilenceException<Exception>(), Task.Delay(delayMs));
+            await When(Task.WhenAll(tasks).SilenceException<Exception>(), delayMs);
             return tasks.ToArray();
         }
 

--- a/src/Windows/Host/Client/Test/Session/RSessionTest.Blobs.cs
+++ b/src/Windows/Host/Client/Test/Session/RSessionTest.Blobs.cs
@@ -31,7 +31,7 @@ namespace Microsoft.R.Host.Client.Test.Session {
 
             public async Task InitializeAsync() {
                 await _session.StartHostAsync(new RHostStartupInfo(), null, 50000);
-                TestEnvironment.Current.AddTaskToWait(_session.RHost.GetRHostRunTask());
+                TestEnvironment.Current.TryAddTaskToWait(_session.RHost.GetRHostRunTask());
             }
 
             public async Task DisposeAsync() {

--- a/src/Windows/Host/Client/Test/Session/RSessionTest.CancelAll.cs
+++ b/src/Windows/Host/Client/Test/Session/RSessionTest.CancelAll.cs
@@ -31,7 +31,7 @@ namespace Microsoft.R.Host.Client.Test.Session {
 
             public async Task InitializeAsync() {
                 await _session.StartHostAsync(new RHostStartupInfo(isInteractive: true), _callback, 50000);
-                TestEnvironment.Current.AddTaskToWait(_session.RHost.GetRHostRunTask());
+                TestEnvironment.Current.TryAddTaskToWait(_session.RHost.GetRHostRunTask());
             }
 
             public async Task DisposeAsync() {

--- a/src/Windows/Host/Client/Test/Session/RSessionTest.InteractionEvaluation.cs
+++ b/src/Windows/Host/Client/Test/Session/RSessionTest.InteractionEvaluation.cs
@@ -36,7 +36,7 @@ namespace Microsoft.R.Host.Client.Test.Session {
 
             public async Task InitializeAsync() {
                 await _session.StartHostAsync(new RHostStartupInfo(isInteractive: true), null, 50000);
-                TestEnvironment.Current.AddTaskToWait(_session.RHost.GetRHostRunTask());
+                TestEnvironment.Current.TryAddTaskToWait(_session.RHost.GetRHostRunTask());
             }
 
             public async Task DisposeAsync() {

--- a/src/Windows/Host/Client/Test/Session/RSessionTest.ReadInput.cs
+++ b/src/Windows/Host/Client/Test/Session/RSessionTest.ReadInput.cs
@@ -1,8 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -32,7 +36,7 @@ namespace Microsoft.R.Host.Client.Test.Session {
 
             public async Task InitializeAsync() {
                 await _session.StartHostAsync(new RHostStartupInfo (isInteractive:true), _callback, 50000);
-                TestEnvironment.Current.AddTaskToWait(_session.RHost.GetRHostRunTask());
+                TestEnvironment.Current.TryAddTaskToWait(_session.RHost.GetRHostRunTask());
             }
 
             public async Task DisposeAsync() {
@@ -60,13 +64,13 @@ paste(h, name)
 
             [Test]
             public async Task ConcurrentRequests() {
-                var responds = new List<string>();
-                var input = new List<string>();
-                var output = new List<string>();
-                void OutputHandler(object o, ROutputEventArgs e) => output.Add(e.Message);
+                var responds = new ConcurrentQueue<int>();
+                var input = new ConcurrentQueue<string>();
+                var output = new ConcurrentQueue<string>();
+                void OutputHandler(object o, ROutputEventArgs e) => output.Enqueue(e.Message);
 
                 Task<string> InputHandler(string prompt, int maximumLength, CancellationToken ct) {
-                    input.Add(prompt);
+                    input.Enqueue(prompt);
                     return Task.FromResult($"{prompt}\n");
                 }
 
@@ -74,14 +78,15 @@ paste(h, name)
                 _session.Output += OutputHandler;
                 await ParallelTools.InvokeAsync(10, async i => {
                     using (var interaction = await _session.BeginInteractionAsync()) {
-                        responds.Add(i.ToString());
+                        responds.Enqueue(i);
                         await interaction.RespondAsync($"readline('{i}')");
                     }
-                });
+                }, 20000);
                 _session.Output -= OutputHandler;
 
-                input.Should().Equal(responds);
-                output.Should().Contain(Enumerable.Range(0, 10).Select(i => $" \"{i}\""));
+                responds.Should().BeEquivalentTo(Enumerable.Range(0, 10));
+                input.Should().Equal(responds.Select(i => i.ToString()));
+                output.Should().Contain(responds.Select(i => $" \"{i}\""));
             }
         }
     }


### PR DESCRIPTION
- Fix ParallelTools.InvokeAsync so that it correctly fails on timeout
- Change ITestEnvironment.AddTaskToWait to TryAddTaskToWait so that assembly fixtures can call DoNotWait