### PR TITLE
Fix #3890: Connecting to remote windows fails with "Unable to load one or more of the requested types"

### DIFF
--- a/src/Host/Broker/Impl/Microsoft.R.Host.Broker.csproj
+++ b/src/Host/Broker/Impl/Microsoft.R.Host.Broker.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.2" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />

--- a/src/Linux/Core/Impl/Microsoft.R.Common.Core.Linux.csproj
+++ b/src/Linux/Core/Impl/Microsoft.R.Common.Core.Linux.csproj
@@ -5,10 +5,10 @@
     <AssemblyName>Microsoft.R.Common.Core.Linux</AssemblyName>
     <RootNamespace>Microsoft.Common.Core</RootNamespace>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\Core\Impl\Microsoft.R.Common.Core.csproj" />
   </ItemGroup>
+  <Import Project="..\..\..\R.Settings.NetCore.props" />
   <Import Project="..\..\..\R.Settings.props" />
   <Import Project="$(SourceDirectory)R.Build.Version.targets" />
   <Import Project="$(SourceDirectory)R.Build.Loc.targets" />

--- a/src/Linux/Host/Broker/Impl/Microsoft.R.Host.Broker.Linux.csproj
+++ b/src/Linux/Host/Broker/Impl/Microsoft.R.Host.Broker.Linux.csproj
@@ -6,6 +6,8 @@
     <AssemblyName>Microsoft.R.Host.Broker.Linux</AssemblyName>
     <RootNamespace>Microsoft.R.Host.Broker</RootNamespace>
   </PropertyGroup>
+  <Import Project="..\..\..\..\R.Settings.NetCore.props" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\..\..\..\R.Settings.props" />
   <Import Project="$(SourceDirectory)R.Build.Version.targets" />
   <Import Project="$(SourceDirectory)R.Build.Loc.targets" />

--- a/src/Linux/R/Interpreters/Impl/Microsoft.R.Interpreters.Linux.csproj
+++ b/src/Linux/R/Interpreters/Impl/Microsoft.R.Interpreters.Linux.csproj
@@ -21,7 +21,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
     </EmbeddedResource>
   </ItemGroup>
-
+  <Import Project="..\..\..\..\R.Settings.NetCore.props" />
   <Import Project="..\..\..\..\R.Settings.props" />
   <Import Project="$(SourceDirectory)R.Build.Version.targets" />
   <Import Project="$(SourceDirectory)R.Build.Loc.targets" />

--- a/src/R.Settings.NetCore.props
+++ b/src/R.Settings.NetCore.props
@@ -13,4 +13,7 @@
     <MicroBuild_DoNotStrongNameSign>true</MicroBuild_DoNotStrongNameSign>
     <BuildDependsOn>ValidateAssemblyName;$(BuildDependsOn)</BuildDependsOn>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="NETStandard.Library" Version="2.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/R.Settings.NetCore.props
+++ b/src/R.Settings.NetCore.props
@@ -5,6 +5,7 @@
     <Error Condition = " '$(AssemblyName)'=='' " Text = "AssemblyName property must be specified before R.Settings.NetCore.props is referenced" />
   </Target>
   <PropertyGroup>
+    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <RootDirectory Condition="'$(RootDirectory)' == ''">$(MSBuildThisFileDirectory)..\</RootDirectory>
     <ObjDirectory Condition="'$(ObjDirectory)' == ''">$(RootDirectory)obj\</ObjDirectory>
     <BaseIntermediateOutputPath>$(ObjDirectory)\$(AssemblyName)\</BaseIntermediateOutputPath>


### PR DESCRIPTION
.Net Core projects can reference .Net Standard Library metapackage which version is different than the framework itself. Since System.Web.Http is part of the metapackage, bumping its version to 2.0 solves the issue for .Net Core projects. For .Net Framework projects, we need to update version of System.Web.Http explicitly, but only for the projects that really reference it.