### PR TITLE
#3594 RHostSession not terminate RHostBroker

### DIFF
--- a/src/Host/API/Test/RSessionApiTest.cs
+++ b/src/Host/API/Test/RSessionApiTest.cs
@@ -44,15 +44,14 @@ namespace Microsoft.R.Host.Client.Test.Session {
             result.Should().Be(2);
 
             Process.GetProcesses()
-                .Any(p => p.ProcessName.EqualsIgnoreCase("Microsoft.R.Host.Broker.exe"))
+                .Any(p => p.ProcessName.EqualsIgnoreCase("Microsoft.R.Host.Broker"))
                 .Should()
                 .BeTrue();
 
             RHostSession.TerminateBroker();
-            _session.IsHostRunning.Should().BeFalse();
 
             Process.GetProcesses()
-                .Any(p => p.ProcessName.EqualsIgnoreCase("Microsoft.R.Host.Broker.exe"))
+                .Any(p => p.ProcessName.EqualsIgnoreCase("Microsoft.R.Host.Broker"))
                 .Should()
                 .BeFalse();
         }

--- a/src/Host/API/Test/RSessionApiTest.cs
+++ b/src/Host/API/Test/RSessionApiTest.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Common.Core;
 using Microsoft.UnitTests.Core.FluentAssertions;
 using Microsoft.UnitTests.Core.XUnit;
 using NSubstitute;
@@ -40,6 +42,19 @@ namespace Microsoft.R.Host.Client.Test.Session {
 
             var result = await _session.EvaluateAsync<int>("1+1");
             result.Should().Be(2);
+
+            Process.GetProcesses()
+                .Any(p => p.ProcessName.EqualsIgnoreCase("Microsoft.R.Host.Broker.exe"))
+                .Should()
+                .BeTrue();
+
+            RHostSession.TerminateBroker();
+            _session.IsHostRunning.Should().BeFalse();
+
+            Process.GetProcesses()
+                .Any(p => p.ProcessName.EqualsIgnoreCase("Microsoft.R.Host.Broker.exe"))
+                .Should()
+                .BeFalse();
         }
 
         [Test]


### PR DESCRIPTION
Added method to terminate broker process. This is scoped fix for Release/1_0. Will restore project and refresh API for 1.2+ separately.