### PR TITLE
Accessibility fixes

### DIFF
--- a/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml
+++ b/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml
@@ -43,7 +43,9 @@
                      Background="{DynamicResource {x:Static wpf:Brushes.BackgroundBrushKey}}" 
                      Foreground="{DynamicResource {x:Static wpf:Brushes.UITextKey}}" 
                      IsReadOnly="True" AutomationProperties.Name="{x:Static pkg:Resources.Tab_InputFile}"/>
-            <Button Grid.Column="2" x:Name="FileOpenButton" Padding="0" Content="..." Name="{x:Static pkg:Resources.Browse}" Click="FileOpenButton_Click" VerticalAlignment="Center"
+            <Button Grid.Column="2" x:Name="FileOpenButton" Padding="0" Content="..." 
+                    AutomationProperties.Name="{x:Static pkg:Resources.Browse}"
+                    Click="FileOpenButton_Click" VerticalAlignment="Center"
                     Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" MinHeight="22" MinWidth="22" 
                     FontSize="{Binding ElementName=Self, Path=FontSize, Converter={x:Static wpf:Converters.Scale155}}" 
                     Foreground="{DynamicResource {x:Static wpf:Brushes.WindowTextKey}}"/>

--- a/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml
+++ b/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml
@@ -43,7 +43,7 @@
                      Background="{DynamicResource {x:Static wpf:Brushes.BackgroundBrushKey}}" 
                      Foreground="{DynamicResource {x:Static wpf:Brushes.UITextKey}}" 
                      IsReadOnly="True" AutomationProperties.Name="{x:Static pkg:Resources.Tab_InputFile}"/>
-            <Button Grid.Column="2" x:Name="FileOpenButton" Padding="0" Content="..." Click="FileOpenButton_Click" VerticalAlignment="Center"
+            <Button Grid.Column="2" x:Name="FileOpenButton" Padding="0" Content="..." Name="{x:Static pkg:Resources.Browse}" Click="FileOpenButton_Click" VerticalAlignment="Center"
                     Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" MinHeight="22" MinWidth="22" 
                     FontSize="{Binding ElementName=Self, Path=FontSize, Converter={x:Static wpf:Converters.Scale155}}" 
                     Foreground="{DynamicResource {x:Static wpf:Brushes.WindowTextKey}}"/>

