### PR TITLE
Fix #3606: RTVS crashes when loading breast cancer NKI dataset into global environment in R interactive

### DIFF
--- a/src/Host/Client/Impl/rtvs/R/eval.R
+++ b/src/Host/Client/Impl/rtvs/R/eval.R
@@ -68,6 +68,8 @@ describe_object <- function(obj, res, fields, repr = NULL) {
 
     if (field('dim')) {
         dim <- NA_if_error(dim(obj));
+		names(dim) <- NULL;
+
         # Since the entire dimension vector is serialized, restrict exceedingly large numbers of dimensions.
         if (is.integer(dim) && !anyNA(dim) && length(dim) < 1000) {
             res$dim <- as.list(dim);


### PR DESCRIPTION
Properly handle the case when `dim(x)` has named elements.