### PR TITLE
Assorted small bug fixes

### DIFF
--- a/src/Common/Core/Test/Fixtures/ServiceManagerWithMefFixture.cs
+++ b/src/Common/Core/Test/Fixtures/ServiceManagerWithMefFixture.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Common.Core.Test.Fixtures {
 
         private sealed class TestServiceManagerWithMef : TestServiceManager {
             private readonly CompositionContainer _compositionContainer;
-            private readonly DisposeToken _disposeToken = DisposeToken.Create< TestServiceManagerWithMef>();
+            private readonly DisposeToken _disposeToken = DisposeToken.Create<TestServiceManagerWithMef>();
 
             public TestServiceManagerWithMef(ComposablePartCatalog catalog, Action<IServiceManager, ITestInput> addServices) : base(addServices) {
                 _compositionContainer = new CompositionContainer(catalog, CompositionOptions.DisableSilentRejection);
@@ -67,10 +67,12 @@ namespace Microsoft.Common.Core.Test.Fixtures {
             }
 
             public override T GetService<T>(Type type = null) {
-                if (_disposeToken.IsDisposed) {
-                    return null;
+                // Allow basic services even if disposed
+                var service = base.GetService<T>(type);
+                if (service == null && !_disposeToken.IsDisposed) {
+                    service = _compositionContainer.GetExportedValueOrDefault<T>();
                 }
-                return base.GetService<T>(type) ?? _compositionContainer.GetExportedValueOrDefault<T>();
+                return service;
             }
         }
     }

--- a/src/Package/Impl/Options/R/Editor/RLintOptionsDialog.cs
+++ b/src/Package/Impl/Options/R/Editor/RLintOptionsDialog.cs
@@ -234,8 +234,8 @@ namespace Microsoft.VisualStudio.R.Package.Options.R.Editor {
         [LocDescription("Settings_Lint_Semicolons_Description")]
         [DefaultValue(false)]
         public bool Semicolons {
-            get => _options.LineLength;
-            set => _options.LineLength = value;
+            get => _options.Semicolons;
+            set => _options.Semicolons = value;
         }
 
         [LocCategory("Settings_LintCategory_Statements")]

--- a/src/Package/Impl/Package.vsct
+++ b/src/Package/Impl/Package.vsct
@@ -1394,15 +1394,6 @@
         </Strings>
       </Button>
 
-      <!-- Check for Updates -->
-      <Button guid="guidRToolsCmdSet" id="icmdCheckForUpdates" priority="0x0400" type="Button">
-        <Parent guid="guidRToolsCmdSet" id="docsGroup"/>
-        <Strings>
-          <ButtonText>&amp;Check for Updates...</ButtonText>
-          <CommandName>Check for Updates</CommandName>
-        </Strings>
-      </Button>
-
       <!-- Survey/News -->
       <Button guid="guidRToolsCmdSet" id="icmdSurveyNews" priority="0x600" type="Button">
         <Parent guid="guidRToolsCmdSet" id="docsGroup"/>
@@ -2886,7 +2877,6 @@
       <IDSymbol name="icmdRDocsDataImportExport" value="1404" />
       <IDSymbol name="icmdRDocsWritingRExtensions" value="1405" />
       <IDSymbol name="icmdMicrosoftRProducts" value="1406" />
-      <IDSymbol name="icmdCheckForUpdates" value="1407" />
       <IDSymbol name="icmdInstallRClient" value="1408" />
 
       <!-- Project -->

--- a/src/Package/Impl/Shell/Services/VsPlotExportDialog.cs
+++ b/src/Package/Impl/Shell/Services/VsPlotExportDialog.cs
@@ -7,7 +7,7 @@ using Microsoft.R.Components.Plots;
 using Microsoft.VisualStudio.R.Package.ExportDialog;
 
 namespace Microsoft.VisualStudio.R.Package.Shell {
-    internal class VsPlotExportDialog : IRPlotExportDialogs {
+    internal class VsPlotExportDialog : IRPlotExportDialog {
         private readonly ICoreShell _shell;
 
         public VsPlotExportDialog(ICoreShell shell) {

--- a/src/Package/Impl/Templates/ItemTemplates/DatasetRD/datasetrd.vstemplate
+++ b/src/Package/Impl/Templates/ItemTemplates/DatasetRD/datasetrd.vstemplate
@@ -13,6 +13,6 @@
     <SortOrder>4</SortOrder>
   </TemplateData>
   <TemplateContent>
-    <ProjectItem ReplaceParameters="true" TargetFileName="$fileinputname$.$fileinputextension$" OpenInEditor="true">dataset.rd</ProjectItem>
+    <ProjectItem ReplaceParameters="true" TargetFileName="$fileinputname$.$fileinputextension$" OpenInEditor="true">Dataset.Rd</ProjectItem>
   </TemplateContent>
 </VSTemplate>

--- a/src/Package/Impl/Templates/ItemTemplates/EmptyRD/emptyrd.vstemplate
+++ b/src/Package/Impl/Templates/ItemTemplates/EmptyRD/emptyrd.vstemplate
@@ -13,6 +13,6 @@
     <SortOrder>2</SortOrder>
   </TemplateData>
   <TemplateContent>
-    <ProjectItem ReplaceParameters="true" TargetFileName="$fileinputname$.$fileinputextension$" OpenInEditor="true">document.rd</ProjectItem>
+    <ProjectItem ReplaceParameters="true" TargetFileName="$fileinputname$.$fileinputextension$" OpenInEditor="true">Document.Rd</ProjectItem>
   </TemplateContent>
 </VSTemplate>

--- a/src/Package/Impl/Templates/ItemTemplates/EmptyRMD/emptyrmd.vstemplate
+++ b/src/Package/Impl/Templates/ItemTemplates/EmptyRMD/emptyrmd.vstemplate
@@ -13,6 +13,6 @@
     <SortOrder>1</SortOrder>
   </TemplateData>
   <TemplateContent>
-    <ProjectItem TargetFileName="$fileinputname$.$fileinputextension$" OpenInEditor="true">markdown.rmd</ProjectItem>
+    <ProjectItem TargetFileName="$fileinputname$.$fileinputextension$" OpenInEditor="true">Markdown.Rmd</ProjectItem>
   </TemplateContent>
 </VSTemplate>

--- a/src/Package/Impl/Templates/ItemTemplates/FunctionRD/functionrd.vstemplate
+++ b/src/Package/Impl/Templates/ItemTemplates/FunctionRD/functionrd.vstemplate
@@ -13,6 +13,6 @@
     <SortOrder>5</SortOrder>
   </TemplateData>
   <TemplateContent>
-    <ProjectItem ReplaceParameters="true" TargetFileName="$fileinputname$.$fileinputextension$" OpenInEditor="true">function.rd</ProjectItem>
+    <ProjectItem ReplaceParameters="true" TargetFileName="$fileinputname$.$fileinputextension$" OpenInEditor="true">Function.Rd</ProjectItem>
   </TemplateContent>
 </VSTemplate>

--- a/src/Package/Impl/Templates/ItemTemplates/RScript/rscript.vstemplate
+++ b/src/Package/Impl/Templates/ItemTemplates/RScript/rscript.vstemplate
@@ -13,6 +13,6 @@
     <SortOrder>0</SortOrder>
   </TemplateData>
   <TemplateContent>
-    <ProjectItem TargetFileName="$fileinputname$.$fileinputextension$" OpenInEditor="true">script.R</ProjectItem>
+    <ProjectItem TargetFileName="$fileinputname$.$fileinputextension$" OpenInEditor="true">Script.R</ProjectItem>
   </TemplateContent>
 </VSTemplate>

--- a/src/R/Editor/Impl/Validation/IRDocumentValidator.cs
+++ b/src/R/Editor/Impl/Validation/IRDocumentValidator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.R.Editor.Validation {
         /// <summary>
         /// Called by validation manager when validation session is about to begin.
         /// </summary>
-        void OnBeginValidation(IREditorSettings settings, bool projectedBuffer);
+        void OnBeginValidation(IREditorSettings settings, bool projectedBuffer, bool linterEnabled);
 
         /// <summary>
         /// Called by validation manager/aggregator when validation session is completed.

--- a/src/R/Editor/Impl/Validation/IValidatorAggregator.cs
+++ b/src/R/Editor/Impl/Validation/IValidatorAggregator.cs
@@ -9,7 +9,7 @@ using Microsoft.R.Editor.Validation.Errors;
 
 namespace Microsoft.R.Editor.Validation {
     public interface IValidatorAggregator {
-        Task RunAsync(AstRoot ast, bool projectedBuffer, ConcurrentQueue<IValidationError> results, CancellationToken ct);
+        Task RunAsync(AstRoot ast, bool projectedBuffer, bool linterEnabled, ConcurrentQueue<IValidationError> results, CancellationToken ct);
         bool Busy { get; }
     }
 }

--- a/src/R/Editor/Impl/Validation/Lint/Lint.Nodes.cs
+++ b/src/R/Editor/Impl/Validation/Lint/Lint.Nodes.cs
@@ -297,10 +297,10 @@ namespace Microsoft.R.Editor.Validation.Lint {
         }
 
         private static bool IsCamelCase(string text)
-            => text.Length > 0 && char.IsLower(text[0]) && text.Any(char.IsUpper) && !IsSnakeCase(text);
+            => text.Length > 0 && char.IsLower(text[0]) && text.Any(char.IsUpper) && !IsSnakeCase(text) && text.All(c => c != '.');
 
         private static bool IsPascalCase(string text)
-            => text.Length > 0 && char.IsUpper(text[0]) && text.Any(char.IsLower) && !IsSnakeCase(text);
+            => text.Length > 0 && char.IsUpper(text[0]) && text.Any(char.IsLower) && !IsSnakeCase(text) && text.All(c => c != '.');
 
         private static bool IsSnakeCase(string text)
             => text.Length > 0 && text.Any(x => x == '_');

--- a/src/R/Editor/Impl/Validation/Lint/LintValidator.cs
+++ b/src/R/Editor/Impl/Validation/Lint/LintValidator.cs
@@ -43,16 +43,18 @@ namespace Microsoft.R.Editor.Validation.Lint {
 
         private IREditorSettings _settings;
         private bool _projectedBuffer;
+        private bool _linterEnabled;
 
-        public void OnBeginValidation(IREditorSettings settings, bool projectedBuffer) {
+        public void OnBeginValidation(IREditorSettings settings, bool projectedBuffer, bool linterEnabled) {
             _settings = settings;
             _projectedBuffer = projectedBuffer;
+            _linterEnabled = linterEnabled & settings.LintOptions.Enabled;
         }
 
         public void OnEndValidation() { }
 
         public IReadOnlyCollection<IValidationError> ValidateElement(IAstNode node) {
-            if (!_settings.LintOptions.Enabled) {
+            if (!_linterEnabled) {
                 return Enumerable.Empty<IValidationError>().ToList();
             }
 
@@ -69,7 +71,7 @@ namespace Microsoft.R.Editor.Validation.Lint {
         /// </summary>
         /// <returns>A collection of validation errors</returns>
         public IReadOnlyCollection<IValidationError> ValidateWhitespace(ITextProvider tp) {
-            if (!_settings.LintOptions.Enabled) {
+            if (!_linterEnabled) {
                 return Enumerable.Empty<IValidationError>().ToList();
             }
 

--- a/src/R/Editor/Impl/Validation/TreeValidator.cs
+++ b/src/R/Editor/Impl/Validation/TreeValidator.cs
@@ -171,7 +171,7 @@ namespace Microsoft.R.Editor.Validation {
                 }
                 // Run all validators
                 _cts = new CancellationTokenSource();
-                _aggregator.RunAsync(_editorTree.AstRoot, _projectedBuffer, ValidationResults, _cts.Token).DoNotWait();
+                _aggregator.RunAsync(_editorTree.AstRoot, _projectedBuffer, _lintCheckEnabled, ValidationResults, _cts.Token).DoNotWait();
             }
         }
 

--- a/src/R/Editor/Impl/Validation/ValidatorAggregator.cs
+++ b/src/R/Editor/Impl/Validation/ValidatorAggregator.cs
@@ -42,10 +42,10 @@ namespace Microsoft.R.Editor.Validation {
         /// Launches AST and file validation / syntax check.
         /// The process runs asyncronously.
         /// </summary>
-        public Task RunAsync(AstRoot ast, bool projectedBuffer, ConcurrentQueue<IValidationError> results, CancellationToken ct) {
+        public Task RunAsync(AstRoot ast, bool projectedBuffer, bool linterEnabled, ConcurrentQueue<IValidationError> results, CancellationToken ct) {
             _tcs = new TaskCompletionSource<bool>();
             try {
-                BeginValidation(_settings, projectedBuffer);
+                BeginValidation(_settings, projectedBuffer, linterEnabled);
                 _validationTask = Task.Run(() => {
                     var outcome = Validate(ast, ct);
                     foreach (var o in outcome) {
@@ -87,9 +87,9 @@ namespace Microsoft.R.Editor.Validation {
         }
         #endregion
 
-        private void BeginValidation(IREditorSettings settings, bool projectedBuffer) {
+        private void BeginValidation(IREditorSettings settings, bool projectedBuffer, bool linterEnabled) {
             foreach (var v in _validators) {
-                v.OnBeginValidation(settings, projectedBuffer);
+                v.OnBeginValidation(settings, projectedBuffer, linterEnabled);
             }
         }
 

--- a/src/Windows/Markdown/Editor/Impl/Preview/Code/EvalSession.cs
+++ b/src/Windows/Markdown/Editor/Impl/Preview/Code/EvalSession.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Markdown.Editor.Preview.Code {
         private readonly Task _sessionStart;
 
         public EvalSession(string documentName, IServiceContainer services) {
-            _services = services;
-            _sessionId = Invariant($"{documentName} - {Guid.NewGuid()}");
-            _sessionStart = StartSessionAsync(_hostStartCts.Token);
-
             SessionCallback = new RSessionCallback {
                 PlotDeviceProperties = new PlotDeviceProperties(800, 600, 96)
             };
+
+            _services = services;
+            _sessionId = Invariant($"{documentName} - {Guid.NewGuid()}");
+            _sessionStart = StartSessionAsync(_hostStartCts.Token);
         }
 
         public IRSession RSession { get; private set; }

--- a/src/Windows/Markdown/Editor/Impl/Preview/Code/RCodeEvaluator.cs
+++ b/src/Windows/Markdown/Editor/Impl/Preview/Code/RCodeEvaluator.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Markdown.Editor.Preview.Code {
                 await ExecuteAndCaptureOutputAsync(session, block.Text, ct);
 
                 if (callback.PlotResult != null) {
-                    block.Result = Invariant($"<img src='data:image/gif;base64, {Convert.ToBase64String(callback.PlotResult)}' />");
+                    block.Result = Invariant($"<img src='data:image/gif;base64, {Convert.ToBase64String(callback.PlotResult)}' style='display:block; margin: 0 auto; text-align: center;' />");
                     callback.PlotResult = null;
                 } else if (_output.Length > 0) {
                     block.Result = Invariant($"<code style='white-space: pre-wrap'>{_output.ToString()}</code>");

--- a/src/Windows/Markdown/Editor/Impl/Preview/Commands/AutomaticSyncCommand.cs
+++ b/src/Windows/Markdown/Editor/Impl/Preview/Commands/AutomaticSyncCommand.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.Common.Core.Services;
 using Microsoft.Common.Core.UI.Commands;
 using Microsoft.Languages.Editor.Controllers.Commands;
+using Microsoft.Languages.Editor.Text;
 using Microsoft.Markdown.Editor.Commands;
 using Microsoft.Markdown.Editor.Settings;
 using Microsoft.VisualStudio.Text.Editor;
@@ -23,6 +24,9 @@ namespace Microsoft.Markdown.Editor.Preview.Commands {
 
         public override CommandResult Invoke(Guid group, int id, object inputArg, ref object outputArg) {
             _settings.AutomaticSync = !_settings.AutomaticSync;
+            if (_settings.AutomaticSync) {
+                TextView.GetService<IMarkdownPreview>().Update(force: true);
+            }
             return CommandResult.Executed;
         }
     }

--- a/src/Windows/Markdown/Editor/Impl/Preview/Commands/RunCurrentChunkCommand.cs
+++ b/src/Windows/Markdown/Editor/Impl/Preview/Commands/RunCurrentChunkCommand.cs
@@ -12,7 +12,10 @@ namespace Microsoft.Markdown.Editor.Preview.Commands {
         public RunCurrentChunkCommand(ITextView textView, IServiceContainer services) :
             base(textView, services, MdPackageCommandId.icmdRunCurrentChunk) { }
 
-        protected override Task ExecuteAsync() 
-            => TextView.GetService<IMarkdownPreview>()?.RunCurrentChunkAsync() ?? Task.CompletedTask;
+        protected override Task ExecuteAsync() {
+            var mp = TextView.GetService<IMarkdownPreview>();
+            mp?.Update(force: false);
+            return mp?.RunCurrentChunkAsync() ?? Task.CompletedTask;
+        }
     }
 }

--- a/src/Windows/Markdown/Editor/Impl/Preview/IMarkdownPreview.cs
+++ b/src/Windows/Markdown/Editor/Impl/Preview/IMarkdownPreview.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Markdown.Editor.Preview {
     public interface IMarkdownPreview {
-        void Update();
+        void Update(bool force);
         Task RunCurrentChunkAsync();
         Task RunAllChunksAboveAsync();
     }

--- a/src/Windows/Markdown/Editor/Impl/Preview/Margin/PreviewMargin.cs
+++ b/src/Windows/Markdown/Editor/Impl/Preview/Margin/PreviewMargin.cs
@@ -94,11 +94,17 @@ namespace Microsoft.Markdown.Editor.Preview.Margin {
 
         private void UpdateOnIdle() {
             IdleTimeAction.Cancel(_idleActionTag);
-            IdleTimeAction.Create(Update, 0, _idleActionTag, _idleTime);
+            IdleTimeAction.Create(() => Update(force: true), 0, _idleActionTag, _idleTime);
         }
 
         #region IMarkdownPreview
-        public void Update() => UpdateBrowser();
+
+        public void Update(bool force) {
+            if (_textChanged || force) {
+                UpdateBrowser();
+            }
+        }
+
         public Task RunCurrentChunkAsync() {
             var index = _textView.GetCurrentRCodeBlockNumber();
             return index.HasValue ? Browser.UpdateBlocksAsync(_textView.TextBuffer.CurrentSnapshot, index.Value, 1) : Task.CompletedTask;
@@ -118,7 +124,7 @@ namespace Microsoft.Markdown.Editor.Preview.Margin {
                     .ContinueWith(t => _browserUpdateTask = null);
             } else {
                 // Still running, try again later
-                IdleTimeAction.Create(Update, 500, _idleActionTag, _idleTime);
+                IdleTimeAction.Create(() => Update(true), 500, _idleActionTag, _idleTime);
             }
         }
 

--- a/src/Windows/R/Components/Impl/Plots/IRPlotExportDialogs.cs
+++ b/src/Windows/R/Components/Impl/Plots/IRPlotExportDialogs.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace Microsoft.R.Components.Plots {
-    public interface IRPlotExportDialogs {
+    public interface IRPlotExportDialog {
         /// <summary>
         /// Show the export image dialog box.
         /// </summary>

--- a/src/Windows/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceExportAsImageCommand.cs
+++ b/src/Windows/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceExportAsImageCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.R.Components.Plots.Implementation.Commands {
             => HasCurrentPlot && !IsInLocatorMode ? CommandStatus.SupportedAndEnabled:CommandStatus.Supported;
 
         public async Task InvokeAsync() {
-            var plotExportDialogs = InteractiveWorkflow.Shell.GetService<IRPlotExportDialogs>();
+            var plotExportDialogs = InteractiveWorkflow.Shell.GetService<IRPlotExportDialog>();
             var exportImageArguments = new ExportArguments(VisualComponent.Device.PixelWidth, VisualComponent.Device.PixelHeight, VisualComponent.Device.Resolution);
             var exportImageParameters = plotExportDialogs.ShowExportImageDialog(exportImageArguments, Resources.Plots_ExportAsImageFilter, null, Resources.Plots_ExportAsImageDialogTitle);
             if (!string.IsNullOrEmpty(exportImageParameters?.FilePath)) {

--- a/src/Windows/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceExportAsPdfCommand.cs
+++ b/src/Windows/R/Components/Impl/Plots/Implementation/Commands/PlotDeviceExportAsPdfCommand.cs
@@ -17,7 +17,7 @@ namespace Microsoft.R.Components.Plots.Implementation.Commands {
             => HasCurrentPlot && !IsInLocatorMode ? CommandStatus.SupportedAndEnabled : CommandStatus.Supported;
 
         public async Task InvokeAsync() {
-            var plotExportDialogs = InteractiveWorkflow.Shell.GetService<IRPlotExportDialogs>();
+            var plotExportDialogs = InteractiveWorkflow.Shell.GetService<IRPlotExportDialog>();
             var exportPdfArguments = new ExportArguments(VisualComponent.Device.PixelWidth, VisualComponent.Device.PixelHeight, VisualComponent.Device.Resolution);
             var exportPdfParameters = plotExportDialogs.ShowExportPdfDialog(exportPdfArguments, Resources.Plots_ExportAsPdfFilter, null, Resources.Plots_ExportAsPdfDialogTitle);
            

--- a/src/Windows/R/Components/Test/Fixtures/RComponentServicesFixture.cs
+++ b/src/Windows/R/Components/Test/Fixtures/RComponentServicesFixture.cs
@@ -4,10 +4,12 @@
 using System.Collections.Generic;
 using Microsoft.Common.Core.Services;
 using Microsoft.Common.Core.Test.Fixtures;
+using Microsoft.R.Components.Plots;
 using Microsoft.R.Components.Settings;
 using Microsoft.R.Components.StatusBar;
 using Microsoft.R.Components.Test.Fakes.StatusBar;
 using Microsoft.R.Components.Test.StubFactories;
+using Microsoft.R.Components.Test.Stubs;
 using Microsoft.R.Host.Client;
 using Microsoft.R.Interpreters;
 using Microsoft.UnitTests.Core.XUnit;
@@ -36,6 +38,7 @@ namespace Microsoft.R.Components.Test.Fixtures {
                 .AddWindowsHostClientServices()
                 .AddWindowsRComponentstServices()
                 .AddService<IStatusBar, TestStatusBar>()
+                .AddService<IRPlotExportDialog, TestPlotExportDialog>()
                 .AddService<IRSettings>(RSettingsStubFactory.CreateForExistingRPath(testInput.FileSytemSafeName));
         }
     }

--- a/src/Windows/R/Components/Test/Microsoft.R.Components.Test.csproj
+++ b/src/Windows/R/Components/Test/Microsoft.R.Components.Test.csproj
@@ -110,6 +110,7 @@
     <Compile Include="StubFactories\RSettingsStubFactory.cs" />
     <Compile Include="StubFactories\RtfBuilderServiceStubFactory.cs" />
     <Compile Include="StubFactories\TextSearchServiceStubFactory.cs" />
+    <Compile Include="Stubs\TestPlotExportDialog.cs" />
     <Compile Include="Stubs\RSettingsStub.cs" />
     <Compile Include="Stubs\VisualComponents\VisualComponentContainerStub.cs" />
     <Compile Include="Fixtures\TestFilesFixture.cs" />

--- a/src/Windows/R/Components/Test/Plots/RPlotIntegrationTest.cs
+++ b/src/Windows/R/Components/Test/Plots/RPlotIntegrationTest.cs
@@ -17,8 +17,8 @@ using Microsoft.Common.Wpf.Imaging;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Components.Plots;
 using Microsoft.R.Components.Plots.Commands;
-using Microsoft.R.Components.Test.Fakes.InteractiveWindow;
 using Microsoft.R.Components.Test.Fakes.VisualComponentFactories;
+using Microsoft.R.Components.Test.Stubs;
 using Microsoft.R.Host.Client;
 using Microsoft.R.Host.Client.Test.Fixtures;
 using Microsoft.UnitTests.Core.FluentAssertions;
@@ -63,7 +63,7 @@ namespace Microsoft.R.Components.Test.Plots {
             return Task.CompletedTask;
         }
 
-        private TestFileDialog FileDialog => _workflow.Shell.FileDialog() as TestFileDialog;
+        private TestPlotExportDialog ExportDialog => _workflow.Shell.GetService<IRPlotExportDialog>() as TestPlotExportDialog;
 
         [Test(ThreadType.UI)]
         public async Task AllCommandsDisabledWhenNoPlot() {
@@ -489,7 +489,7 @@ namespace Microsoft.R.Components.Test.Plots {
             });
 
             var outputFilePath = _testFiles.GetDestinationPath("ExportedPlot.pdf");
-            FileDialog.SaveFilePath = outputFilePath;
+            ExportDialog.SaveFilePath = outputFilePath;
 
             var deviceVC = _plotManager.GetPlotVisualComponent(_plotManager.ActiveDevice);
             var deviceCommands = new RPlotDeviceCommands(_workflow, deviceVC);
@@ -510,7 +510,7 @@ namespace Microsoft.R.Components.Test.Plots {
 
             foreach (var ext in new string[] { "bmp", "jpg", "jpeg", "png", "tif", "tiff" }) {
                 var outputFilePath = _testFiles.GetDestinationPath("ExportedPlot." + ext);
-                FileDialog.SaveFilePath = outputFilePath;
+                ExportDialog.SaveFilePath = outputFilePath;
 
                 var deviceVC = _plotManager.GetPlotVisualComponent(_plotManager.ActiveDevice);
                 var deviceCommands = new RPlotDeviceCommands(_workflow, deviceVC);
@@ -540,7 +540,7 @@ namespace Microsoft.R.Components.Test.Plots {
             // dialog is what determines the image format. When it's an
             // unsupported format, we show an error msg.
             var outputFilePath = _testFiles.GetDestinationPath("ExportedPlot.unsupportedextension");
-            FileDialog.SaveFilePath = outputFilePath;
+            ExportDialog.SaveFilePath = outputFilePath;
 
             var deviceVC = _plotManager.GetPlotVisualComponent(_plotManager.ActiveDevice);
             var deviceCommands = new RPlotDeviceCommands(_workflow, deviceVC);
@@ -548,7 +548,7 @@ namespace Microsoft.R.Components.Test.Plots {
             deviceCommands.ExportAsImage.Should().BeEnabled();
             await deviceCommands.ExportAsImage.InvokeAsync();
 
-            File.Exists(FileDialog.SaveFilePath).Should().BeFalse();
+            File.Exists(ExportDialog.SaveFilePath).Should().BeFalse();
             _ui.LastShownErrorMessage.Should().Contain(".unsupportedextension");
         }
 

--- a/src/Windows/R/Components/Test/Plots/RPlotIntegrationTest.cs
+++ b/src/Windows/R/Components/Test/Plots/RPlotIntegrationTest.cs
@@ -522,8 +522,8 @@ namespace Microsoft.R.Components.Test.Plots {
                 _ui.LastShownErrorMessage.Should().BeNullOrEmpty();
 
                 var image = BitmapImageFactory.Load(outputFilePath);
-                image.PixelWidth.Should().Be(600);
-                image.PixelHeight.Should().Be(500);
+                image.PixelWidth.Should().Be(640);
+                image.PixelHeight.Should().Be(480);
                 ((int)Math.Round(image.DpiX)).Should().Be(96);
                 ((int)Math.Round(image.DpiY)).Should().Be(96);
             }

--- a/src/Windows/R/Components/Test/Stubs/TestPlotExportDialog.cs
+++ b/src/Windows/R/Components/Test/Stubs/TestPlotExportDialog.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.R.Components.Plots;
+
+namespace Microsoft.R.Components.Test.Stubs {
+    internal sealed class TestPlotExportDialog: IRPlotExportDialog {
+        public string SaveFilePath { get; set; }
+
+        public ExportImageParameters ShowExportImageDialog(ExportArguments imageArguments, string filter, string initialPath = null, string title = null)
+            => new ExportImageParameters {
+                FilePath = SaveFilePath,
+                PixelWidth = 640,
+                PixelHeight = 480,
+                Resolution = 96,
+                ViewPlot = false
+            };
+
+        public ExportPdfParameters ShowExportPdfDialog(ExportArguments pdfArguments, string filter, string initialPath = null, string title = null)
+            => new ExportPdfParameters {
+                FilePath = SaveFilePath,
+                WidthInInches = 2,
+                HeightInInches = 2,
+                Resolution = 96,
+                ViewPlot = false
+            };
+    }
+}

--- a/src/Windows/R/Editor/Test/Formatting/SmartIndentTest.cs
+++ b/src/Windows/R/Editor/Test/Formatting/SmartIndentTest.cs
@@ -63,6 +63,8 @@ namespace Microsoft.R.Editor.Test.Formatting {
         [InlineData("x <- func(\n    z = list(\n        a = function() {\n        }\n)\n", 5, 0)]
         [InlineData("x <- \n", 1, 4)]
         [InlineData("x <- func(\n    z = list(\n        a = function() {\n        }\n)\n", 5, 0)]
+        [InlineData("x <- \n\n    a", 1, 4)]
+        [InlineData("x <- \n      a+\n", 2, 6)]
         public void Scope(string content, int lineNum, int expectedIndent) {
             var tv = MakeTextView(content);
             var indenter = _provider.CreateSmartIndent(tv);

--- a/src/Windows/R/Editor/Test/Validation/LinterTest.cs
+++ b/src/Windows/R/Editor/Test/Validation/LinterTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.R.Editor.Test.Roxygen {
             prop?.SetValue(_options, true);
 
             var ast = RParser.Parse(content);
-            await _validator.RunAsync(ast, false, _results, CancellationToken.None);
+            await _validator.RunAsync(ast, false, true, _results, CancellationToken.None);
             _results.Should().HaveCount(length > 0 ? 1 : 0);
 
             if (length > 0) {
@@ -96,7 +96,7 @@ namespace Microsoft.R.Editor.Test.Roxygen {
             if (prop != null) {
                 prop.SetValue(_options, false);
                 var r = new ConcurrentQueue<IValidationError>();
-                await _validator.RunAsync(ast, false, r, CancellationToken.None);
+                await _validator.RunAsync(ast, false, true, r, CancellationToken.None);
                 r.Should().BeEmpty();
             }
         }
@@ -109,7 +109,7 @@ namespace Microsoft.R.Editor.Test.Roxygen {
         public async Task Validate2(string content, int[] start, int[] length, string[] message) {
 
             var ast = RParser.Parse(content);
-            await _validator.RunAsync(ast, false, _results, CancellationToken.None);
+            await _validator.RunAsync(ast, false, true, _results, CancellationToken.None);
             _results.Should().HaveCount(start.Length);
 
             for (var i = 0; i < start.Length; i++) {
@@ -133,7 +133,7 @@ namespace Microsoft.R.Editor.Test.Roxygen {
             propLimit?.SetValue(_options, maxLength);
 
             var ast = RParser.Parse(content);
-            await _validator.RunAsync(ast, false, _results, CancellationToken.None);
+            await _validator.RunAsync(ast, false, true, _results, CancellationToken.None);
             _results.Should().HaveCount(1);
 
             _results.TryPeek(out IValidationError e);
@@ -146,7 +146,7 @@ namespace Microsoft.R.Editor.Test.Roxygen {
             if (prop != null) {
                 prop.SetValue(_options, false);
                 var r = new ConcurrentQueue<IValidationError>();
-                await _validator.RunAsync(ast, false, r, CancellationToken.None);
+                await _validator.RunAsync(ast, false, true, r, CancellationToken.None);
                 r.Should().BeEmpty();
             }
         }
@@ -163,7 +163,7 @@ namespace Microsoft.R.Editor.Test.Roxygen {
             prop?.SetValue(_options, true);
 
             var ast = RParser.Parse(content);
-            await _validator.RunAsync(ast, true, _results, CancellationToken.None);
+            await _validator.RunAsync(ast, true, true, _results, CancellationToken.None);
             _results.Should().BeEmpty();
         }
     }


### PR DESCRIPTION
#3752 Lint 'semicolons' and 'line length' options change together 
- Copy/paste typo, fixed

#3750 Exclude dotted names from Pascal and camelCase 
- added check that name doesn't have dots

#3749 Snippets should not multiply spaces 
- instead of not formatting operator snippets, do format but append space at the end

#3747 Check for updates... still visible in 2017 
- removed command

#3746 RMD should update blocks on execute command 
- force update on auto-sync option change, lazy update of text changed before running the command

#3729 Graphics device does not initialize in markdown session 
- race issue, callback must be initialized before starting the host

#3751 Indent in complex expressions should respect last line indent 
- improved analysis of current/incomplete statements + tests