--- a/src/Package/Impl/Resources.Designer.cs
+++ b/src/Package/Impl/Resources.Designer.cs
@@ -115,6 +115,15 @@ namespace Microsoft.VisualStudio.R.Package {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Browse.
+        /// </summary>
+        public static string Browse {
+            get {
+                return ResourceManager.GetString("Browse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to External.
         /// </summary>
         public static string BrowserType_External {

--- a/src/Package/Impl/Resources.resx
+++ b/src/Package/Impl/Resources.resx
@@ -1153,4 +1153,7 @@ Click OK to open MiKTeX download page in the default browser. R Remote Services 
   <data name="RunPropertyPage_TransferFilesFilter" xml:space="preserve">
     <value>Files to transfer</value>
   </data>
+  <data name="Browse" xml:space="preserve">
+    <value>Browse</value>
+  </data>
 </root>

--- a/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
@@ -140,7 +140,8 @@
                                  Background="{DynamicResource {x:Static rwpf:Brushes.BackgroundBrushKey}}" 
                                  Foreground="{DynamicResource {x:Static rwpf:Brushes.UITextKey}}"
                                  ToolTip="{Binding Path=NameTextBoxTooltip}"
-                                 IsVisibleChanged="TextBoxName_IsVisibleChanged"/>
+                                 IsVisibleChanged="TextBoxName_IsVisibleChanged"
+                                 AutomationProperties.Name="{Binding Path=NameTextBoxTooltip}"/>
 
                         <TextBox Grid.Row="1" Grid.Column="1" Style="{StaticResource InputTextBoxStyle}" 
                                  Text="{Binding Path=Path, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -149,12 +150,14 @@
                                  LostFocus="PathTextBox_LostFocus"
                                  Background="{DynamicResource {x:Static rwpf:Brushes.BackgroundBrushKey}}"
                                  Foreground="{DynamicResource {x:Static rwpf:Brushes.UITextKey}}"
-                                 ToolTip="{Binding Path=PathTextBoxTooltip}"/>
+                                 ToolTip="{Binding Path=PathTextBoxTooltip}"
+                                 AutomationProperties.Name="{Binding Path=PathTextBoxTooltip}"/>
 
                         <Button Grid.Row="1" Grid.Column="2" Margin="3,0,0,6" Padding="2,0,2,0" Content="..." 
                                 VerticalAlignment="Stretch" MinHeight="0" MinWidth="0" Click="ButtonPath_Click"
                                 IsEnabled="{Binding Path=IsUserCreated}" 
-                                Visibility="{Binding Path=IsRemote, Converter={x:Static rwpf:Converters.TrueIsCollapsed}}"/>
+                                Visibility="{Binding Path=IsRemote, Converter={x:Static rwpf:Converters.TrueIsCollapsed}}"
+                                AutomationProperties.Name="{x:Static components:Resources.Browse}"/>
 
                         <TextBox Grid.Row="2" Grid.Column="1" Style="{StaticResource InputTextBoxStyle}" 
                                  Text="{Binding Path=RCommandLineArguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -167,7 +170,8 @@
                                     VerticalAlignment="Center" Click="ButtonSave_Click" 
                                     Style="{StaticResource ToolWindowButtonStyle}"  ToolTipService.ShowOnDisabled="True"
                                     Content="{x:Static components:Resources.ConnectionManager_Save}" 
-                                    ToolTip="{Binding Path=SaveButtonTooltip}">
+                                    ToolTip="{Binding Path=SaveButtonTooltip}"
+                                    AutomationProperties.Name="{Binding Path=SaveButtonTooltip}">
                                 <Button.IsEnabled>
                                     <MultiBinding Converter="{x:Static rwpf:Converters.All}">
                                         <Binding Path="IsValid" />
@@ -194,7 +198,8 @@
 -->
                             <Button VerticalAlignment="Center" Click="ButtonCancel_Click"
                                     Style="{StaticResource HyperlinkButton}"
-                                    Content="{x:Static components:Resources.ConnectionManager_Cancel}"/>
+                                    Content="{x:Static components:Resources.ConnectionManager_Cancel}"
+                                    IsCancel="True" AutomationProperties.Name="{x:Static components:Resources.ConnectionManager_Cancel}"/>
 
                         </WrapPanel>
 
@@ -284,12 +289,14 @@
                         </Button>
 
                         <!-- edit/properties button -->
-                        <Button x:Name="ButtonEdit" Grid.Row="0" Grid.Column="4" Style="{StaticResource EditButtonStyle}">
+                        <Button x:Name="ButtonEdit" Grid.Row="0" Grid.Column="4" Style="{StaticResource EditButtonStyle}"
+                                AutomationProperties.Name="{x:Static components:Resources.ConnectionManager_EditConnection}">
                             <imaging:CrispImage  Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.Settings}" />
                         </Button>
 
                         <!-- delete button -->
-                        <Button x:Name="ButtonDelete" Grid.Row="0" Grid.Column="5" Style="{StaticResource DeleteButtonStyle}">
+                        <Button x:Name="ButtonDelete" Grid.Row="0" Grid.Column="5" Style="{StaticResource DeleteButtonStyle}"
+                                AutomationProperties.Name="{x:Static components:Resources.ConnectionManager_DeleteConnection}">
                             <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.Cancel}" 
                                                 Grayscale="{Binding Path=IsUserCreated, Converter={x:Static rwpf:Converters.Not}}" />
                         </Button>
@@ -380,6 +387,7 @@
                     <Button x:Name="ToggleButtonAdd" Style="{StaticResource HyperlinkDownArrowButton}"
                             IsEnabled="{Binding Path=IsEditingNew, Converter={x:Static rwpf:Converters.Not}}"
                             Content="{x:Static components:Resources.ConnectionManager_Add}"
+                            AutomationProperties.Name="{x:Static components:Resources.ConnectionManager_Add}"
                             Click="ButtonAdd_Click"/>
                 </WrapPanel>
 

--- a/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
+++ b/src/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
@@ -289,14 +289,12 @@
                         </Button>
 
                         <!-- edit/properties button -->
-                        <Button x:Name="ButtonEdit" Grid.Row="0" Grid.Column="4" Style="{StaticResource EditButtonStyle}"
-                                AutomationProperties.Name="{x:Static components:Resources.ConnectionManager_EditConnection}">
+                        <Button x:Name="ButtonEdit" Grid.Row="0" Grid.Column="4" Style="{StaticResource EditButtonStyle}">
                             <imaging:CrispImage  Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.Settings}" />
                         </Button>
 
                         <!-- delete button -->
-                        <Button x:Name="ButtonDelete" Grid.Row="0" Grid.Column="5" Style="{StaticResource DeleteButtonStyle}"
-                                AutomationProperties.Name="{x:Static components:Resources.ConnectionManager_DeleteConnection}">
+                        <Button x:Name="ButtonDelete" Grid.Row="0" Grid.Column="5" Style="{StaticResource DeleteButtonStyle}">
                             <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static imagecatalog:KnownMonikers.Cancel}" 
                                                 Grayscale="{Binding Path=IsUserCreated, Converter={x:Static rwpf:Converters.Not}}" />
                         </Button>

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
@@ -93,7 +93,7 @@
                         Content="{x:Static local:Resources.Install}"
                         Visibility="{Binding Path=IsInstalled, Converter={x:Static wpf:Converters.TrueIsCollapsed}}"
                         IsEnabled="{Binding Path=IsChanging, Converter={x:Static wpf:Converters.Not}}" 
-                        Focusable="{Binding Path=IsInstalled"/>
+                        Focusable="{Binding Path=IsInstalled}"/>
 
                 <Button Grid.Row="3" Grid.Column="4" MinWidth="100" MinHeight="24" HorizontalAlignment="Left" Click="ButtonUpdate_Click" Content="{x:Static local:Resources.Update}"
                         IsEnabled="{Binding Path=IsChanging, Converter={x:Static wpf:Converters.Not}}">

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
@@ -75,7 +75,7 @@
                         </MultiBinding>
                     </Button.Visibility>
                     <Button.Focusable>
-                        <MultiBinding Converter="{x:Static wpf:Converters.AllIsNotHidden}">
+                        <MultiBinding Converter="{x:Static wpf:Converters.All}">
                             <Binding Path="CanBeUninstalled" />
                             <Binding Path="IsInstalled" />
                         </MultiBinding>
@@ -104,7 +104,7 @@
                         </MultiBinding>
                     </Button.Visibility>
                     <Button.Focusable>
-                        <MultiBinding Converter="{x:Static wpf:Converters.AllIsNotCollapsed}" Mode="OneWay">
+                        <MultiBinding Converter="{x:Static wpf:Converters.All}" Mode="OneWay">
                             <Binding Path="IsUpdateAvailable" />
                             <Binding Path="IsInstalled" />
                         </MultiBinding>

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
@@ -37,7 +37,9 @@
             <StackPanel Grid.Row="0" Orientation="Horizontal" MinHeight="32" Margin="0,8">
 
                 <TextBox Background="Transparent" Foreground="{DynamicResource {x:Static wpf:Brushes.UITextKey}}" BorderThickness="0" Margin="-2,0,-2,0"
-                         Text="{Binding Path=Name, Mode=OneWay}" IsReadOnly="True" FontSize="{Binding ElementName=Self, Path=FontSize, Converter={x:Static wpf:Converters.Scale155}}" />
+                         Text="{Binding Path=Name, Mode=OneWay}" IsReadOnly="True" 
+                         FontSize="{Binding ElementName=Self, Path=FontSize, Converter={x:Static wpf:Converters.Scale155}}" 
+                         Focusable="False"/>
             </StackPanel>
 
             <!-- project action when in project package manager -->
@@ -72,6 +74,12 @@
                             <Binding Path="IsInstalled" />
                         </MultiBinding>
                     </Button.Visibility>
+                    <Button.Focusable>
+                        <MultiBinding Converter="{x:Static wpf:Converters.AllIsNotHidden}">
+                            <Binding Path="CanBeUninstalled" />
+                            <Binding Path="IsInstalled" />
+                        </MultiBinding>
+                    </Button.Focusable>
                 </Button>
 
                 <!-- Row 2 -->
@@ -81,9 +89,11 @@
                            Visibility="{Binding Path=LatestVersion, Converter={x:Static wpf:Converters.NullIsCollapsed}}" />
 
                 <!-- install button and update button. They are in fact the same button. Which one is displayed depends on whether InstalledVersion is null. -->
-                <Button Grid.Row="3" Grid.Column="4" MinWidth="100" MinHeight="24" HorizontalAlignment="Left" Click="ButtonInstall_Click" Content="{x:Static local:Resources.Install}"
+                <Button Grid.Row="3" Grid.Column="4" MinWidth="100" MinHeight="24" HorizontalAlignment="Left" Click="ButtonInstall_Click" 
+                        Content="{x:Static local:Resources.Install}"
                         Visibility="{Binding Path=IsInstalled, Converter={x:Static wpf:Converters.TrueIsCollapsed}}"
-                        IsEnabled="{Binding Path=IsChanging, Converter={x:Static wpf:Converters.Not}}" />
+                        IsEnabled="{Binding Path=IsChanging, Converter={x:Static wpf:Converters.Not}}" 
+                        Focusable="{Binding Path=IsInstalled, Converter={x:Static wpf:Converters.TrueIsCollapsed}}"/>
 
                 <Button Grid.Row="3" Grid.Column="4" MinWidth="100" MinHeight="24" HorizontalAlignment="Left" Click="ButtonUpdate_Click" Content="{x:Static local:Resources.Update}"
                         IsEnabled="{Binding Path=IsChanging, Converter={x:Static wpf:Converters.Not}}">
@@ -93,6 +103,12 @@
                             <Binding Path="IsInstalled" />
                         </MultiBinding>
                     </Button.Visibility>
+                    <Button.Focusable>
+                        <MultiBinding Converter="{x:Static wpf:Converters.AllIsNotCollapsed}" Mode="OneWay">
+                            <Binding Path="IsUpdateAvailable" />
+                            <Binding Path="IsInstalled" />
+                        </MultiBinding>
+                    </Button.Focusable>
                 </Button>
             </Grid>
 

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageDetails.xaml
@@ -93,7 +93,7 @@
                         Content="{x:Static local:Resources.Install}"
                         Visibility="{Binding Path=IsInstalled, Converter={x:Static wpf:Converters.TrueIsCollapsed}}"
                         IsEnabled="{Binding Path=IsChanging, Converter={x:Static wpf:Converters.Not}}" 
-                        Focusable="{Binding Path=IsInstalled, Converter={x:Static wpf:Converters.TrueIsCollapsed}}"/>
+                        Focusable="{Binding Path=IsInstalled"/>
 
                 <Button Grid.Row="3" Grid.Column="4" MinWidth="100" MinHeight="24" HorizontalAlignment="Left" Click="ButtonUpdate_Click" Content="{x:Static local:Resources.Update}"
                         IsEnabled="{Binding Path=IsChanging, Converter={x:Static wpf:Converters.Not}}">

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
@@ -37,7 +37,7 @@
                         <!-- Load button -->
                         <Button x:Name="ButtonLoad" Grid.Column="1" Style="{StaticResource ToolWindowButtonStyle}" 
                                 Click="ButtonLoad_Click" VerticalAlignment="Center"
-                                Name="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_LoadButtonToolTip}}">
+                                AutomationProperties.Name="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_LoadButtonToolTip}}">
                             <Button.Visibility>
                                 <MultiBinding Converter="{x:Static rwpf:Converters.AllIsNotHidden}">
                                     <Binding Path="IsLoaded" Converter="{x:Static rwpf:Converters.Not}" />
@@ -54,7 +54,8 @@
                         <Button x:Name="ButtonUnload" Grid.Column="1" 
                                 Style="{StaticResource ToolWindowButtonStyle}" Click="ButtonUnload_Click" 
                                 Visibility="{Binding Path=IsLoaded, Converter={x:Static rwpf:Converters.FalseIsCollapsed}}"
-                                VerticalAlignment="Center" Name="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_UnloadButtonToolTip}}">
+                                VerticalAlignment="Center" 
+                                AutomationProperties.Name="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_UnloadButtonToolTip}}">
                             <Button.ToolTip>
                                 <TextBlock Text="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_UnloadButtonToolTip}}" />
                             </Button.ToolTip>
@@ -102,7 +103,7 @@
                             <Button x:Name="ButtonUninstall" Grid.Column="1" Style="{StaticResource ToolWindowButtonStyle}"
                                     Click="ButtonUninstall_Click"
                                     ToolTip="{x:Static components:Resources.PackageManager_UninstallButtonToolTip}"
-                                    Name="{x:Static components:Resources.PackageManager_UninstallButtonToolTip}">
+                                    AutomationProperties.Name="{x:Static components:Resources.PackageManager_UninstallButtonToolTip}">
                                 <Button.Visibility>
                                     <MultiBinding Converter="{x:Static rwpf:Converters.AllIsNotHidden}">
                                         <Binding Path="CanBeUninstalled" />
@@ -116,12 +117,12 @@
                             <Button x:Name="ButtonInstall" Grid.Column="1" Style="{StaticResource ToolWindowButtonStyle}"
                                     Click="ButtonInstall_Click"
                                     Visibility="{Binding Path=IsInstalled, Converter={x:Static rwpf:Converters.TrueIsCollapsed}}">
-                                <Button.Name>
+                                <AutomationProperties.Name>
                                     <MultiBinding StringFormat="{x:Static components:Resources.PackageManager_InstallButtonToolTip}">
                                         <Binding Path="Name" />
                                         <Binding Path="LatestVersion" />
                                     </MultiBinding>
-                                </Button.Name>
+                                </AutomationProperties.Name>
                                 <Button.ToolTip>
                                     <TextBlock>
                                         <TextBlock.Text>
@@ -146,12 +147,12 @@
 
                             <!-- update button -->
                             <Button x:Name="ButtonUpdate" Grid.Column="3" Style="{StaticResource ToolWindowButtonStyle}" Click="ButtonUpdate_Click">
-                                <Button.Name>
+                                <AutomationProperties.Name>
                                     <MultiBinding StringFormat="{x:Static components:Resources.PackageManager_UpdateButtonToolTip}">
                                         <Binding Path="Name" />
                                         <Binding Path="LatestVersion" />
                                     </MultiBinding>
-                                </Button.Name>
+                                </AutomationProperties.Name>
                                 <Button.ToolTip>
                                     <TextBlock>
                                         <TextBlock.Text>
@@ -196,7 +197,8 @@
                 <CheckBox x:Name="CheckBoxSelectAllPackages" Grid.Column="0" Margin="16, 8" VerticalAlignment="Center"
                           Foreground="{DynamicResource {x:Static rwpf:Brushes.UITextKey}}" Content="{x:Static components:Resources.PackageManager_SelectAllPackages}" />
                 <Button x:Name="ButtonUpdate" Grid.Column="2" MinWidth="100" MinHeight="24" Margin="24,8" VerticalAlignment="Center"
-                        Click="ButtonUpdate_Click" Content="{x:Static components:Resources.Update}" Name="{x:Static components:Resources.Update}"/>
+                        Click="ButtonUpdate_Click" Content="{x:Static components:Resources.Update}"
+                        AutomationProperties.Name="{x:Static components:Resources.Update}"/>
             </Grid>
         </Border>
         <Grid DockPanel.Dock="Bottom" Background="{DynamicResource {x:Static rwpf:Brushes.ListPaneBackgroundKey}}">

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageList.xaml
@@ -35,8 +35,9 @@
                                   Visibility="{Binding Path=CheckBoxesEnabled, RelativeSource={RelativeSource AncestorType={x:Type view:PackageList}}, Converter={x:Static rwpf:Converters.FalseIsCollapsed}}"/>
 
                         <!-- Load button -->
-                        <Button x:Name="ButtonLoad" Grid.Column="1" Style="{StaticResource ToolWindowButtonStyle}" Click="ButtonLoad_Click"
-                                VerticalAlignment="Center">
+                        <Button x:Name="ButtonLoad" Grid.Column="1" Style="{StaticResource ToolWindowButtonStyle}" 
+                                Click="ButtonLoad_Click" VerticalAlignment="Center"
+                                Name="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_LoadButtonToolTip}}">
                             <Button.Visibility>
                                 <MultiBinding Converter="{x:Static rwpf:Converters.AllIsNotHidden}">
                                     <Binding Path="IsLoaded" Converter="{x:Static rwpf:Converters.Not}" />
@@ -50,8 +51,10 @@
                         </Button>
 
                         <!-- Unload button -->
-                        <Button x:Name="ButtonUnload" Grid.Column="1" Style="{StaticResource ToolWindowButtonStyle}" Click="ButtonUnload_Click" 
-                                        Visibility="{Binding Path=IsLoaded, Converter={x:Static rwpf:Converters.FalseIsCollapsed}}" VerticalAlignment="Center">
+                        <Button x:Name="ButtonUnload" Grid.Column="1" 
+                                Style="{StaticResource ToolWindowButtonStyle}" Click="ButtonUnload_Click" 
+                                Visibility="{Binding Path=IsLoaded, Converter={x:Static rwpf:Converters.FalseIsCollapsed}}"
+                                VerticalAlignment="Center" Name="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_UnloadButtonToolTip}}">
                             <Button.ToolTip>
                                 <TextBlock Text="{Binding Path=Name, StringFormat={x:Static components:Resources.PackageManager_UnloadButtonToolTip}}" />
                             </Button.ToolTip>
@@ -96,8 +99,10 @@
                             </TextBlock>
 
                             <!-- uninstall button -->
-                            <Button x:Name="ButtonUninstall" Grid.Column="1" Style="{StaticResource ToolWindowButtonStyle}" Click="ButtonUninstall_Click"
-                                    ToolTip="{x:Static components:Resources.PackageManager_UninstallButtonToolTip}">
+                            <Button x:Name="ButtonUninstall" Grid.Column="1" Style="{StaticResource ToolWindowButtonStyle}"
+                                    Click="ButtonUninstall_Click"
+                                    ToolTip="{x:Static components:Resources.PackageManager_UninstallButtonToolTip}"
+                                    Name="{x:Static components:Resources.PackageManager_UninstallButtonToolTip}">
                                 <Button.Visibility>
                                     <MultiBinding Converter="{x:Static rwpf:Converters.AllIsNotHidden}">
                                         <Binding Path="CanBeUninstalled" />
@@ -108,8 +113,15 @@
                             </Button>
 
                             <!-- install button -->
-                            <Button x:Name="ButtonInstall" Grid.Column="1" Style="{StaticResource ToolWindowButtonStyle}" Click="ButtonInstall_Click" 
+                            <Button x:Name="ButtonInstall" Grid.Column="1" Style="{StaticResource ToolWindowButtonStyle}"
+                                    Click="ButtonInstall_Click"
                                     Visibility="{Binding Path=IsInstalled, Converter={x:Static rwpf:Converters.TrueIsCollapsed}}">
+                                <Button.Name>
+                                    <MultiBinding StringFormat="{x:Static components:Resources.PackageManager_InstallButtonToolTip}">
+                                        <Binding Path="Name" />
+                                        <Binding Path="LatestVersion" />
+                                    </MultiBinding>
+                                </Button.Name>
                                 <Button.ToolTip>
                                     <TextBlock>
                                         <TextBlock.Text>
@@ -134,6 +146,12 @@
 
                             <!-- update button -->
                             <Button x:Name="ButtonUpdate" Grid.Column="3" Style="{StaticResource ToolWindowButtonStyle}" Click="ButtonUpdate_Click">
+                                <Button.Name>
+                                    <MultiBinding StringFormat="{x:Static components:Resources.PackageManager_UpdateButtonToolTip}">
+                                        <Binding Path="Name" />
+                                        <Binding Path="LatestVersion" />
+                                    </MultiBinding>
+                                </Button.Name>
                                 <Button.ToolTip>
                                     <TextBlock>
                                         <TextBlock.Text>
@@ -178,7 +196,7 @@
                 <CheckBox x:Name="CheckBoxSelectAllPackages" Grid.Column="0" Margin="16, 8" VerticalAlignment="Center"
                           Foreground="{DynamicResource {x:Static rwpf:Brushes.UITextKey}}" Content="{x:Static components:Resources.PackageManager_SelectAllPackages}" />
                 <Button x:Name="ButtonUpdate" Grid.Column="2" MinWidth="100" MinHeight="24" Margin="24,8" VerticalAlignment="Center"
-                        Click="ButtonUpdate_Click" Content="{x:Static components:Resources.Update}" />
+                        Click="ButtonUpdate_Click" Content="{x:Static components:Resources.Update}" Name="{x:Static components:Resources.Update}"/>
             </Grid>
         </Border>
         <Grid DockPanel.Dock="Bottom" Background="{DynamicResource {x:Static rwpf:Brushes.ListPaneBackgroundKey}}">

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageManagerControl.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageManagerControl.xaml
@@ -95,7 +95,7 @@
                     <GridSplitter Grid.Column="1" Width="4" Grid.RowSpan="2" HorizontalAlignment="Center" VerticalAlignment="Stretch" BorderThickness="1,0"
                                   Background="{DynamicResource {x:Static rwpf:Brushes.SplitterBackgroundKey}}" 
                                   BorderBrush="{DynamicResource {x:Static rwpf:Brushes.ActiveBorderKey}}"
-                                  Name="{x:Static components:Resources.PackageManager_VerticalSplitter}"/>
+                                  AutomationProperties.Name="{x:Static components:Resources.PackageManager_VerticalSplitter}"/>
 
                     <!-- right side -->
                     <view:PackageDetails x:Name="PackageDetails" Grid.Column="2" Grid.RowSpan="2" DataContext="{Binding Path=SelectedPackage}" 

--- a/src/R/Components/Impl/PackageManager/Implementation/View/PackageManagerControl.xaml
+++ b/src/R/Components/Impl/PackageManager/Implementation/View/PackageManagerControl.xaml
@@ -93,7 +93,9 @@
                     </Grid>
 
                     <GridSplitter Grid.Column="1" Width="4" Grid.RowSpan="2" HorizontalAlignment="Center" VerticalAlignment="Stretch" BorderThickness="1,0"
-                                  Background="{DynamicResource {x:Static rwpf:Brushes.SplitterBackgroundKey}}" BorderBrush="{DynamicResource {x:Static rwpf:Brushes.ActiveBorderKey}}" />
+                                  Background="{DynamicResource {x:Static rwpf:Brushes.SplitterBackgroundKey}}" 
+                                  BorderBrush="{DynamicResource {x:Static rwpf:Brushes.ActiveBorderKey}}"
+                                  Name="{x:Static components:Resources.PackageManager_VerticalSplitter}"/>
 
                     <!-- right side -->
                     <view:PackageDetails x:Name="PackageDetails" Grid.Column="2" Grid.RowSpan="2" DataContext="{Binding Path=SelectedPackage}" 

--- a/src/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml
+++ b/src/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml
@@ -61,7 +61,9 @@
                                 <Setter.Value>
                                     <ControlTemplate TargetType="{x:Type GroupItem}">
                                         <StackPanel>
-                                            <controls:ExpandCollapseButton x:Name="Expander" IsExpanded="True" Content="{Binding Path=Name}" Style="{StaticResource ExpandCollapseButtonStyle}"/>
+                                            <controls:ExpandCollapseButton x:Name="Expander" IsExpanded="True" 
+                                                   Content="{Binding Path=Name}" Style="{StaticResource ExpandCollapseButtonStyle}"
+                                                   AutomationProperties.Name="{Binding Path=Name}"/>
                                             <ItemsPresenter Margin="4" Visibility="{Binding ElementName=Expander, Path=IsExpanded, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}"/>
                                             <Separator Margin="8 4 8 8" Foreground="{DynamicResource {x:Static rwpf:Brushes.BorderBrushKey}}"/>
                                         </StackPanel>

--- a/src/R/Components/Impl/Resources.Designer.cs
+++ b/src/R/Components/Impl/Resources.Designer.cs
@@ -1273,6 +1273,15 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Vertical splitter.
+        /// </summary>
+        public static string PackageManager_VerticalSplitter {
+            get {
+                return ResourceManager.GetString("PackageManager_VerticalSplitter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Physical Memory: {0} MB, {1} MB free.
         /// </summary>
         public static string PhysicalMemory {

--- a/src/R/Components/Impl/Resources.Designer.cs
+++ b/src/R/Components/Impl/Resources.Designer.cs
@@ -70,6 +70,15 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Browse.
+        /// </summary>
+        public static string Browse {
+            get {
+                return ResourceManager.GetString("Browse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cancel.
         /// </summary>
         public static string Cancel {
@@ -169,6 +178,15 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete connection.
+        /// </summary>
+        public static string ConnectionManager_DeleteConnection {
+            get {
+                return ResourceManager.GetString("ConnectionManager_DeleteConnection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deleting &quot;{0}&quot;.
         /// </summary>
         public static string ConnectionManager_DeleteConnectionProgressBarMessage {
@@ -201,6 +219,15 @@ namespace Microsoft.R.Components {
         public static string ConnectionManager_Disconnected {
             get {
                 return ResourceManager.GetString("ConnectionManager_Disconnected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit connection.
+        /// </summary>
+        public static string ConnectionManager_EditConnection {
+            get {
+                return ResourceManager.GetString("ConnectionManager_EditConnection", resourceCulture);
             }
         }
         

--- a/src/R/Components/Impl/Resources.resx
+++ b/src/R/Components/Impl/Resources.resx
@@ -696,4 +696,13 @@ This prompt can be suppressed in R Tools | Options.
   <data name="PackageManager_VerticalSplitter" xml:space="preserve">
     <value>Vertical splitter</value>
   </data>
+  <data name="Browse" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="ConnectionManager_DeleteConnection" xml:space="preserve">
+    <value>Delete connection</value>
+  </data>
+  <data name="ConnectionManager_EditConnection" xml:space="preserve">
+    <value>Edit connection</value>
+  </data>
 </root>

--- a/src/R/Components/Impl/Resources.resx
+++ b/src/R/Components/Impl/Resources.resx
@@ -693,4 +693,7 @@ This prompt can be suppressed in R Tools | Options.
   <data name="Error_OdbcDriver" xml:space="preserve">
     <value>Connection to SQL database in Azure requires SQL ODBC driver 13.1 or higher. Please install the latest Microsoft ODBC Driver from {0}.</value>
   </data>
+  <data name="PackageManager_VerticalSplitter" xml:space="preserve">
+    <value>Vertical splitter</value>
+  </data>
 </root>


### PR DESCRIPTION
VSTS stuff assigned to me

**407002** Accessibility : MAS05A : Keyboard R Tools+R Packages : KB focus invisible over package name in package description pane
**402127** Accessibility : MAS40B : Inspect : Name property is empty for all Edit boxes and combo boxes in "Import DataSet" window
**407002** Accessibility : MAS05A : Keyboard R Tools+R Packages : KB focus invisible over package name in package description pane
**406548** Accessibility : MAS40B : INPSECT : R Tools + R Packages : Name property for the thumb is null in R Packages window
**406112** Accessibility : MAS40B : INPSECT : R Tools + R Packages : Name property for buttons is null in R Packages window
**406109** Accessibility : MAS40 : INSPECT : R Tools + R Plot History : Device Number and expand collapse button in R Plot History is not programatically defined
**406110** Accessibility : MAS40B : INSPECT : R Tools + Workspace : Name property for the edit in Workspace window is null