### PR TITLE
Default code page fix +  crash fix

### DIFF
--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -222,11 +222,13 @@ grDevices::deviceIsInteractive('ide')
 
         public static async Task SetCodePageAsync(this IRExpressionEvaluator evaluation, int codePage, CancellationToken cancellationToken = default(CancellationToken)) {
             var cp = $".{codePage}";
-            if (codePage == 0) {
-                cp = await evaluation.IsRSessionPlatformWindowsAsync() ? ".437" : "en_US.UTF-8";
+            if (codePage == 0 && !await evaluation.IsRSessionPlatformWindowsAsync(cancellationToken)) {
+                cp = "en_US.UTF-8";
             }
-            var script = Invariant($"Sys.setlocale('LC_CTYPE', '{cp}')");
-            await evaluation.ExecuteAsync(script, cancellationToken);
+            if (!string.IsNullOrEmpty(cp)) {
+                var script = Invariant($"Sys.setlocale('LC_CTYPE', '{cp}')");
+                await evaluation.ExecuteAsync(script, cancellationToken);
+            }
         }
 
         public static Task OverrideFunctionAsync(this IRExpressionEvaluator evaluation, string name, string ns) {

--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -221,10 +221,17 @@ grDevices::deviceIsInteractive('ide')
         }
 
         public static async Task SetCodePageAsync(this IRExpressionEvaluator evaluation, int codePage, CancellationToken cancellationToken = default(CancellationToken)) {
-            var cp = $".{codePage}";
-            if (codePage == 0 && !await evaluation.IsRSessionPlatformWindowsAsync(cancellationToken)) {
-                cp = "en_US.UTF-8";
+            string cp = null;
+            if (codePage == 0) {
+                // Non-Windows defaults to UTF-8, on Windows leave default alone.
+                if (!await evaluation.IsRSessionPlatformWindowsAsync(cancellationToken)) {
+                    cp = "en_US.UTF-8";
+                }
             }
+            else {
+                cp = Invariant($".{codePage}");
+            }
+
             if (!string.IsNullOrEmpty(cp)) {
                 var script = Invariant($"Sys.setlocale('LC_CTYPE', '{cp}')");
                 await evaluation.ExecuteAsync(script, cancellationToken);

--- a/src/Windows/R/Editor/Impl/Signatures/RSignatureHelp.cs
+++ b/src/Windows/R/Editor/Impl/Signatures/RSignatureHelp.cs
@@ -66,14 +66,14 @@ namespace Microsoft.R.Editor.Signatures {
         /// Current parameter for this signature.
         /// </summary>
         public IParameter CurrentParameter {
-            get => new RSignatureHelpParameter(this, FunctionSignatureHelp.CurrentParameter);
+            get => FunctionSignatureHelp.CurrentParameter != null ? new RSignatureHelpParameter(this, FunctionSignatureHelp.CurrentParameter) : null;
             set => FunctionSignatureHelp.CurrentParameter = (value as RSignatureHelpParameter)?.SignatureParameterHelp;
         }
         #endregion
 
         private void OnCurrentParameterChanged(object sender, SignatureParameterChangedEventArgs e) {
-            var prevParameter = new RSignatureHelpParameter(this, e.PreviousParameter);
-            var newParameter = new RSignatureHelpParameter(this, e.NewParameter);
+            var prevParameter = e.PreviousParameter != null ? new RSignatureHelpParameter(this, e.PreviousParameter) : null;
+            var newParameter = e.NewParameter != null ? new RSignatureHelpParameter(this, e.NewParameter) : null;
             CurrentParameterChanged?.Invoke(this, new CurrentParameterChangedEventArgs(prevParameter, newParameter));
         }
     }


### PR DESCRIPTION
Leave code page alone, R sets it correctly on its own (tried on Spanish Windows Language pack)
Fix crash in parameter-less signatures