### PR TITLE
 #3695 Drag-drop fails with: Cannot complete the drag and drop operation

### DIFF
--- a/src/Windows/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceCutCopyCommand.cs
+++ b/src/Windows/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceCutCopyCommand.cs
@@ -17,25 +17,17 @@ namespace Microsoft.R.Components.Plots.Implementation.Commands {
             _cut = cut;
         }
 
-        public CommandStatus Status {
-            get {
-                if (HasCurrentPlot && !IsInLocatorMode) {
-                    return CommandStatus.SupportedAndEnabled;
-                }
-
-                return CommandStatus.Supported;
-            }
-        }
+        public CommandStatus Status
+            => HasCurrentPlot && !IsInLocatorMode
+                ? CommandStatus.SupportedAndEnabled
+                : CommandStatus.Supported;
 
         public Task InvokeAsync() {
             try {
-                var data = PlotClipboardData.Serialize(new PlotClipboardData(VisualComponent.Device.DeviceId, VisualComponent.Device.ActivePlot.PlotId, _cut));
-                Clipboard.Clear();
-                Clipboard.SetData(PlotClipboardData.Format, data);
+                PlotClipboardData.ToClipboard(VisualComponent.Device.DeviceId, VisualComponent.Device.ActivePlot.PlotId, _cut);
             } catch (ExternalException ex) {
                 InteractiveWorkflow.Shell.ShowErrorMessage(ex.Message);
             }
-
             return Task.CompletedTask;
         }
     }

--- a/src/Windows/R/Components/Impl/Plots/Implementation/Commands/PlotHistoryCutCopyCommand.cs
+++ b/src/Windows/R/Components/Impl/Plots/Implementation/Commands/PlotHistoryCutCopyCommand.cs
@@ -22,9 +22,7 @@ namespace Microsoft.R.Components.Plots.Implementation.Commands {
             var selection = VisualComponent.SelectedPlots.ToList();
             if (selection.Count > 0) {
                 try {
-                    var data = selection.Select(p => PlotClipboardData.Serialize(new PlotClipboardData(p.ParentDevice.DeviceId, p.PlotId, _cut))).ToArray();
-                    Clipboard.Clear();
-                    Clipboard.SetData(PlotClipboardData.Format, data);
+                    PlotClipboardData.ToClipboard(selection);
                 } catch (ExternalException ex) {
                     InteractiveWorkflow.Shell.ShowErrorMessage(ex.Message);
                 }

--- a/src/Windows/R/Components/Impl/Plots/Implementation/PlotClipboardData.cs
+++ b/src/Windows/R/Components/Impl/Plots/Implementation/PlotClipboardData.cs
@@ -2,17 +2,20 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
 using Microsoft.Common.Core.Json;
 using Newtonsoft.Json;
 
 namespace Microsoft.R.Components.Plots.Implementation {
     [Serializable]
     internal class PlotClipboardData {
+        private const string Format = "RPlotRef";
+
         public Guid PlotId { get; }
         public Guid DeviceId { get; }
         public bool Cut { get; }
-
-        public const string Format = "RPlotRef";
 
         public PlotClipboardData(Guid deviceId, Guid plotId, bool cut) {
             DeviceId = deviceId;
@@ -20,11 +23,48 @@ namespace Microsoft.R.Components.Plots.Implementation {
             Cut = cut;
         }
 
-        public static string Serialize(PlotClipboardData data) {
-            return JsonConvert.SerializeObject(data);
+        public static IEnumerable<PlotClipboardData> FromDataObject(IDataObject dataObject) {
+            IEnumerable<PlotClipboardData> result = null;
+            if (dataObject != null && dataObject.GetDataPresent(Format)) {
+                var cbd = dataObject.GetData(Format) as string[];
+                result = cbd?.Select(Parse);
+            }
+            return result ?? Enumerable.Empty<PlotClipboardData>();
         }
 
-        public static PlotClipboardData Parse(string text) {
+        public static IDataObject ToDataObject(IEnumerable<IRPlot> plots)
+            => new DataObject(Format, Serialize(plots));
+
+        public static IDataObject ToDataObject(Guid deviceId, Guid plotId)
+            => new DataObject(Format, Serialize(deviceId, plotId));
+
+        public static IEnumerable<PlotClipboardData> FromClipboard()
+            => FromDataObject(Clipboard.GetDataObject());
+
+        public static void ToClipboard(IEnumerable<IRPlot> plots, bool cut = false) {
+            var data = Serialize(plots, cut);
+            Clipboard.Clear();
+            Clipboard.SetData(Format, data);
+        }
+
+        public static void ToClipboard(Guid deviceId, Guid plotId, bool cut = false) {
+            var data = Serialize(deviceId, plotId, cut);
+            Clipboard.Clear();
+            Clipboard.SetData(Format, data);
+        }
+
+        public static bool IsClipboardDataAvailable()
+            => Clipboard.GetDataObject()?.GetDataPresent(Format) ?? false;
+
+        private static string[] Serialize(IEnumerable<IRPlot> plots, bool cut = false)
+            => plots.Select(p => Serialize(new PlotClipboardData(p.ParentDevice.DeviceId, p.PlotId, cut))).ToArray();
+
+        private static string[] Serialize(Guid deviceId, Guid plotId, bool cut = false)
+            => new[] { Serialize(new PlotClipboardData(deviceId, plotId, cut)) };
+
+        private static string Serialize(PlotClipboardData data) => JsonConvert.SerializeObject(data);
+
+        private static PlotClipboardData Parse(string text) {
             try {
                 return Json.DeserializeObject<PlotClipboardData>(text);
             } catch (JsonReaderException) {

--- a/src/Windows/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml
+++ b/src/Windows/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml
@@ -50,8 +50,10 @@
                   BorderThickness="0"
                   MouseMove="HistoryListView_MouseMove"
                   MouseLeave="HistoryListView_MouseLeave"
-                  PreviewMouseDown="HistoryListView_PreviewMouseDown"
-                  MouseRightButtonUp="HistoryListView_MouseRightButtonUp">
+                  PreviewMouseLeftButtonDown="HistoryListView_PreviewMouseLeftButtonDown"
+                  PreviewMouseLeftButtonUp="HistoryListView_PreviewMouseLeftButtonUp"
+                  PreviewMouseRightButtonUp="HistoryListView_PreviewMouseRightButtonUp"
+                  PreviewMouseRightButtonDown="HistoryListView_PreviewMouseRightButtonDown">
             <ListView.GroupStyle>
                 <GroupStyle>
                     <GroupStyle.ContainerStyle>

--- a/src/Windows/R/Components/Impl/Plots/Implementation/ViewModel/RPlotHistoryViewModel.cs
+++ b/src/Windows/R/Components/Impl/Plots/Implementation/ViewModel/RPlotHistoryViewModel.cs
@@ -58,13 +58,8 @@ namespace Microsoft.R.Components.Plots.Implementation.ViewModel {
         public ObservableCollection<IRPlotHistoryEntryViewModel> Entries { get; } =
             new ObservableCollection<IRPlotHistoryEntryViewModel>();
 
-        public IEnumerable<IRPlotHistoryEntryViewModel> SelectedPlots {
-            get {
-                foreach (var item in _control.HistoryListView.SelectedItems) {
-                    yield return (IRPlotHistoryEntryViewModel)item;
-                }
-            }
-        }
+        public IEnumerable<IRPlotHistoryEntryViewModel> SelectedPlots 
+            => _control.HistoryListView.SelectedItems.Cast<IRPlotHistoryEntryViewModel>();
 
         public int ThumbnailSize {
             get => _thumbnailSize;


### PR DESCRIPTION
The issue was that some code still assumed `string` rather than `string[]`

Consolidated data object operations in one place so they are consistent across code and use same data representation. Also fixed multiselect (right click unselected elements)