### PR TITLE
Data grid on snapshots

### DIFF
--- a/src/Host/Client/Impl/DataInspection/IREvaluationResultInfo.cs
+++ b/src/Host/Client/Impl/DataInspection/IREvaluationResultInfo.cs
@@ -45,6 +45,7 @@ namespace Microsoft.R.DataInspection {
         /// This property is filled automatically when the result is produced by <see cref="IRValueInfo.GetChildrenAsync"/>, 
         /// and is primarily useful in that scenario. See the documentation of that method for more information.
         /// </para>
+        /// </remarks>
         string Name { get; }
 
         /// <summary>

--- a/src/Host/Client/Impl/Definitions/RHostStartupInfo.cs
+++ b/src/Host/Client/Impl/Definitions/RHostStartupInfo.cs
@@ -9,7 +9,8 @@ namespace Microsoft.R.Host.Client {
             , int terminalWidth = 80
             , bool enableAutosave = false
             , bool useRHostCommandLineArguments = false
-            , bool isInteractive = false) {
+            , bool isInteractive = false
+            , bool gridDynamicEvaluation = false) {
 
             CranMirrorName = cranMirrorName;
             WorkingDirectory = workingDirectory;
@@ -18,6 +19,7 @@ namespace Microsoft.R.Host.Client {
             EnableAutosave = enableAutosave;
             UseRHostCommandLineArguments = useRHostCommandLineArguments;
             IsInteractive = isInteractive;
+            GridDynamicEvaluation = gridDynamicEvaluation;
         }
 
         public string CranMirrorName { get; }
@@ -27,5 +29,6 @@ namespace Microsoft.R.Host.Client {
         public bool EnableAutosave { get; }
         public bool UseRHostCommandLineArguments { get; }
         public bool IsInteractive { get; }
+        public bool GridDynamicEvaluation { get; }
     }
 }

--- a/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
+++ b/src/Host/Client/Impl/Microsoft.R.Host.Client.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets.Protocol" Version="0.1.0" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.3.0" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -446,6 +446,7 @@ namespace Microsoft.R.Host.Client.Session {
 
                     await evaluator.OverrideFunctionAsync("setwd", "base");
                     await evaluator.SetFunctionRedirectionAsync();
+                    await evaluator.SetGridEvalModeAsync(startupInfo.GridDynamicEvaluation);
 
                     try {
                         await evaluator.OptionsSetWidthAsync(startupInfo.TerminalWidth);

--- a/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
+++ b/src/Host/Client/Impl/Session/RSessionEvaluationCommands.cs
@@ -261,6 +261,11 @@ grDevices::deviceIsInteractive('ide')
             return evaluation.ExecuteAsync(script);
         }
 
+        public static Task SetGridEvalModeAsync(this IRExpressionEvaluator evaluation, bool dynamicEval) {
+            var script = Invariant($"rtvs:::set_view_mode({(dynamicEval ? 1 : 0)})");
+            return evaluation.ExecuteAsync(script);
+        }
+
         public static Task<bool> QueryReloadAutosaveAsync(this IRExpressionEvaluator evaluation) =>
             evaluation.EvaluateAsync<bool>($"rtvs:::query_reload_autosave()", REvaluationKind.Reentrant);
 

--- a/src/Host/Client/Impl/rtvs/R/grid.R
+++ b/src/Host/Client/Impl/rtvs/R/grid.R
@@ -30,6 +30,7 @@ grid_order <- function(x, ...) {
 
 grid_data <- function(x, rows, cols, row_selector) {
     # If it's a 1D vector, turn it into a single-column 2D matrix, then process as such.
+    x <- as.data.frame(x)
     d <- dim(x);
     if (is.null(d) || length(d) == 1) {
         dim(x) <- c(NROW(x), 1)

--- a/src/Host/Client/Impl/rtvs/R/grid.R
+++ b/src/Host/Client/Impl/rtvs/R/grid.R
@@ -32,12 +32,6 @@ grid_data <- function(x, rows, cols, row_selector) {
     # If it's a 1D vector, turn it into a single-column 2D matrix, then process as such.
     x <- as.data.frame(x)
     d <- dim(x);
-    if (is.null(d) || length(d) == 1) {
-        dim(x) <- c(NROW(x), 1)
-        vp <- grid_data(x, rows, cols, row_selector)
-        vp$is_1d <- TRUE;
-        return(vp);
-    }
 
     if (missing(rows)) {
         rows <- 1:d[[1]];
@@ -49,22 +43,6 @@ grid_data <- function(x, rows, cols, row_selector) {
     # Row names must be retrieved before slicing the data, because slicing can change the type -
     # for example, a sliced timeseries is just a vector or matrix, and so time() no longer works.
     rn <- row.names(x);
-    if (is.null(rn)) {
-        # If there are no explicit row names, try some alternatives
-        if (is.ts(x)) {
-            # For time series, use time().
-            rn <- tryCatch(time(x), error = function(e) NULL);
-        } else {
-            # For zoo objects, use zoo::index. Note that this package might not be installed,
-            # so both the type check and the index call are inside a try.
-            rn <- tryCatch(if (zoo::is.zoo(x)) zoo::index(x) else NULL, error = function(e) NULL);
-        }
-
-        # Make sure the length actually matches the number of rows.
-        if (length(rn) != nrow(x)) {
-            rn <- NULL;
-        } 
-    }
 
     # Slice the row names to match the data.
     if (!missing(row_selector)) {
@@ -124,7 +102,7 @@ grid_data <- function(x, rows, cols, row_selector) {
             else { paste0(substr(s, 1, max_length), '...', collapse = '') }
         })
     }), recursive = TRUE)
-
+    
     # Any names in the original data will flow through, but we don't want them.
     names(data) <- NULL;
 

--- a/src/Host/Client/Impl/rtvs/R/overrides.R
+++ b/src/Host/Client/Impl/rtvs/R/overrides.R
@@ -2,7 +2,6 @@
 # Licensed under the MIT License. See LICENSE in the project root for license information.
 
 view_env <- new.env() # Make sure this matches ViewEnvPrefix in VariableGridHost
-view_variable_num <- 1
 
 # 0 = cached, 1 = dynamic
 set_view_mode <- function(mode) {
@@ -21,8 +20,11 @@ view <- function(x, title) {
         # Cache expression result in default mode.
         # In dynamic mode pass expression to the main module for evaluation.
         if((is.null(view_env$view_mode) || view_env$view_mode == 0) && !is.function(x)) {
-            var_name <- paste0("x", view_variable_num)
-            view_variable_num <- view_variable_num + 1
+            if(is.null(view_env$view_variable_num)) {
+                view_env$view_variable_num = 1
+            }
+            var_name <- paste0("x", view_env$view_variable_num)
+            view_env$view_variable_num <- view_env$view_variable_num + 1
             assign(var_name, as.data.frame(x), view_env)
             dep <- paste0("rtvs:::view_env$", var_name)
         }

--- a/src/Host/Client/Impl/rtvs/R/overrides.R
+++ b/src/Host/Client/Impl/rtvs/R/overrides.R
@@ -21,7 +21,7 @@ view <- function(x, title) {
         # In dynamic mode pass expression to the main module for evaluation.
         if((is.null(view_env$view_mode) || view_env$view_mode == 0) && !is.function(x)) {
             if(is.null(view_env$view_variable_num)) {
-                view_env$view_variable_num = 1
+                view_env$view_variable_num <- 1
             }
             var_name <- paste0("x", view_env$view_variable_num)
             view_env$view_variable_num <- view_env$view_variable_num + 1

--- a/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml.cs
+++ b/src/Package/Impl/DataInspect/DataImport/ImportDataWindow.xaml.cs
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
         }
 
         private void FileOpenButton_Click(object sender, RoutedEventArgs e) {
-            string filePath = _services.FileDialog().ShowOpenFileDialog(Package.Resources.CsvFileFilter);
+            var filePath = _services.FileDialog().ShowOpenFileDialog(Package.Resources.CsvFileFilter);
             if (!string.IsNullOrEmpty(filePath)) {
                 SetFilePath(filePath);
             }
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
                 return;
             }
 
-            int cp = GetSelectedValueAsInt(EncodingComboBox);
+            var cp = GetSelectedValueAsInt(EncodingComboBox);
             PreviewFileContent(FilePathBox.Text, cp);
             await ConvertToUtf8(FilePathBox.Text, cp, false, MaxPreviewLines);
 
@@ -160,7 +160,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
                 if (expression != null) {
                     try {
                         var session = _services.GetService<IRInteractiveWorkflowProvider>().GetOrCreate().RSession;
-                        var grid = await session.GetGridDataAsync(expression, null);
+                        var ds = new GridDataSource(session);
+                        var grid = await ds.GetGridDataAsync(expression, null);
                         PopulateDataFramePreview(grid);
                         DataFramePreview.Visibility = Visibility.Visible;
                     } catch (Exception ex) {
@@ -190,7 +191,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
         private void PopulateEncodingList() {
             var encodings = Encoding.GetEncodings().OrderBy(x => x.DisplayName);
             foreach (var enc in encodings) {
-                string item = Invariant($"{enc.DisplayName} (CP {enc.CodePage})");
+                var item = Invariant($"{enc.DisplayName} (CP {enc.CodePage})");
                 Encodings[item] = enc.CodePage;
             }
 
@@ -225,11 +226,11 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
         }
 
         private string ReadFilePreview(string filePath, Encoding enc) {
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             using (var sr = new StreamReader(filePath, enc, detectEncodingFromByteOrderMarks: true)) {
-                int readCount = 0;
+                var readCount = 0;
                 while (readCount < MaxPreviewLines) {
-                    string read = sr.ReadLine();
+                    var read = sr.ReadLine();
                     if (read == null) {
                         break;
                     }
@@ -254,8 +255,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
         }
 
         private void PreviewFileContent(string file, int codePage) {
-            Encoding encoding = Encoding.GetEncoding(codePage);
-            string text = ReadFilePreview(file, encoding);
+            var encoding = Encoding.GetEncoding(codePage);
+            var text = ReadFilePreview(file, encoding);
             InputFilePreview.Text = text;
         }
 
@@ -273,10 +274,10 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
         private async Task ConvertToUtf8Worker(string file, int codePage, bool reportProgress, int nRows = Int32.MaxValue) {
             await TaskUtilities.SwitchToBackgroundThread();
 
-            Encoding encoding = Encoding.GetEncoding(codePage);
+            var encoding = Encoding.GetEncoding(codePage);
             _utf8FilePath = Path.Combine(Path.GetTempPath(), Path.GetFileName(file) + ".utf8");
 
-            int lineCount = 0;
+            var lineCount = 0;
             double progressValue = 0;
 
             using (var sr = new StreamReader(file, encoding, detectEncodingFromByteOrderMarks: true)) {
@@ -326,10 +327,10 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataImport
             var result = false;
 
             try {
-                int cp = GetSelectedValueAsInt(EncodingComboBox);
+                var cp = GetSelectedValueAsInt(EncodingComboBox);
 
                 var nRowsString = NRowsTextBox.Text;
-                int nrows = Int32.MaxValue;
+                var nrows = Int32.MaxValue;
                 if (!string.IsNullOrWhiteSpace(nRowsString)) {
                     if (!Int32.TryParse(nRowsString, out nrows) || nrows <= 0) {
                         _services.ShowErrorMessage(Package.Resources.ImportData_NRowsError);

--- a/src/Package/Impl/DataInspect/DataSource/GridDataSource.cs
+++ b/src/Package/Impl/DataInspect/DataSource/GridDataSource.cs
@@ -15,10 +15,10 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.DataSource {
         public static async Task<IGridData<string>> GetGridDataAsync(this IRSession rSession, string expression, GridRange? gridRange, ISortOrder sortOrder = null) {
             await TaskUtilities.SwitchToBackgroundThread();
 
-            string rows = gridRange?.Rows.ToRString();
-            string columns = gridRange?.Columns.ToRString();
-            string rowSelector = (sortOrder != null && !sortOrder.IsEmpty) ? sortOrder.GetRowSelector() : "";
-            string expr = Invariant($"rtvs:::grid_data({expression}, {rows}, {columns}, {rowSelector})");
+            var rows = gridRange?.Rows.ToRString();
+            var columns = gridRange?.Columns.ToRString();
+            var rowSelector = (sortOrder != null && !sortOrder.IsEmpty) ? sortOrder.GetRowSelector() : "";
+            var expr = Invariant($"rtvs:::grid_data({expression}, {rows}, {columns}, {rowSelector})");
 
             try {
                 return await rSession.EvaluateAsync<GridData>(expr, REvaluationKind.Normal);

--- a/src/Package/Impl/DataInspect/DataSource/ListToRange.cs
+++ b/src/Package/Impl/DataInspect/DataSource/ListToRange.cs
@@ -3,34 +3,28 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Common.Core.Diagnostics;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect {
     /// <summary>
     /// Adapter IList to IRange
     /// </summary>
     internal class ListToRange<T> : IRange<T> {
-        private IList<T> _list;
+        private readonly IList<T> _list;
 
         public ListToRange(Range range, IList<T> list) {
-            if (range.Count != list.Count) {
-                throw new ArgumentException("Range data cound doesn't match with range");
-            }
+            Check.Argument(nameof(range), () => range.Count <= list.Count);
 
             Range = range;
-
             _list = list;
         }
 
         public Range Range { get; }
 
         public T this[long index] {
-            get {
-                return _list[checked((int)(index - Range.Start))];
-            }
-
-            set {
-                _list[checked((int)( index - Range.Start))] = value;
-            }
+            get => _list[checked((int)(index - Range.Start))];
+            set => _list[checked((int)(index - Range.Start))] = value;
         }
     }
 }

--- a/src/Package/Impl/DataInspect/DataSource/Range.cs
+++ b/src/Package/Impl/DataInspect/DataSource/Range.cs
@@ -21,32 +21,41 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         public long Count { get; }
         public long End { get; }
 
-        public bool Contains(long value) {
-            return value >= Start && value < End;
-        }
+        public bool Contains(long value) => value >= Start && value < End;
 
         public bool Contains(Range other) {
             if (Count == 0) {
                 return false;
             }
-
             return other.Start <= Start && other.End >= End;
         }
 
         public IEnumerable<long> GetEnumerable(bool ascending = true) {
             if (ascending) {
-                for (long i = Start; i < End; i++) {
+                for (var i = Start; i < End; i++) {
                     yield return i;
                 }
             } else {
-                for (long i = End - 1; i >= Start; i--) {
+                for (var i = End - 1; i >= Start; i--) {
                     yield return i;
                 }
             }
         }
 
-        public string ToRString() {
-            return Invariant($"{Start + 1}:{Start + Count}");
+        public string ToRString() => Invariant($"{Start + 1}:{Start + Count}");
+
+        public static bool operator ==(Range x, Range y)
+            => x.Start == y.Start && x.Count == y.Count;
+
+        public static bool operator !=(Range x, Range y) => !(x == y);
+
+        public override bool Equals(object obj) {
+            if (!(obj is Range)) {
+                return false;
+            }
+            return (Range)obj == this;
         }
+
+        public override int GetHashCode() => base.GetHashCode();
     }
 }

--- a/src/Package/Impl/DataInspect/GridData.cs
+++ b/src/Package/Impl/DataInspect/GridData.cs
@@ -60,12 +60,9 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         private IGrid<string> _grid;
         public IGrid<string> Grid {
             get {
-                if (_grid == null) {
-                    _grid = new Grid<string>(
-                        new GridRange(new Range(RowStart - 1, RowCount), new Range(ColumnStart - 1, ColumnCount)),
-                        Values.Select(s => s.ConvertCharacterCodes()).ToList());
-                }
-
+                _grid = _grid ?? new Grid<string>(
+                    new GridRange(new Range(RowStart - 1, RowCount), new Range(ColumnStart - 1, ColumnCount)),
+                    Values.Select(s => s.ConvertCharacterCodes()).ToList());
                 return _grid;
             }
         }

--- a/src/Package/Impl/DataInspect/GridDataProvider.cs
+++ b/src/Package/Impl/DataInspect/GridDataProvider.cs
@@ -14,10 +14,12 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
     internal sealed class GridDataProvider : IGridProvider<string> {
         private readonly VariableViewModel _evaluation;
         private readonly IRSession _session;
+        private readonly GridDataSource _dataSource;
 
         public GridDataProvider(IRSession session, VariableViewModel evaluation) {
             _session = session;
             _evaluation = evaluation;
+            _dataSource = new GridDataSource(session);
 
             RowCount = evaluation.Dimensions[0];
             ColumnCount = evaluation.Dimensions.Count >= 2 ? evaluation.Dimensions[1] : 1;
@@ -37,6 +39,6 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         public bool CanSort { get; }
 
         public Task<IGridData<string>> GetAsync(GridRange gridRange, ISortOrder sortOrder = null)
-            => _session.GetGridDataAsync(_evaluation.Expression, gridRange, sortOrder);
+            => _dataSource.GetGridDataAsync(_evaluation.Expression, gridRange, sortOrder);
     }
 }

--- a/src/Package/Impl/DataInspect/GridDataProvider.cs
+++ b/src/Package/Impl/DataInspect/GridDataProvider.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.R.DataInspection;
 using Microsoft.R.Host.Client;
 using Microsoft.VisualStudio.R.Package.DataInspect.DataSource;
-using static System.FormattableString;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect {
     /// <summary>
@@ -38,14 +36,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         public bool CanSort { get; }
 
-        public Task<IGridData<string>> GetAsync(GridRange gridRange, ISortOrder sortOrder = null) {
-            var t = _session.GetGridDataAsync(_evaluation.Expression, gridRange, sortOrder);
-            if (t == null) {
-                // May happen when R host is not running
-                Trace.Fail(Invariant($"{nameof(VariableViewModel)} returned null grid data"));
-                return Task.FromResult<IGridData<string>>(null);
-            }
-            return t;
-        }
+        public Task<IGridData<string>> GetAsync(GridRange gridRange, ISortOrder sortOrder = null)
+            => _session.GetGridDataAsync(_evaluation.Expression, gridRange, sortOrder);
     }
 }

--- a/src/Package/Impl/DataInspect/GridDataProvider.cs
+++ b/src/Package/Impl/DataInspect/GridDataProvider.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.R.DataInspection;
+using Microsoft.R.Editor.Data;
 using Microsoft.R.Host.Client;
 using Microsoft.VisualStudio.R.Package.DataInspect.DataSource;
 
@@ -12,22 +13,20 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
     /// grid data provider to control
     /// </summary>
     internal sealed class GridDataProvider : IGridProvider<string> {
-        private readonly VariableViewModel _evaluation;
-        private readonly IRSession _session;
+        private readonly IRSessionDataObject _dataObject;
         private readonly GridDataSource _dataSource;
 
-        public GridDataProvider(IRSession session, VariableViewModel evaluation) {
-            _session = session;
-            _evaluation = evaluation;
+        public GridDataProvider(IRSession session, IRSessionDataObject dataObject) {
+            _dataObject = dataObject;
             _dataSource = new GridDataSource(session);
 
-            RowCount = evaluation.Dimensions[0];
-            ColumnCount = evaluation.Dimensions.Count >= 2 ? evaluation.Dimensions[1] : 1;
+            RowCount = dataObject.Dimensions[0];
+            ColumnCount = dataObject.Dimensions.Count >= 2 ? dataObject.Dimensions[1] : 1;
             CanSort = true;
 
             // Lists cannot be sorted, except when the list is a dataframe.
-            if (evaluation.TypeName == "list") {
-                var er = evaluation.DebugEvaluation as IRValueInfo;
+            if (dataObject.TypeName == "list") {
+                var er = dataObject.DebugEvaluation as IRValueInfo;
                 CanSort = er?.Classes.Contains("data.frame") == true;
             }
         }
@@ -39,6 +38,6 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
         public bool CanSort { get; }
 
         public Task<IGridData<string>> GetAsync(GridRange gridRange, ISortOrder sortOrder = null)
-            => _dataSource.GetGridDataAsync(_evaluation.Expression, gridRange, sortOrder);
+            => _dataSource.GetGridDataAsync(_dataObject.Expression, gridRange, sortOrder);
     }
 }

--- a/src/Package/Impl/DataInspect/VariableGridHost.xaml.cs
+++ b/src/Package/Impl/DataInspect/VariableGridHost.xaml.cs
@@ -8,24 +8,31 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using Microsoft.Common.Core;
+using Microsoft.Common.Core.Disposables;
 using Microsoft.Common.Core.Services;
 using Microsoft.R.Components.InteractiveWorkflow;
 using Microsoft.R.Components.Settings;
 using Microsoft.R.DataInspection;
+using Microsoft.R.Editor.Data;
 using Microsoft.R.Host.Client;
 using Microsoft.VisualStudio.R.Package.Shell;
 using static Microsoft.R.DataInspection.REvaluationResultProperties;
+using static System.FormattableString;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect {
     /// <summary>
     /// Control that shows two dimensional R object
     /// </summary>
-    public partial class VariableGridHost {
+    public partial class VariableGridHost : IDisposable {
+        private const string ViewEnvName = "rtvs:::view_env";
+
         private readonly IServiceContainer _services;
         private readonly IRSession _rSession;
-        private VariableViewModel _evaluation;
+        private readonly DisposableBag _disposableBag = new DisposableBag(nameof(VariableGridHost));
 
-        public VariableGridHost(): this(VsAppShell.Current.Services) { }
+        private IRSessionDataObject _evaluation;
+
+        public VariableGridHost() : this(VsAppShell.Current.Services) { }
 
         public VariableGridHost(IServiceContainer services) {
             InitializeComponent();
@@ -34,10 +41,26 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             _rSession = _services.GetService<IRInteractiveWorkflowProvider>().GetOrCreate().RSession;
             _rSession.Mutated += RSession_Mutated;
 
+            _disposableBag
+                .Add(() => _rSession.Mutated -= RSession_Mutated)
+                .Add(DeleteCachedVariable);
+
             FocusManager.SetFocusedElement(this, VariableGrid);
         }
 
-        public void CleanUp() => _rSession.Mutated -= RSession_Mutated;
+        public void Dispose() => _disposableBag.TryDispose();
+        
+        private void DeleteCachedVariable() {
+            if (_evaluation != null && _evaluation.Expression.StartsWithOrdinal(ViewEnvName)) {
+                if (_rSession.IsHostRunning) {
+                    var varName = _evaluation.Expression.Substring(ViewEnvName.Length + 1);
+                    try {
+                        _rSession.ExecuteAsync(Invariant($"rm('{varName}', envir = {ViewEnvName})")).DoNotWait();
+                    } catch (Exception ex) when (!ex.IsCriticalException()) { }
+                }
+            }
+            _evaluation = null;
+        }
 
         private void RSession_Mutated(object sender, EventArgs e) {
             if (_evaluation != null && _services.GetService<IRSettings>().GridDynamicEvaluation) {
@@ -59,12 +82,12 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
         }
 
-        internal void SetEvaluation(VariableViewModel wrapper) {
+        internal void SetEvaluation(IRSessionDataObject dataObject) {
             _services.MainThread().Assert();
 
             // Is the variable gone?
-            if (wrapper.TypeName == null) {
-                SetError(string.Format(CultureInfo.InvariantCulture, Package.Resources.VariableGrid_Missing, wrapper.Expression));
+            if (dataObject.TypeName == null) {
+                SetError(string.Format(CultureInfo.InvariantCulture, Package.Resources.VariableGrid_Missing, dataObject.Expression));
                 _evaluation = null;
                 return;
             }
@@ -72,15 +95,15 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             ClearError();
 
             // Does it have the same size and shape? If so, can update in-place (without losing scrolling etc).
-            if (_evaluation?.Dimensions.SequenceEqual(wrapper.Dimensions) == true) {
+            if (_evaluation?.Dimensions.SequenceEqual(dataObject.Dimensions) == true) {
                 VariableGrid.Refresh();
                 return;
             }
 
             // Otherwise, need to refresh the whole thing from scratch.
             var session = _services.GetService<IRInteractiveWorkflowProvider>().GetOrCreate().RSession;
-            VariableGrid.Initialize(new GridDataProvider(session, wrapper));
-            _evaluation = wrapper;
+            VariableGrid.Initialize(new GridDataProvider(session, dataObject));
+            _evaluation = dataObject;
         }
 
         private void SetError(string text) {

--- a/src/Package/Impl/DataInspect/VariableGridHost.xaml.cs
+++ b/src/Package/Impl/DataInspect/VariableGridHost.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Input;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.Services;
 using Microsoft.R.Components.InteractiveWorkflow;
+using Microsoft.R.Components.Settings;
 using Microsoft.R.DataInspection;
 using Microsoft.R.Host.Client;
 using Microsoft.VisualStudio.R.Package.Shell;
@@ -38,8 +39,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         public void CleanUp() => _rSession.Mutated -= RSession_Mutated;
 
-        private void RSession_Mutated(object sender, System.EventArgs e) {
-            if (_evaluation != null) {
+        private void RSession_Mutated(object sender, EventArgs e) {
+            if (_evaluation != null && _services.GetService<IRSettings>().GridDynamicEvaluation) {
                 EvaluateAsync().DoNotWait();
             }
         }

--- a/src/Package/Impl/DataInspect/VariableGridWindowPane.cs
+++ b/src/Package/Impl/DataInspect/VariableGridWindowPane.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Runtime.InteropServices;
+using Microsoft.R.Editor.Data;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.R.Package.Windows;
 using Microsoft.VisualStudio.R.Packages.R;
@@ -18,16 +19,16 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             BitmapImageMoniker = KnownMonikers.VariableProperty;
         }
 
-        internal void SetEvaluation(VariableViewModel evaluation, string caption) {
-            if (!string.IsNullOrWhiteSpace(evaluation.Expression)) {
+        internal void SetViewModel(IRSessionDataObject dataObject, string caption) {
+            if (!string.IsNullOrWhiteSpace(dataObject.Expression)) {
                 Caption = Invariant($"{Resources.VariableGrid_Caption}: {caption}");
             }
-            _gridHost.SetEvaluation(evaluation);
+            _gridHost.SetEvaluation(dataObject);
         }
 
         protected override void OnClose() {
             base.OnClose();
-            _gridHost.CleanUp();
+            _gridHost.Dispose();
         }
     }
 }

--- a/src/Package/Impl/DataInspect/VariableViewModel.cs
+++ b/src/Package/Impl/DataInspect/VariableViewModel.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.Common.Core;
-using Microsoft.Common.Core.IO;
 using Microsoft.Common.Core.OS;
 using Microsoft.Common.Core.Services;
 using Microsoft.Common.Core.Shell;

--- a/src/Package/Impl/DataInspect/Viewers/GridViewerBase.cs
+++ b/src/Package/Impl/DataInspect/Viewers/GridViewerBase.cs
@@ -6,13 +6,13 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core.Services;
-using Microsoft.Common.Core.Shell;
 using Microsoft.Common.Core.Threading;
+using Microsoft.R.Components.Settings;
 using Microsoft.R.DataInspection;
-using Microsoft.VisualStudio.R.Package.Shell;
 using Microsoft.VisualStudio.R.Package.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 using static Microsoft.R.DataInspection.REvaluationResultProperties;
+using static System.FormattableString;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
     internal abstract class GridViewerBase : ViewerBase, IObjectDetailsViewer {
@@ -20,11 +20,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
         private const REvaluationResultProperties _properties =
            ClassesProperty | ExpressionProperty | TypeNameProperty | DimProperty | LengthProperty;
 
-        private readonly IServiceContainer _services;
-
-        public GridViewerBase(IServiceContainer services, IDataObjectEvaluator evaluator) : base(evaluator) {
-            _services = services;
-        }
+        protected GridViewerBase(IServiceContainer services, IDataObjectEvaluator evaluator) : 
+            base(services, evaluator) { }
 
         #region IObjectDetailsViewer
         public ViewerCapabilities Capabilities => ViewerCapabilities.List | ViewerCapabilities.Table;
@@ -32,9 +29,12 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
         public abstract bool CanView(IRValueInfo evaluation);
 
         public async Task ViewAsync(string expression, string title, CancellationToken cancellationToken = default(CancellationToken)) {
+            if (!Services.GetService<IRSettings>().GridDynamicEvaluation) {
+                expression = Invariant($"as.data.frame({expression})");
+            }
             var evaluation = await EvaluateAsync(expression, _properties, RValueRepresentations.Str(), cancellationToken);
             if (evaluation != null) {
-                await _services.MainThread().SwitchToAsync(cancellationToken);
+                await Services.MainThread().SwitchToAsync(cancellationToken);
                 var id = Math.Abs(_toolWindowIdBase + expression.GetHashCode() % (Int32.MaxValue - _toolWindowIdBase));
 
                 var pane = ToolWindowUtilities.FindWindowPane<VariableGridWindowPane>(id);
@@ -46,8 +46,8 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
                     frame?.Show();
                 }
 
-                title = !string.IsNullOrEmpty(title) ? title : evaluation.Expression;
-                pane.SetEvaluation(new VariableViewModel(evaluation, _services), title);
+                title = !string.IsNullOrEmpty(title) ? title : expression;
+                pane.SetEvaluation(new VariableViewModel(evaluation, Services), title);
             }
         }
         #endregion

--- a/src/Package/Impl/DataInspect/Viewers/GridViewerBase.cs
+++ b/src/Package/Impl/DataInspect/Viewers/GridViewerBase.cs
@@ -11,6 +11,7 @@ using Microsoft.R.DataInspection;
 using Microsoft.VisualStudio.R.Package.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 using static Microsoft.R.DataInspection.REvaluationResultProperties;
+using static System.FormattableString;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
     internal abstract class GridViewerBase : ViewerBase, IObjectDetailsViewer {
@@ -27,6 +28,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
         public abstract bool CanView(IRValueInfo evaluation);
 
         public async Task ViewAsync(string expression, string title, CancellationToken cancellationToken = default(CancellationToken)) {
+            expression = Invariant($"as.data.frame({expression})");
             var evaluation = await EvaluateAsync(expression, _properties, RValueRepresentations.Str(), cancellationToken);
             if (evaluation != null) {
                 await Services.MainThread().SwitchToAsync(cancellationToken);

--- a/src/Package/Impl/DataInspect/Viewers/GridViewerBase.cs
+++ b/src/Package/Impl/DataInspect/Viewers/GridViewerBase.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Common.Core.Services;
 using Microsoft.Common.Core.Threading;
 using Microsoft.R.DataInspection;
+using Microsoft.R.Editor.Data;
 using Microsoft.VisualStudio.R.Package.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 using static Microsoft.R.DataInspection.REvaluationResultProperties;
@@ -28,7 +29,6 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
         public abstract bool CanView(IRValueInfo evaluation);
 
         public async Task ViewAsync(string expression, string title, CancellationToken cancellationToken = default(CancellationToken)) {
-            expression = Invariant($"as.data.frame({expression})");
             var evaluation = await EvaluateAsync(expression, _properties, RValueRepresentations.Str(), cancellationToken);
             if (evaluation != null) {
                 await Services.MainThread().SwitchToAsync(cancellationToken);
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
                 }
 
                 title = !string.IsNullOrEmpty(title) ? title : expression;
-                pane.SetEvaluation(new VariableViewModel(evaluation, Services), title);
+                pane.SetViewModel(new RSessionDataObject(evaluation, false), title);
             }
         }
         #endregion

--- a/src/Package/Impl/DataInspect/Viewers/GridViewerBase.cs
+++ b/src/Package/Impl/DataInspect/Viewers/GridViewerBase.cs
@@ -7,12 +7,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core.Services;
 using Microsoft.Common.Core.Threading;
-using Microsoft.R.Components.Settings;
 using Microsoft.R.DataInspection;
 using Microsoft.VisualStudio.R.Package.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 using static Microsoft.R.DataInspection.REvaluationResultProperties;
-using static System.FormattableString;
 
 namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
     internal abstract class GridViewerBase : ViewerBase, IObjectDetailsViewer {
@@ -29,9 +27,6 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect.Viewers {
         public abstract bool CanView(IRValueInfo evaluation);
 
         public async Task ViewAsync(string expression, string title, CancellationToken cancellationToken = default(CancellationToken)) {
-            if (!Services.GetService<IRSettings>().GridDynamicEvaluation) {
-                expression = Invariant($"as.data.frame({expression})");
-            }
             var evaluation = await EvaluateAsync(expression, _properties, RValueRepresentations.Str(), cancellationToken);
             if (evaluation != null) {
                 await Services.MainThread().SwitchToAsync(cancellationToken);

--- a/src/Package/Impl/DataInspect/VisualGrid/GridPoints.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/GridPoints.cs
@@ -194,12 +194,12 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
 
         public double xPosition(long xIndex) {
             EnsureXPositions();
-            return xIndex > _columnCount ? double.NaN : _xPositions[xIndex] - HorizontalComputedOffset;
+            return xIndex < 0 || xIndex > _columnCount ? double.NaN : _xPositions[xIndex] - HorizontalComputedOffset;
         }
 
         public double yPosition(long yIndex) {
             EnsureYPositions();
-            return yIndex > _rowCount ? double.NaN : _yPositions[yIndex] - VerticalComputedOffset;
+            return yIndex < 0 || yIndex > _rowCount ? double.NaN : _yPositions[yIndex] - VerticalComputedOffset;
         }
 
         public double GetWidth(long columnIndex) => columnIndex < _columnCount ? _width[columnIndex] : 0;

--- a/src/Package/Impl/DataInspect/VisualGrid/ScrollCommand.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/ScrollCommand.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Diagnostics;
-using System.Windows;
-
 namespace Microsoft.VisualStudio.R.Package.DataInspect {
     internal class ScrollCommand {
         public ScrollCommand(GridUpdateType code, object param) {

--- a/src/Package/Impl/DataInspect/VisualGrid/SortOrder.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/SortOrder.cs
@@ -44,9 +44,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             }
         }
 
-        public void Add(ColumnSortOrder order) {
-            _sortOrderList.Add(order);
-        }
+        public void Add(ColumnSortOrder order) => _sortOrderList.Add(order);
 
         /// <remarks>
         /// Complete expression looks like:

--- a/src/Package/Impl/DataInspect/VisualGrid/VisualGridScroller.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/VisualGridScroller.cs
@@ -143,28 +143,28 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             var suppress = false;
             switch (cmd.UpdateType) {
                 case LineUp:
-                    Points.VerticalOffset -= Points.AverageItemHeight * (int)cmd.Param;
+                    Points.VerticalOffset -= Points.AverageItemHeight * Convert.ToInt32(cmd.Param);
                     break;
                 case LineDown:
-                    Points.VerticalOffset += Points.AverageItemHeight * (int)cmd.Param;
+                    Points.VerticalOffset += Points.AverageItemHeight * Convert.ToInt32(cmd.Param);
                     break;
                 case LineLeft:
-                    Points.HorizontalOffset -= Points.AverageItemHeight * (int)cmd.Param;    // for horizontal line increment, use vertical size
+                    Points.HorizontalOffset -= Points.AverageItemHeight * Convert.ToInt32(cmd.Param);    // for horizontal line increment, use vertical size
                     break;
                 case LineRight:
-                    Points.HorizontalOffset += Points.AverageItemHeight * (int)cmd.Param;    // for horizontal line increment, use vertical size
+                    Points.HorizontalOffset += Points.AverageItemHeight * Convert.ToInt32(cmd.Param);    // for horizontal line increment, use vertical size
                     break;
                 case PageUp:
-                    Points.VerticalOffset -= Points.ViewportHeight * (int)cmd.Param;
+                    Points.VerticalOffset -= Points.ViewportHeight * Convert.ToInt32(cmd.Param);
                     break;
                 case PageDown:
-                    Points.VerticalOffset += Points.ViewportHeight * (int)cmd.Param;
+                    Points.VerticalOffset += Points.ViewportHeight * Convert.ToInt32(cmd.Param);
                     break;
                 case PageLeft:
-                    Points.HorizontalOffset -= Points.ViewportWidth * (int)cmd.Param;
+                    Points.HorizontalOffset -= Points.ViewportWidth * Convert.ToInt32(cmd.Param);
                     break;
                 case PageRight:
-                    Points.HorizontalOffset += Points.ViewportWidth * (int)cmd.Param;
+                    Points.HorizontalOffset += Points.ViewportWidth * Convert.ToInt32(cmd.Param);
                     break;
                 case SetHorizontalOffset: {
                         var (offset, thumbtrack) = ((double, ThumbTrack))cmd.Param;
@@ -179,7 +179,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                     }
                     break;
                 case MouseWheel:
-                    Points.VerticalOffset -= (int)cmd.Param;
+                    Points.VerticalOffset -= Convert.ToInt32(cmd.Param);
                     break;
                 case SizeChange:
                     Points.ViewportWidth = ((Size)cmd.Param).Width;
@@ -189,27 +189,27 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                 case Sort:
                     break;
                 case FocusUp:
-                    DataGrid.SelectedIndex = new GridIndex(Math.Max(DataGrid.SelectedIndex.Row - (long)cmd.Param, 0), DataGrid.SelectedIndex.Column);
+                    DataGrid.SelectedIndex = new GridIndex(Math.Max(DataGrid.SelectedIndex.Row - Convert.ToInt32(cmd.Param), 0), DataGrid.SelectedIndex.Column);
                     await BringFocusedCellIntoViewAsync(token);
                     return;
                 case FocusDown:
-                    DataGrid.SelectedIndex = new GridIndex(Math.Min(DataGrid.SelectedIndex.Row + (long)cmd.Param, DataProvider.RowCount - 1), DataGrid.SelectedIndex.Column);
+                    DataGrid.SelectedIndex = new GridIndex(Math.Min(DataGrid.SelectedIndex.Row + Convert.ToInt32(cmd.Param), DataProvider.RowCount - 1), DataGrid.SelectedIndex.Column);
                     await BringFocusedCellIntoViewAsync(token);
                     return;
                 case FocusLeft:
-                    DataGrid.SelectedIndex = new GridIndex(DataGrid.SelectedIndex.Row, Math.Max(DataGrid.SelectedIndex.Column - (long)cmd.Param, 0));
+                    DataGrid.SelectedIndex = new GridIndex(DataGrid.SelectedIndex.Row, Math.Max(DataGrid.SelectedIndex.Column - Convert.ToInt32(cmd.Param), 0));
                     await BringFocusedCellIntoViewAsync(token);
                     return;
                 case FocusRight:
-                    DataGrid.SelectedIndex = new GridIndex(DataGrid.SelectedIndex.Row, Math.Min(DataGrid.SelectedIndex.Column + (long)cmd.Param, DataProvider.RowCount - 1));
+                    DataGrid.SelectedIndex = new GridIndex(DataGrid.SelectedIndex.Row, Math.Min(DataGrid.SelectedIndex.Column + Convert.ToInt32(cmd.Param), DataProvider.RowCount - 1));
                     await BringFocusedCellIntoViewAsync(token);
                     return;
                 case FocusPageUp:
-                    DataGrid.SelectedIndex = new GridIndex(Math.Max(DataGrid.SelectedIndex.Row - (long)cmd.Param, 0), DataGrid.SelectedIndex.Column);
+                    DataGrid.SelectedIndex = new GridIndex(Math.Max(DataGrid.SelectedIndex.Row - Convert.ToInt32(cmd.Param), 0), DataGrid.SelectedIndex.Column);
                     await BringFocusedCellIntoViewAsync(token);
                     return;
                 case FocusPageDown:
-                    DataGrid.SelectedIndex = new GridIndex(Math.Min(DataGrid.SelectedIndex.Row + (long)cmd.Param, DataProvider.RowCount - 1), DataGrid.SelectedIndex.Column);
+                    DataGrid.SelectedIndex = new GridIndex(Math.Min(DataGrid.SelectedIndex.Row + Convert.ToInt32(cmd.Param), DataProvider.RowCount - 1), DataGrid.SelectedIndex.Column);
                     await BringFocusedCellIntoViewAsync(token);
                     return;
                 case SetFocus:
@@ -217,11 +217,11 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                     await BringFocusedCellIntoViewAsync(token);
                     return;
                 case HeaderFocusLeft:
-                    ColumnHeader.SelectedIndex = new GridIndex(ColumnHeader.SelectedIndex.Row, Math.Max(ColumnHeader.SelectedIndex.Column - (long)cmd.Param, 0));
+                    ColumnHeader.SelectedIndex = new GridIndex(ColumnHeader.SelectedIndex.Row, Math.Max(ColumnHeader.SelectedIndex.Column - Convert.ToInt32(cmd.Param), 0));
                     await BringFocusedHeaderIntoViewAsync(token);
                     return;
                 case HeaderFocusRight:
-                    ColumnHeader.SelectedIndex = new GridIndex(ColumnHeader.SelectedIndex.Row, Math.Min(ColumnHeader.SelectedIndex.Column + (long)cmd.Param, DataProvider.RowCount - 1));
+                    ColumnHeader.SelectedIndex = new GridIndex(ColumnHeader.SelectedIndex.Row, Math.Min(ColumnHeader.SelectedIndex.Column + Convert.ToInt32(cmd.Param), DataProvider.RowCount - 1));
                     await BringFocusedHeaderIntoViewAsync(token);
                     return;
                 case SetHeaderFocus:

--- a/src/Package/Impl/DataInspect/VisualGrid/VisualGridScroller.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/VisualGridScroller.cs
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                                 if (IsRepeating(batch, i, RepeatSkip)) {
                                     execute = false;
                                 } else if (IsRepeating(batch, i, RepeatAccum)) {
-                                    batch[i + 1].Param = (double)batch[i + 1].Param + (double)batch[i].Param;
+                                    batch[i + 1].Param = Convert.ToDouble(batch[i + 1].Param) + Convert.ToDouble(batch[i].Param);
                                     execute = false;
                                 }
                             }
@@ -213,7 +213,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                     await BringFocusedCellIntoViewAsync(token);
                     return;
                 case SetFocus:
-                    DataGrid.SelectedIndex = (GridIndex) cmd.Param;
+                    DataGrid.SelectedIndex = (GridIndex)cmd.Param;
                     await BringFocusedCellIntoViewAsync(token);
                     return;
                 case HeaderFocusLeft:
@@ -225,7 +225,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                     await BringFocusedHeaderIntoViewAsync(token);
                     return;
                 case SetHeaderFocus:
-                    ColumnHeader.SelectedIndex = (GridIndex) cmd.Param;
+                    ColumnHeader.SelectedIndex = (GridIndex)cmd.Param;
                     await BringFocusedHeaderIntoViewAsync(token);
                     return;
                 case Invalid:

--- a/src/Package/Impl/DataInspect/VisualGrid/VisualGridScroller.cs
+++ b/src/Package/Impl/DataInspect/VisualGrid/VisualGridScroller.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
             await TaskUtilities.SwitchToBackgroundThread();
 
             const int ScrollCommandUpperBound = 100;
-            List<ScrollCommand> batch = new List<ScrollCommand>();
+            var batch = new List<ScrollCommand>();
 
             while (true) {
                 var command = await _scrollCommands.ReceiveAsync(cancellationToken);
@@ -106,12 +106,12 @@ namespace Microsoft.VisualStudio.R.Package.DataInspect {
                         // upperbound prevents infinite loop in case scroll commands is queued fast and endlessly, which happens only in theory
                         continue;
                     } else {
-                        for (int i = 0; i < batch.Count; i++) {
+                        for (var i = 0; i < batch.Count; i++) {
                             if (cancellationToken.IsCancellationRequested) {
                                 break;
                             }
 
-                            bool execute = true;
+                            var execute = true;
                             // if next command is same the current one, skip to next (new one) for optimization
                             if (i < (batch.Count - 1)) {
                                 if (IsRepeating(batch, i, RepeatSkip)) {

--- a/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
+++ b/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
@@ -1099,6 +1099,10 @@
       <Project>{6d62df0d-d9c3-49a7-a693-acd0691ba69d}</Project>
       <Name>Microsoft.R.Debugger</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Host\Protocol\Impl\Microsoft.R.Host.Protocol.csproj">
+      <Project>{c46e5f53-4caf-4c65-b173-ca8140fb41e0}</Project>
+      <Name>Microsoft.R.Host.Protocol</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Windows\Containers\Impl\Microsoft.R.Containers.Windows.csproj">
       <Project>{8ed6ef0a-08a9-4f77-8ec1-f1630aad2ddb}</Project>
       <Name>Microsoft.R.Containers.Windows</Name>

--- a/src/Package/Impl/Options/R/RToolsOptionsPage.cs
+++ b/src/Package/Impl/Options/R/RToolsOptionsPage.cs
@@ -210,6 +210,15 @@ namespace Microsoft.VisualStudio.R.Package.Options.R {
             set => _holder.SetValue(value);
         }
 
+        [LocCategory(nameof(Resources.Settings_GridViewCategory))]
+        [CustomLocDisplayName(nameof(Resources.Settings_GridView_DynamicEvaluation))]
+        [LocDescription(nameof(Resources.Settings_GridView_DynamicEvaluation_Description))]
+        [DefaultValue(false)]
+        public bool GridDynamicEvaluation {
+            get => _holder.GetValue(false);
+            set => _holder.SetValue(value);
+        }
+
         /// Overrides default methods since we provide custom settings storage
         public override void LoadSettingsFromStorage() { }
         public override void SaveSettingsToStorage() { }

--- a/src/Package/Impl/Options/R/Tools/CranMirrorTypeConverter.cs
+++ b/src/Package/Impl/Options/R/Tools/CranMirrorTypeConverter.cs
@@ -10,9 +10,7 @@ using Microsoft.R.Components.Settings.Mirrors;
 
 namespace Microsoft.VisualStudio.R.Package.Options.R.Tools {
     internal sealed class CranMirrorTypeConverter : TypeConverter {
-        public override bool GetStandardValuesSupported(ITypeDescriptorContext context) {
-            return true;
-        }
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context) => true;
 
         public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context) {
             var mirrors = new List<string> { null };
@@ -20,27 +18,24 @@ namespace Microsoft.VisualStudio.R.Package.Options.R.Tools {
             return new StandardValuesCollection(mirrors);
         }
 
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) {
-            return sourceType == typeof(string);
-        }
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) => sourceType == typeof(string);
 
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
             string s = value as string;
             if (s == Resources.CranMirror_UseRProfile) {
                 return null;
-            } else if (CranMirrorList.MirrorNames.Contains(s)) {
-                return s;
-            } else {
-                throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, Resources.Error_UnknownMirror, value));
             }
+            if (CranMirrorList.MirrorNames.Contains(s)) {
+                return s;
+            }
+
+            throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, Resources.Error_UnknownMirror, value));
         }
 
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) {
-            return destinationType == typeof(string);
-        }
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) 
+            => destinationType == typeof(string);
 
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType) {
-            return value ?? Resources.CranMirror_UseRProfile;
-        }
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType) 
+            => value ?? Resources.CranMirror_UseRProfile;
     }
 }

--- a/src/Package/Impl/Options/R/Tools/RSettingsImplementation.cs
+++ b/src/Package/Impl/Options/R/Tools/RSettingsImplementation.cs
@@ -51,6 +51,9 @@ namespace Microsoft.VisualStudio.R.Package.Options.R {
         private BrowserType _htmlBrowserType = BrowserType.External;
         private BrowserType _markdownBrowserType = BrowserType.External;
         private LogVerbosity _logVerbosity = LogVerbosity.Normal;
+        private bool _showRToolbar = true;
+        private bool _showLoadMeter;
+        private bool _dynamicGridEvaluation;
 
         public RSettingsImplementation(IServiceContainer services) {
             _services = services;
@@ -135,7 +138,7 @@ namespace Microsoft.VisualStudio.R.Package.Options.R {
                 SetProperty(ref _workingDirectory, newDirectory);
                 UpdateWorkingDirectoryList(newDirectory);
 
-                
+
                 _services?.MainThread().Post(() => {
                     var shell = _services.GetService<IVsUIShell>(typeof(SVsUIShell));
                     shell.UpdateCommandUI(1);
@@ -204,9 +207,20 @@ namespace Microsoft.VisualStudio.R.Package.Options.R {
             set => SetProperty(ref _logVerbosity, value);
         }
 
-        public bool ShowRToolbar { get; set; } = true;
-        public bool ShowHostLoadMeter { get; set; }
-        public bool GridDynamicEvaluation { get; set; }
+        public bool ShowRToolbar {
+            get => _showRToolbar;
+            set => SetProperty(ref _showRToolbar, value);
+        }
+
+        public bool ShowHostLoadMeter {
+            get => _showLoadMeter;
+            set => SetProperty(ref _showLoadMeter, value);
+        }
+
+        public bool GridDynamicEvaluation {
+            get => _dynamicGridEvaluation;
+            set => SetProperty(ref _dynamicGridEvaluation, value);
+        }
 
         private void UpdateWorkingDirectoryList(string newDirectory) {
             var list = new List<string>(WorkingDirectoryList ?? Enumerable.Empty<string>());
@@ -224,7 +238,7 @@ namespace Microsoft.VisualStudio.R.Package.Options.R {
         public void LoadSettings() {
             _settingStorage.LoadPropertyValues(this);
             // Correct setting if stored value exceed currently set maximum
-            LogVerbosity = MathExtensions.Min<LogVerbosity>(LogVerbosity, _loggingPermissions.MaxVerbosity);
+            LogVerbosity = MathExtensions.Min(LogVerbosity, _loggingPermissions.MaxVerbosity);
             _loggingPermissions.CurrentVerbosity = LogVerbosity;
         }
 

--- a/src/Package/Impl/Options/R/Tools/RSettingsImplementation.cs
+++ b/src/Package/Impl/Options/R/Tools/RSettingsImplementation.cs
@@ -206,9 +206,10 @@ namespace Microsoft.VisualStudio.R.Package.Options.R {
 
         public bool ShowRToolbar { get; set; } = true;
         public bool ShowHostLoadMeter { get; set; }
+        public bool GridDynamicEvaluation { get; set; }
 
         private void UpdateWorkingDirectoryList(string newDirectory) {
-            List<string> list = new List<string>(WorkingDirectoryList ?? Enumerable.Empty<string>());
+            var list = new List<string>(WorkingDirectoryList ?? Enumerable.Empty<string>());
             if (!string.IsNullOrEmpty(newDirectory) && !list.Contains(newDirectory, StringComparer.OrdinalIgnoreCase)) {
                 list.Insert(0, newDirectory);
                 if (list.Count > MaxDirectoryEntries) {

--- a/src/Package/Impl/Packages/R/RPackageToolWindowProvider.cs
+++ b/src/Package/Impl/Packages/R/RPackageToolWindowProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.R.Packages.R {
         }
 
         public ToolWindowPane CreateToolWindow(Guid toolWindowGuid, int id) 
-            => CreateVisualComponent(toolWindowGuid, id).Container as ToolWindowPane;
+            => CreateVisualComponent(toolWindowGuid, id)?.Container as ToolWindowPane;
 
         private IVisualComponent CreateVisualComponent(Guid toolWindowGuid, int id) {
             if (toolWindowGuid == RGuidList.ReplInteractiveWindowProviderGuid) {

--- a/src/Package/Impl/ProjectSystem/ProjectSystemServices.cs
+++ b/src/Package/Impl/ProjectSystem/ProjectSystemServices.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.R.Package.ProjectSystem {
         public string GetProjectItemTemplatesFolder() {
             // In F5 (Experimental instance) scenario templates are deployed where the extension is.
             var assemblyPath = Assembly.GetExecutingAssembly().GetAssemblyPath();
-            var templatesFolder = Path.Combine(Path.GetDirectoryName(assemblyPath), @"Templates\ItemTemplates\");
+            var templatesFolder = Path.Combine(Path.GetDirectoryName(assemblyPath), @"ItemTemplates\");
             if (!Directory.Exists(templatesFolder)) {
                 // Real install scenario, templates are in 
                 // C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\ItemTemplates\R

--- a/src/Package/Impl/Properties/AssemblyInfo.cs
+++ b/src/Package/Impl/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 [assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.Win32.Primitives",
     OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "4.0.2.0", NewVersion = "4.0.2.0")]
 [assembly: ProvideBindingRedirection(AssemblyName = "System.Diagnostics.DiagnosticSource",
-    OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "4.0.2.0", NewVersion = "4.0.2.0")]
+    OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "4.0.1.0", NewVersion = "4.0.1.0")]
 [assembly: ProvideBindingRedirection(AssemblyName = "System.Net.Http",
     OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "4.1.1.1", NewVersion = "4.1.1.1")]
 

--- a/src/Package/Impl/Resources.Designer.cs
+++ b/src/Package/Impl/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.R.Package {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -1910,6 +1910,33 @@ namespace Microsoft.VisualStudio.R.Package {
         public static string Settings_GeneralCategory {
             get {
                 return ResourceManager.GetString("Settings_GeneralCategory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dynamic evaluation.
+        /// </summary>
+        public static string Settings_GridView_DynamicEvaluation {
+            get {
+                return ResourceManager.GetString("Settings_GridView_DynamicEvaluation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to By default View(x) takes snapshot of data as a data frame. This may consume subtantial amount of memory with large data sets. With dynamic evaluation the expression is evaluated every time grid refreshes in order to only fetch part of the data for display. However, if the variable changes the data in the grid will also change. This mode may be unsuitable for dplyr pipe expressions..
+        /// </summary>
+        public static string Settings_GridView_DynamicEvaluation_Description {
+            get {
+                return ResourceManager.GetString("Settings_GridView_DynamicEvaluation_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Grid view.
+        /// </summary>
+        public static string Settings_GridViewCategory {
+            get {
+                return ResourceManager.GetString("Settings_GridViewCategory", resourceCulture);
             }
         }
         

--- a/src/Package/Impl/Resources.resx
+++ b/src/Package/Impl/Resources.resx
@@ -1377,4 +1377,13 @@ You can modify Visual Studio installation in Control Panel -&gt; Uninstall Progr
   <data name="Settings_MarkdownCategory_Scroll" xml:space="preserve">
     <value>Scrolling</value>
   </data>
+  <data name="Settings_GridViewCategory" xml:space="preserve">
+    <value>Grid view</value>
+  </data>
+  <data name="Settings_GridView_DynamicEvaluation" xml:space="preserve">
+    <value>Dynamic evaluation</value>
+  </data>
+  <data name="Settings_GridView_DynamicEvaluation_Description" xml:space="preserve">
+    <value>By default View(x) takes snapshot of data as a data frame. This may consume subtantial amount of memory with large data sets. With dynamic evaluation the expression is evaluated every time grid refreshes in order to only fetch part of the data for display. However, if the variable changes the data in the grid will also change. This mode may be unsuitable for dplyr pipe expressions.</value>
+  </data>
 </root>

--- a/src/Package/Impl/Shell/Services/VsIdleTimeSource.cs
+++ b/src/Package/Impl/Shell/Services/VsIdleTimeSource.cs
@@ -17,14 +17,13 @@ namespace Microsoft.VisualStudio.R.Package.Shell {
         private uint _componentID;
         private bool _startupComplete;
 
-        public VsIdleTimeService(IServiceContainer services) {
+        public VsIdleTimeService(IOleComponentManager oleComponentManager) {
             var crinfo = new OLECRINFO[1];
             crinfo[0].cbSize = (uint)Marshal.SizeOf(typeof(OLECRINFO));
             crinfo[0].grfcrf = (uint)_OLECRF.olecrfNeedIdleTime | (uint)_OLECRF.olecrfNeedPeriodicIdleTime;
             crinfo[0].grfcadvf = (uint)_OLECADVF.olecadvfModal | (uint)_OLECADVF.olecadvfRedrawOff | (uint)_OLECADVF.olecadvfWarningsOff;
             crinfo[0].uIdleTimeInterval = 200;
 
-            var oleComponentManager = services.GetService<IOleComponentManager>(typeof(SOleComponentManager));
             oleComponentManager.FRegisterComponent(this, crinfo, out _componentID);
         }
 

--- a/src/Package/Impl/Shell/VsAppShell.Idle.cs
+++ b/src/Package/Impl/Shell/VsAppShell.Idle.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.VisualStudio.OLE.Interop;
+
 namespace Microsoft.VisualStudio.R.Package.Shell {
     public sealed partial class VsAppShell {
         private VsIdleTimeService _idleTimeService;
 
-        private void ConfigureIdleSource() {
-            _idleTimeService = new VsIdleTimeService(_services);
+        private void ConfigureIdleSource(IOleComponentManager oleComponentManager) {
+            _idleTimeService = new VsIdleTimeService(oleComponentManager);
             _idleTimeService.ApplicationClosing += (s, e) => _application.FireTerminating();
             _services.AddService(_idleTimeService);
         }

--- a/src/Package/Impl/Shell/VsAppShell.Lifetime.cs
+++ b/src/Package/Impl/Shell/VsAppShell.Lifetime.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using Microsoft.Common.Core.Shell;
 using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.R.Package.Wpf;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -27,15 +28,17 @@ namespace Microsoft.VisualStudio.R.Package.Shell {
         }
 
         private void Initialize() {
+            _vsShell = (IVsShell)VsPackage.GetGlobalService(typeof(SVsShell));
             VsWpfOverrides.Apply();
 
+            var oleCm = (IOleComponentManager)VsPackage.GetGlobalService(typeof(SOleComponentManager));
+            ConfigureIdleSource(oleCm);
+
             ConfigurePackageServices();
-            ConfigureIdleSource();
             CheckVsStarted();
         }
 
         private void CheckVsStarted() {
-            _vsShell = (IVsShell)VsPackage.GetGlobalService(typeof(SVsShell));
             _vsShell.GetProperty((int)__VSSPROPID4.VSSPROPID_ShellInitialized, out var value);
             if (value is bool) {
                 if ((bool)value) {

--- a/src/Package/Impl/Telemetry/RtvsTelemetry.cs
+++ b/src/Package/Impl/Telemetry/RtvsTelemetry.cs
@@ -139,7 +139,8 @@ namespace Microsoft.VisualStudio.R.Package.Telemetry {
                 foreach (var c in connections) {
                     if (Uri.TryCreate(c.Path, UriKind.Absolute, out Uri uri)) {
                         if (uri.IsFile) {
-                            TelemetryService.ReportEvent(TelemetryArea.Configuration, ConfigurationEvents.LocalConnection, uri.ToString());
+                            // Do not report local since they are reported via installed R
+                            // TelemetryService.ReportEvent(TelemetryArea.Configuration, ConfigurationEvents.LocalConnection, uri.ToString());
                         } else if (uri.IsLoopback) {
                             TelemetryService.ReportEvent(TelemetryArea.Configuration, ConfigurationEvents.ContainerConnection, uri.ToString());
                         } else {
@@ -171,7 +172,11 @@ namespace Microsoft.VisualStudio.R.Package.Telemetry {
                                 CompletionEnabled = _editorSettings.CompletionEnabled,
                                 SyntaxCheckInRepl = _editorSettings.SyntaxCheckInRepl,
                                 PartialArgumentNameMatch = _editorSettings.PartialArgumentNameMatch,
-                                RCommandLineArguments = _settings.LastActiveConnection?.RCommandLineArguments ?? string.Empty,
+
+                                // Do not report command line arguments - they may contain 
+                                // PII information and they are not that interesting anyway.
+                                // RCommandLineArguments = _settings.LastActiveConnection?.RCommandLineArguments ?? string.Empty,
+
                                 // R Linter
                                 LinterEnabled = _editorSettings.LintOptions.Enabled,
                                 LinterCamelCase = _editorSettings.LintOptions.CamelCase,
@@ -197,6 +202,7 @@ namespace Microsoft.VisualStudio.R.Package.Telemetry {
                                 LinterDoubleQuotes = _editorSettings.LintOptions.DoubleQuotes,
                                 LinterLineLength = _editorSettings.LintOptions.LineLength,
                                 LinterMaxLineLength = _editorSettings.LintOptions.MaxLineLength,
+
                                 // R formatter
                                 FormatterTabSize = _editorSettings.FormatOptions.TabSize,
                                 FormatterIndentSize = _editorSettings.FormatOptions.IndentSize,
@@ -207,6 +213,7 @@ namespace Microsoft.VisualStudio.R.Package.Telemetry {
                                 FormatterSpaceAfterKeyword = _editorSettings.FormatOptions.SpaceAfterKeyword,
                                 FormatterSpaceBeforeCurly = _editorSettings.FormatOptions.SpaceBeforeCurly,
                                 FormatterSpacesAroundEquals = _editorSettings.FormatOptions.SpacesAroundEquals,
+
                                 // R Markdown
                                 MarkdownPreviewEnabled = _markdownSettings.EnablePreview,
                                 MarkdownPreviewRight = _markdownSettings.PreviewPosition == RMarkdownPreviewPosition.Right,

--- a/src/Package/Impl/Telemetry/RtvsTelemetry.cs
+++ b/src/Package/Impl/Telemetry/RtvsTelemetry.cs
@@ -175,7 +175,6 @@ namespace Microsoft.VisualStudio.R.Package.Telemetry {
 
                                 // Do not report command line arguments - they may contain 
                                 // PII information and they are not that interesting anyway.
-                                // RCommandLineArguments = _settings.LastActiveConnection?.RCommandLineArguments ?? string.Empty,
 
                                 // R Linter
                                 LinterEnabled = _editorSettings.LintOptions.Enabled,

--- a/src/Package/Impl/project.json
+++ b/src/Package/Impl/project.json
@@ -37,7 +37,7 @@
     "Microsoft.Win32.Primitives": "4.3.0",
     "System.IO.Compression": "4.3.0",
     "System.IO.Compression.ZipFile": "4.3.0",
-    "System.Net.Http.WinHttpHandler": "4.4.0",
+    "System.Net.Http.WinHttpHandler": "4.3.0",
     "System.Threading.Tasks.Dataflow": "4.5.24",
     "System.ValueTuple": "4.3.0",
     "VSSDK.DTE.8": "8.0.4"

--- a/src/Package/TestApp/Files/VariableGrid02.tree
+++ b/src/Package/TestApp/Files/VariableGrid02.tree
@@ -440,7 +440,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,1]"
+                                      "Value": "V1"
                                     }
                                   ],
                                   "Children": []
@@ -450,7 +450,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,2]"
+                                      "Value": "V2"
                                     }
                                   ],
                                   "Children": []
@@ -460,7 +460,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,3]"
+                                      "Value": "V3"
                                     }
                                   ],
                                   "Children": []
@@ -470,7 +470,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,4]"
+                                      "Value": "V4"
                                     }
                                   ],
                                   "Children": []
@@ -480,7 +480,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,5]"
+                                      "Value": "V5"
                                     }
                                   ],
                                   "Children": []
@@ -576,7 +576,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[1,]"
+                                      "Value": "1"
                                     }
                                   ],
                                   "Children": []
@@ -586,7 +586,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[2,]"
+                                      "Value": "2"
                                     }
                                   ],
                                   "Children": []

--- a/src/Package/TestApp/Files/VariableGridDynamic.tree
+++ b/src/Package/TestApp/Files/VariableGridDynamic.tree
@@ -440,7 +440,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,1]"
+                                      "Value": "V1"
                                     }
                                   ],
                                   "Children": []
@@ -536,7 +536,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[1,]"
+                                      "Value": "1"
                                     }
                                   ],
                                   "Children": []
@@ -546,7 +546,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[2,]"
+                                      "Value": "2"
                                     }
                                   ],
                                   "Children": []
@@ -556,7 +556,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[3,]"
+                                      "Value": "3"
                                     }
                                   ],
                                   "Children": []
@@ -566,7 +566,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[4,]"
+                                      "Value": "4"
                                     }
                                   ],
                                   "Children": []
@@ -576,7 +576,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[5,]"
+                                      "Value": "5"
                                     }
                                   ],
                                   "Children": []
@@ -586,7 +586,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[6,]"
+                                      "Value": "6"
                                     }
                                   ],
                                   "Children": []
@@ -596,7 +596,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[7,]"
+                                      "Value": "7"
                                     }
                                   ],
                                   "Children": []
@@ -606,7 +606,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[8,]"
+                                      "Value": "8"
                                     }
                                   ],
                                   "Children": []
@@ -616,7 +616,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[9,]"
+                                      "Value": "9"
                                     }
                                   ],
                                   "Children": []
@@ -626,7 +626,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[10,]"
+                                      "Value": "10"
                                     }
                                   ],
                                   "Children": []
@@ -636,7 +636,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[11,]"
+                                      "Value": "11"
                                     }
                                   ],
                                   "Children": []
@@ -646,7 +646,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[12,]"
+                                      "Value": "12"
                                     }
                                   ],
                                   "Children": []
@@ -656,7 +656,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[13,]"
+                                      "Value": "13"
                                     }
                                   ],
                                   "Children": []
@@ -666,7 +666,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[14,]"
+                                      "Value": "14"
                                     }
                                   ],
                                   "Children": []
@@ -676,7 +676,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[15,]"
+                                      "Value": "15"
                                     }
                                   ],
                                   "Children": []
@@ -686,7 +686,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[16,]"
+                                      "Value": "16"
                                     }
                                   ],
                                   "Children": []
@@ -696,7 +696,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[17,]"
+                                      "Value": "17"
                                     }
                                   ],
                                   "Children": []
@@ -706,7 +706,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[18,]"
+                                      "Value": "18"
                                     }
                                   ],
                                   "Children": []
@@ -716,7 +716,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[19,]"
+                                      "Value": "19"
                                     }
                                   ],
                                   "Children": []
@@ -726,7 +726,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[20,]"
+                                      "Value": "20"
                                     }
                                   ],
                                   "Children": []

--- a/src/Package/TestApp/Files/VariableGridDynamic.tree
+++ b/src/Package/TestApp/Files/VariableGridDynamic.tree
@@ -1,0 +1,2653 @@
+{
+  "Name": "VariableGridHost",
+  "Properties": [
+    {
+      "Name": "Content",
+      "Value": "System.Windows.Controls.Grid"
+    },
+    {
+      "Name": "ContentTemplate",
+      "Value": "null"
+    },
+    {
+      "Name": "Padding",
+      "Value": "0,0,0,0"
+    },
+    {
+      "Name": "DataContext",
+      "Value": "null"
+    },
+    {
+      "Name": "Name",
+      "Value": ""
+    },
+    {
+      "Name": "Margin",
+      "Value": "0,0,0,0"
+    },
+    {
+      "Name": "HorizontalAlignment",
+      "Value": "Stretch"
+    },
+    {
+      "Name": "VerticalAlignment",
+      "Value": "Stretch"
+    },
+    {
+      "Name": "ToolTip",
+      "Value": "null"
+    },
+    {
+      "Name": "ContextMenu",
+      "Value": "null"
+    },
+    {
+      "Name": "Visibility",
+      "Value": "Visible"
+    }
+  ],
+  "Children": [
+    {
+      "Name": "Border",
+      "Properties": [
+        {
+          "Name": "Padding",
+          "Value": "0,0,0,0"
+        },
+        {
+          "Name": "DataContext",
+          "Value": "null"
+        },
+        {
+          "Name": "Name",
+          "Value": ""
+        },
+        {
+          "Name": "Margin",
+          "Value": "0,0,0,0"
+        },
+        {
+          "Name": "HorizontalAlignment",
+          "Value": "Stretch"
+        },
+        {
+          "Name": "VerticalAlignment",
+          "Value": "Stretch"
+        },
+        {
+          "Name": "ToolTip",
+          "Value": "null"
+        },
+        {
+          "Name": "ContextMenu",
+          "Value": "null"
+        },
+        {
+          "Name": "Visibility",
+          "Value": "Visible"
+        }
+      ],
+      "Children": [
+        {
+          "Name": "ContentPresenter",
+          "Properties": [
+            {
+              "Name": "Content",
+              "Value": "System.Windows.Controls.Grid"
+            },
+            {
+              "Name": "ContentTemplate",
+              "Value": "null"
+            },
+            {
+              "Name": "DataContext",
+              "Value": "null"
+            },
+            {
+              "Name": "Name",
+              "Value": ""
+            },
+            {
+              "Name": "Margin",
+              "Value": "0,0,0,0"
+            },
+            {
+              "Name": "HorizontalAlignment",
+              "Value": "Stretch"
+            },
+            {
+              "Name": "VerticalAlignment",
+              "Value": "Stretch"
+            },
+            {
+              "Name": "ToolTip",
+              "Value": "null"
+            },
+            {
+              "Name": "ContextMenu",
+              "Value": "null"
+            },
+            {
+              "Name": "Visibility",
+              "Value": "Visible"
+            }
+          ],
+          "Children": [
+            {
+              "Name": "Grid",
+              "Properties": [
+                {
+                  "Name": "DataContext",
+                  "Value": "null"
+                },
+                {
+                  "Name": "Name",
+                  "Value": ""
+                },
+                {
+                  "Name": "Margin",
+                  "Value": "0,0,0,0"
+                },
+                {
+                  "Name": "HorizontalAlignment",
+                  "Value": "Stretch"
+                },
+                {
+                  "Name": "VerticalAlignment",
+                  "Value": "Stretch"
+                },
+                {
+                  "Name": "ToolTip",
+                  "Value": "null"
+                },
+                {
+                  "Name": "ContextMenu",
+                  "Value": "null"
+                },
+                {
+                  "Name": "Visibility",
+                  "Value": "Visible"
+                }
+              ],
+              "Children": [
+                {
+                  "Name": "TextBlock",
+                  "Properties": [
+                    {
+                      "Name": "Text",
+                      "Value": ""
+                    },
+                    {
+                      "Name": "Padding",
+                      "Value": "0,0,0,0"
+                    },
+                    {
+                      "Name": "TextAlignment",
+                      "Value": "Left"
+                    },
+                    {
+                      "Name": "DataContext",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "Name",
+                      "Value": "ErrorTextBlock"
+                    },
+                    {
+                      "Name": "Margin",
+                      "Value": "0,0,0,0"
+                    },
+                    {
+                      "Name": "HorizontalAlignment",
+                      "Value": "Stretch"
+                    },
+                    {
+                      "Name": "VerticalAlignment",
+                      "Value": "Stretch"
+                    },
+                    {
+                      "Name": "ToolTip",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "ContextMenu",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "Visibility",
+                      "Value": "Collapsed"
+                    }
+                  ],
+                  "Children": []
+                },
+                {
+                  "Name": "MatrixView",
+                  "Properties": [
+                    {
+                      "Name": "Content",
+                      "Value": "System.Windows.Controls.Grid"
+                    },
+                    {
+                      "Name": "ContentTemplate",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "Padding",
+                      "Value": "0,0,0,0"
+                    },
+                    {
+                      "Name": "DataContext",
+                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                    },
+                    {
+                      "Name": "Name",
+                      "Value": "VariableGrid"
+                    },
+                    {
+                      "Name": "Margin",
+                      "Value": "0,0,0,0"
+                    },
+                    {
+                      "Name": "HorizontalAlignment",
+                      "Value": "Stretch"
+                    },
+                    {
+                      "Name": "VerticalAlignment",
+                      "Value": "Stretch"
+                    },
+                    {
+                      "Name": "ToolTip",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "ContextMenu",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "Visibility",
+                      "Value": "Visible"
+                    }
+                  ],
+                  "Children": [
+                    {
+                      "Name": "ContentPresenter",
+                      "Properties": [
+                        {
+                          "Name": "Content",
+                          "Value": "System.Windows.Controls.Grid"
+                        },
+                        {
+                          "Name": "ContentTemplate",
+                          "Value": "null"
+                        },
+                        {
+                          "Name": "DataContext",
+                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": ""
+                        },
+                        {
+                          "Name": "Margin",
+                          "Value": "0,0,0,0"
+                        },
+                        {
+                          "Name": "HorizontalAlignment",
+                          "Value": "Stretch"
+                        },
+                        {
+                          "Name": "VerticalAlignment",
+                          "Value": "Stretch"
+                        },
+                        {
+                          "Name": "ToolTip",
+                          "Value": "null"
+                        },
+                        {
+                          "Name": "ContextMenu",
+                          "Value": "null"
+                        },
+                        {
+                          "Name": "Visibility",
+                          "Value": "Visible"
+                        }
+                      ],
+                      "Children": [
+                        {
+                          "Name": "Grid",
+                          "Properties": [
+                            {
+                              "Name": "DataContext",
+                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                            },
+                            {
+                              "Name": "Name",
+                              "Value": ""
+                            },
+                            {
+                              "Name": "Margin",
+                              "Value": "0,0,0,0"
+                            },
+                            {
+                              "Name": "HorizontalAlignment",
+                              "Value": "Stretch"
+                            },
+                            {
+                              "Name": "VerticalAlignment",
+                              "Value": "Stretch"
+                            },
+                            {
+                              "Name": "ToolTip",
+                              "Value": "null"
+                            },
+                            {
+                              "Name": "ContextMenu",
+                              "Value": "null"
+                            },
+                            {
+                              "Name": "Visibility",
+                              "Value": "Visible"
+                            }
+                          ],
+                          "Children": [
+                            {
+                              "Name": "Border",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": []
+                            },
+                            {
+                              "Name": "VisualGrid",
+                              "Properties": [
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": [
+                                {
+                                  "Name": "GridLineVisual",
+                                  "Properties": [],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "HeaderTextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[,1]"
+                                    }
+                                  ],
+                                  "Children": []
+                                }
+                              ]
+                            },
+                            {
+                              "Name": "Border",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": []
+                            },
+                            {
+                              "Name": "VisualGrid",
+                              "Properties": [
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": [
+                                {
+                                  "Name": "GridLineVisual",
+                                  "Properties": [],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[1,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[2,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[3,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[4,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[5,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[6,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[7,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[8,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[9,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[10,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[11,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[12,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[13,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[14,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[15,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[16,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[17,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[18,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[19,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[20,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                }
+                              ]
+                            },
+                            {
+                              "Name": "VisualGrid",
+                              "Properties": [
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": [
+                                {
+                                  "Name": "GridLineVisual",
+                                  "Properties": [],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "1"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "2"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "3"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "4"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "5"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "6"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "7"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "8"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "9"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "10"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "11"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "12"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "13"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "14"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "15"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "16"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "17"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "18"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "19"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "20"
+                                    }
+                                  ],
+                                  "Children": []
+                                }
+                              ]
+                            },
+                            {
+                              "Name": "ScrollBar",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": [
+                                {
+                                  "Name": "Grid",
+                                  "Properties": [
+                                    {
+                                      "Name": "DataContext",
+                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                    },
+                                    {
+                                      "Name": "Name",
+                                      "Value": "Bg"
+                                    },
+                                    {
+                                      "Name": "Margin",
+                                      "Value": "0,0,0,0"
+                                    },
+                                    {
+                                      "Name": "HorizontalAlignment",
+                                      "Value": "Stretch"
+                                    },
+                                    {
+                                      "Name": "VerticalAlignment",
+                                      "Value": "Stretch"
+                                    },
+                                    {
+                                      "Name": "ToolTip",
+                                      "Value": "null"
+                                    },
+                                    {
+                                      "Name": "ContextMenu",
+                                      "Value": "null"
+                                    },
+                                    {
+                                      "Name": "Visibility",
+                                      "Value": "Visible"
+                                    }
+                                  ],
+                                  "Children": [
+                                    {
+                                      "Name": "Border",
+                                      "Properties": [
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": ""
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": []
+                                    },
+                                    {
+                                      "Name": "RepeatButton",
+                                      "Properties": [
+                                        {
+                                          "Name": "Content",
+                                          "Value": "System.Windows.Shapes.Path"
+                                        },
+                                        {
+                                          "Name": "ContentTemplate",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "1,1,1,1"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_LineUpButton"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "Border",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": "border"
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "ContentPresenter",
+                                              "Properties": [
+                                                {
+                                                  "Name": "Content",
+                                                  "Value": "System.Windows.Shapes.Path"
+                                                },
+                                                {
+                                                  "Name": "ContentTemplate",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "contentPresenter"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "1,1,1,1"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": [
+                                                {
+                                                  "Name": "Path",
+                                                  "Properties": [
+                                                    {
+                                                      "Name": "Data",
+                                                      "Value": "M0,4C0,4 0,6 0,6 0,6 3.5,2.5 3.5,2.5 3.5,2.5 7,6 7,6 7,6 7,4 7,4 7,4 3.5,0.5 3.5,0.5 3.5,0.5 0,4 0,4z"
+                                                    },
+                                                    {
+                                                      "Name": "DataContext",
+                                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                    },
+                                                    {
+                                                      "Name": "Name",
+                                                      "Value": "ArrowTop"
+                                                    },
+                                                    {
+                                                      "Name": "Margin",
+                                                      "Value": "3,4,3,3"
+                                                    },
+                                                    {
+                                                      "Name": "HorizontalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "VerticalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "ToolTip",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "ContextMenu",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "Visibility",
+                                                      "Value": "Visible"
+                                                    }
+                                                  ],
+                                                  "Children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Name": "Track",
+                                      "Properties": [
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_Track"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Hidden"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "RepeatButton",
+                                          "Properties": [
+                                            {
+                                              "Name": "Content",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContentTemplate",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": ""
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Name": "RepeatButton",
+                                          "Properties": [
+                                            {
+                                              "Name": "Content",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContentTemplate",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": ""
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Name": "Thumb",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "rectangle"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Name": "RepeatButton",
+                                      "Properties": [
+                                        {
+                                          "Name": "Content",
+                                          "Value": "System.Windows.Shapes.Path"
+                                        },
+                                        {
+                                          "Name": "ContentTemplate",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "1,1,1,1"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_LineDownButton"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "Border",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": "border"
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "ContentPresenter",
+                                              "Properties": [
+                                                {
+                                                  "Name": "Content",
+                                                  "Value": "System.Windows.Shapes.Path"
+                                                },
+                                                {
+                                                  "Name": "ContentTemplate",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "contentPresenter"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "1,1,1,1"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": [
+                                                {
+                                                  "Name": "Path",
+                                                  "Properties": [
+                                                    {
+                                                      "Name": "Data",
+                                                      "Value": "M0,2.5C0,2.5 0,0.5 0,0.5 0,0.5 3.5,4 3.5,4 3.5,4 7,0.5 7,0.5 7,0.5 7,2.5 7,2.5 7,2.5 3.5,6 3.5,6 3.5,6 0,2.5 0,2.5z"
+                                                    },
+                                                    {
+                                                      "Name": "DataContext",
+                                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                    },
+                                                    {
+                                                      "Name": "Name",
+                                                      "Value": "ArrowBottom"
+                                                    },
+                                                    {
+                                                      "Name": "Margin",
+                                                      "Value": "3,4,3,3"
+                                                    },
+                                                    {
+                                                      "Name": "HorizontalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "VerticalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "ToolTip",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "ContextMenu",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "Visibility",
+                                                      "Value": "Visible"
+                                                    }
+                                                  ],
+                                                  "Children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Name": "Border",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": []
+                            },
+                            {
+                              "Name": "ScrollBar",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": [
+                                {
+                                  "Name": "Grid",
+                                  "Properties": [
+                                    {
+                                      "Name": "DataContext",
+                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                    },
+                                    {
+                                      "Name": "Name",
+                                      "Value": "Bg"
+                                    },
+                                    {
+                                      "Name": "Margin",
+                                      "Value": "0,0,0,0"
+                                    },
+                                    {
+                                      "Name": "HorizontalAlignment",
+                                      "Value": "Stretch"
+                                    },
+                                    {
+                                      "Name": "VerticalAlignment",
+                                      "Value": "Stretch"
+                                    },
+                                    {
+                                      "Name": "ToolTip",
+                                      "Value": "null"
+                                    },
+                                    {
+                                      "Name": "ContextMenu",
+                                      "Value": "null"
+                                    },
+                                    {
+                                      "Name": "Visibility",
+                                      "Value": "Visible"
+                                    }
+                                  ],
+                                  "Children": [
+                                    {
+                                      "Name": "Border",
+                                      "Properties": [
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": ""
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": []
+                                    },
+                                    {
+                                      "Name": "RepeatButton",
+                                      "Properties": [
+                                        {
+                                          "Name": "Content",
+                                          "Value": "System.Windows.Shapes.Path"
+                                        },
+                                        {
+                                          "Name": "ContentTemplate",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "1,1,1,1"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_LineLeftButton"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "Border",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": "border"
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "ContentPresenter",
+                                              "Properties": [
+                                                {
+                                                  "Name": "Content",
+                                                  "Value": "System.Windows.Shapes.Path"
+                                                },
+                                                {
+                                                  "Name": "ContentTemplate",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "contentPresenter"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "1,1,1,1"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": [
+                                                {
+                                                  "Name": "Path",
+                                                  "Properties": [
+                                                    {
+                                                      "Name": "Data",
+                                                      "Value": "M3.18,7C3.18,7 5,7 5,7 5,7 1.81,3.5 1.81,3.5 1.81,3.5 5,0 5,0 5,0 3.18,0 3.18,0 3.18,0 0,3.5 0,3.5 0,3.5 3.18,7 3.18,7z"
+                                                    },
+                                                    {
+                                                      "Name": "DataContext",
+                                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                    },
+                                                    {
+                                                      "Name": "Name",
+                                                      "Value": "ArrowLeft"
+                                                    },
+                                                    {
+                                                      "Name": "Margin",
+                                                      "Value": "3,3,3,3"
+                                                    },
+                                                    {
+                                                      "Name": "HorizontalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "VerticalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "ToolTip",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "ContextMenu",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "Visibility",
+                                                      "Value": "Visible"
+                                                    }
+                                                  ],
+                                                  "Children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Name": "Track",
+                                      "Properties": [
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_Track"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Hidden"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "RepeatButton",
+                                          "Properties": [
+                                            {
+                                              "Name": "Content",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContentTemplate",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": ""
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Name": "RepeatButton",
+                                          "Properties": [
+                                            {
+                                              "Name": "Content",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContentTemplate",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": ""
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Name": "Thumb",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "rectangle"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Name": "RepeatButton",
+                                      "Properties": [
+                                        {
+                                          "Name": "Content",
+                                          "Value": "System.Windows.Shapes.Path"
+                                        },
+                                        {
+                                          "Name": "ContentTemplate",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "1,1,1,1"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_LineRightButton"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "Border",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": "border"
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "ContentPresenter",
+                                              "Properties": [
+                                                {
+                                                  "Name": "Content",
+                                                  "Value": "System.Windows.Shapes.Path"
+                                                },
+                                                {
+                                                  "Name": "ContentTemplate",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "contentPresenter"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "1,1,1,1"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": [
+                                                {
+                                                  "Name": "Path",
+                                                  "Properties": [
+                                                    {
+                                                      "Name": "Data",
+                                                      "Value": "M1.81,7C1.81,7 0,7 0,7 0,7 3.18,3.5 3.18,3.5 3.18,3.5 0,0 0,0 0,0 1.81,0 1.81,0 1.81,0 5,3.5 5,3.5 5,3.5 1.81,7 1.81,7z"
+                                                    },
+                                                    {
+                                                      "Name": "DataContext",
+                                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                    },
+                                                    {
+                                                      "Name": "Name",
+                                                      "Value": "ArrowRight"
+                                                    },
+                                                    {
+                                                      "Name": "Margin",
+                                                      "Value": "3,3,3,3"
+                                                    },
+                                                    {
+                                                      "Name": "HorizontalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "VerticalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "ToolTip",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "ContextMenu",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "Visibility",
+                                                      "Value": "Visible"
+                                                    }
+                                                  ],
+                                                  "Children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Name": "Border",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Package/TestApp/Files/VariableGridSnapshot.tree
+++ b/src/Package/TestApp/Files/VariableGridSnapshot.tree
@@ -1,0 +1,2453 @@
+{
+  "Name": "VariableGridHost",
+  "Properties": [
+    {
+      "Name": "Content",
+      "Value": "System.Windows.Controls.Grid"
+    },
+    {
+      "Name": "ContentTemplate",
+      "Value": "null"
+    },
+    {
+      "Name": "Padding",
+      "Value": "0,0,0,0"
+    },
+    {
+      "Name": "DataContext",
+      "Value": "null"
+    },
+    {
+      "Name": "Name",
+      "Value": ""
+    },
+    {
+      "Name": "Margin",
+      "Value": "0,0,0,0"
+    },
+    {
+      "Name": "HorizontalAlignment",
+      "Value": "Stretch"
+    },
+    {
+      "Name": "VerticalAlignment",
+      "Value": "Stretch"
+    },
+    {
+      "Name": "ToolTip",
+      "Value": "null"
+    },
+    {
+      "Name": "ContextMenu",
+      "Value": "null"
+    },
+    {
+      "Name": "Visibility",
+      "Value": "Visible"
+    }
+  ],
+  "Children": [
+    {
+      "Name": "Border",
+      "Properties": [
+        {
+          "Name": "Padding",
+          "Value": "0,0,0,0"
+        },
+        {
+          "Name": "DataContext",
+          "Value": "null"
+        },
+        {
+          "Name": "Name",
+          "Value": ""
+        },
+        {
+          "Name": "Margin",
+          "Value": "0,0,0,0"
+        },
+        {
+          "Name": "HorizontalAlignment",
+          "Value": "Stretch"
+        },
+        {
+          "Name": "VerticalAlignment",
+          "Value": "Stretch"
+        },
+        {
+          "Name": "ToolTip",
+          "Value": "null"
+        },
+        {
+          "Name": "ContextMenu",
+          "Value": "null"
+        },
+        {
+          "Name": "Visibility",
+          "Value": "Visible"
+        }
+      ],
+      "Children": [
+        {
+          "Name": "ContentPresenter",
+          "Properties": [
+            {
+              "Name": "Content",
+              "Value": "System.Windows.Controls.Grid"
+            },
+            {
+              "Name": "ContentTemplate",
+              "Value": "null"
+            },
+            {
+              "Name": "DataContext",
+              "Value": "null"
+            },
+            {
+              "Name": "Name",
+              "Value": ""
+            },
+            {
+              "Name": "Margin",
+              "Value": "0,0,0,0"
+            },
+            {
+              "Name": "HorizontalAlignment",
+              "Value": "Stretch"
+            },
+            {
+              "Name": "VerticalAlignment",
+              "Value": "Stretch"
+            },
+            {
+              "Name": "ToolTip",
+              "Value": "null"
+            },
+            {
+              "Name": "ContextMenu",
+              "Value": "null"
+            },
+            {
+              "Name": "Visibility",
+              "Value": "Visible"
+            }
+          ],
+          "Children": [
+            {
+              "Name": "Grid",
+              "Properties": [
+                {
+                  "Name": "DataContext",
+                  "Value": "null"
+                },
+                {
+                  "Name": "Name",
+                  "Value": ""
+                },
+                {
+                  "Name": "Margin",
+                  "Value": "0,0,0,0"
+                },
+                {
+                  "Name": "HorizontalAlignment",
+                  "Value": "Stretch"
+                },
+                {
+                  "Name": "VerticalAlignment",
+                  "Value": "Stretch"
+                },
+                {
+                  "Name": "ToolTip",
+                  "Value": "null"
+                },
+                {
+                  "Name": "ContextMenu",
+                  "Value": "null"
+                },
+                {
+                  "Name": "Visibility",
+                  "Value": "Visible"
+                }
+              ],
+              "Children": [
+                {
+                  "Name": "TextBlock",
+                  "Properties": [
+                    {
+                      "Name": "Text",
+                      "Value": ""
+                    },
+                    {
+                      "Name": "Padding",
+                      "Value": "0,0,0,0"
+                    },
+                    {
+                      "Name": "TextAlignment",
+                      "Value": "Left"
+                    },
+                    {
+                      "Name": "DataContext",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "Name",
+                      "Value": "ErrorTextBlock"
+                    },
+                    {
+                      "Name": "Margin",
+                      "Value": "0,0,0,0"
+                    },
+                    {
+                      "Name": "HorizontalAlignment",
+                      "Value": "Stretch"
+                    },
+                    {
+                      "Name": "VerticalAlignment",
+                      "Value": "Stretch"
+                    },
+                    {
+                      "Name": "ToolTip",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "ContextMenu",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "Visibility",
+                      "Value": "Collapsed"
+                    }
+                  ],
+                  "Children": []
+                },
+                {
+                  "Name": "MatrixView",
+                  "Properties": [
+                    {
+                      "Name": "Content",
+                      "Value": "System.Windows.Controls.Grid"
+                    },
+                    {
+                      "Name": "ContentTemplate",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "Padding",
+                      "Value": "0,0,0,0"
+                    },
+                    {
+                      "Name": "DataContext",
+                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                    },
+                    {
+                      "Name": "Name",
+                      "Value": "VariableGrid"
+                    },
+                    {
+                      "Name": "Margin",
+                      "Value": "0,0,0,0"
+                    },
+                    {
+                      "Name": "HorizontalAlignment",
+                      "Value": "Stretch"
+                    },
+                    {
+                      "Name": "VerticalAlignment",
+                      "Value": "Stretch"
+                    },
+                    {
+                      "Name": "ToolTip",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "ContextMenu",
+                      "Value": "null"
+                    },
+                    {
+                      "Name": "Visibility",
+                      "Value": "Visible"
+                    }
+                  ],
+                  "Children": [
+                    {
+                      "Name": "ContentPresenter",
+                      "Properties": [
+                        {
+                          "Name": "Content",
+                          "Value": "System.Windows.Controls.Grid"
+                        },
+                        {
+                          "Name": "ContentTemplate",
+                          "Value": "null"
+                        },
+                        {
+                          "Name": "DataContext",
+                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                        },
+                        {
+                          "Name": "Name",
+                          "Value": ""
+                        },
+                        {
+                          "Name": "Margin",
+                          "Value": "0,0,0,0"
+                        },
+                        {
+                          "Name": "HorizontalAlignment",
+                          "Value": "Stretch"
+                        },
+                        {
+                          "Name": "VerticalAlignment",
+                          "Value": "Stretch"
+                        },
+                        {
+                          "Name": "ToolTip",
+                          "Value": "null"
+                        },
+                        {
+                          "Name": "ContextMenu",
+                          "Value": "null"
+                        },
+                        {
+                          "Name": "Visibility",
+                          "Value": "Visible"
+                        }
+                      ],
+                      "Children": [
+                        {
+                          "Name": "Grid",
+                          "Properties": [
+                            {
+                              "Name": "DataContext",
+                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                            },
+                            {
+                              "Name": "Name",
+                              "Value": ""
+                            },
+                            {
+                              "Name": "Margin",
+                              "Value": "0,0,0,0"
+                            },
+                            {
+                              "Name": "HorizontalAlignment",
+                              "Value": "Stretch"
+                            },
+                            {
+                              "Name": "VerticalAlignment",
+                              "Value": "Stretch"
+                            },
+                            {
+                              "Name": "ToolTip",
+                              "Value": "null"
+                            },
+                            {
+                              "Name": "ContextMenu",
+                              "Value": "null"
+                            },
+                            {
+                              "Name": "Visibility",
+                              "Value": "Visible"
+                            }
+                          ],
+                          "Children": [
+                            {
+                              "Name": "Border",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": []
+                            },
+                            {
+                              "Name": "VisualGrid",
+                              "Properties": [
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": [
+                                {
+                                  "Name": "GridLineVisual",
+                                  "Properties": [],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "HeaderTextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[,1]"
+                                    }
+                                  ],
+                                  "Children": []
+                                }
+                              ]
+                            },
+                            {
+                              "Name": "Border",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": []
+                            },
+                            {
+                              "Name": "VisualGrid",
+                              "Properties": [
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": [
+                                {
+                                  "Name": "GridLineVisual",
+                                  "Properties": [],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[1,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[2,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[3,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[4,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[5,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[6,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[7,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[8,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[9,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "[10,]"
+                                    }
+                                  ],
+                                  "Children": []
+                                }
+                              ]
+                            },
+                            {
+                              "Name": "VisualGrid",
+                              "Properties": [
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": [
+                                {
+                                  "Name": "GridLineVisual",
+                                  "Properties": [],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "1"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "2"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "3"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "4"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "5"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "6"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "7"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "8"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "9"
+                                    }
+                                  ],
+                                  "Children": []
+                                },
+                                {
+                                  "Name": "TextVisual",
+                                  "Properties": [
+                                    {
+                                      "Name": "Text",
+                                      "Value": "10"
+                                    }
+                                  ],
+                                  "Children": []
+                                }
+                              ]
+                            },
+                            {
+                              "Name": "ScrollBar",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": [
+                                {
+                                  "Name": "Grid",
+                                  "Properties": [
+                                    {
+                                      "Name": "DataContext",
+                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                    },
+                                    {
+                                      "Name": "Name",
+                                      "Value": "Bg"
+                                    },
+                                    {
+                                      "Name": "Margin",
+                                      "Value": "0,0,0,0"
+                                    },
+                                    {
+                                      "Name": "HorizontalAlignment",
+                                      "Value": "Stretch"
+                                    },
+                                    {
+                                      "Name": "VerticalAlignment",
+                                      "Value": "Stretch"
+                                    },
+                                    {
+                                      "Name": "ToolTip",
+                                      "Value": "null"
+                                    },
+                                    {
+                                      "Name": "ContextMenu",
+                                      "Value": "null"
+                                    },
+                                    {
+                                      "Name": "Visibility",
+                                      "Value": "Visible"
+                                    }
+                                  ],
+                                  "Children": [
+                                    {
+                                      "Name": "Border",
+                                      "Properties": [
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": ""
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": []
+                                    },
+                                    {
+                                      "Name": "RepeatButton",
+                                      "Properties": [
+                                        {
+                                          "Name": "Content",
+                                          "Value": "System.Windows.Shapes.Path"
+                                        },
+                                        {
+                                          "Name": "ContentTemplate",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "1,1,1,1"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_LineUpButton"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "Border",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": "border"
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "ContentPresenter",
+                                              "Properties": [
+                                                {
+                                                  "Name": "Content",
+                                                  "Value": "System.Windows.Shapes.Path"
+                                                },
+                                                {
+                                                  "Name": "ContentTemplate",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "contentPresenter"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "1,1,1,1"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": [
+                                                {
+                                                  "Name": "Path",
+                                                  "Properties": [
+                                                    {
+                                                      "Name": "Data",
+                                                      "Value": "M0,4C0,4 0,6 0,6 0,6 3.5,2.5 3.5,2.5 3.5,2.5 7,6 7,6 7,6 7,4 7,4 7,4 3.5,0.5 3.5,0.5 3.5,0.5 0,4 0,4z"
+                                                    },
+                                                    {
+                                                      "Name": "DataContext",
+                                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                    },
+                                                    {
+                                                      "Name": "Name",
+                                                      "Value": "ArrowTop"
+                                                    },
+                                                    {
+                                                      "Name": "Margin",
+                                                      "Value": "3,4,3,3"
+                                                    },
+                                                    {
+                                                      "Name": "HorizontalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "VerticalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "ToolTip",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "ContextMenu",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "Visibility",
+                                                      "Value": "Visible"
+                                                    }
+                                                  ],
+                                                  "Children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Name": "Track",
+                                      "Properties": [
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_Track"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Hidden"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "RepeatButton",
+                                          "Properties": [
+                                            {
+                                              "Name": "Content",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContentTemplate",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": ""
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Name": "RepeatButton",
+                                          "Properties": [
+                                            {
+                                              "Name": "Content",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContentTemplate",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": ""
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Name": "Thumb",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "rectangle"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Name": "RepeatButton",
+                                      "Properties": [
+                                        {
+                                          "Name": "Content",
+                                          "Value": "System.Windows.Shapes.Path"
+                                        },
+                                        {
+                                          "Name": "ContentTemplate",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "1,1,1,1"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_LineDownButton"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "Border",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": "border"
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "ContentPresenter",
+                                              "Properties": [
+                                                {
+                                                  "Name": "Content",
+                                                  "Value": "System.Windows.Shapes.Path"
+                                                },
+                                                {
+                                                  "Name": "ContentTemplate",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "contentPresenter"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "1,1,1,1"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": [
+                                                {
+                                                  "Name": "Path",
+                                                  "Properties": [
+                                                    {
+                                                      "Name": "Data",
+                                                      "Value": "M0,2.5C0,2.5 0,0.5 0,0.5 0,0.5 3.5,4 3.5,4 3.5,4 7,0.5 7,0.5 7,0.5 7,2.5 7,2.5 7,2.5 3.5,6 3.5,6 3.5,6 0,2.5 0,2.5z"
+                                                    },
+                                                    {
+                                                      "Name": "DataContext",
+                                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                    },
+                                                    {
+                                                      "Name": "Name",
+                                                      "Value": "ArrowBottom"
+                                                    },
+                                                    {
+                                                      "Name": "Margin",
+                                                      "Value": "3,4,3,3"
+                                                    },
+                                                    {
+                                                      "Name": "HorizontalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "VerticalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "ToolTip",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "ContextMenu",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "Visibility",
+                                                      "Value": "Visible"
+                                                    }
+                                                  ],
+                                                  "Children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Name": "Border",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": []
+                            },
+                            {
+                              "Name": "ScrollBar",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": [
+                                {
+                                  "Name": "Grid",
+                                  "Properties": [
+                                    {
+                                      "Name": "DataContext",
+                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                    },
+                                    {
+                                      "Name": "Name",
+                                      "Value": "Bg"
+                                    },
+                                    {
+                                      "Name": "Margin",
+                                      "Value": "0,0,0,0"
+                                    },
+                                    {
+                                      "Name": "HorizontalAlignment",
+                                      "Value": "Stretch"
+                                    },
+                                    {
+                                      "Name": "VerticalAlignment",
+                                      "Value": "Stretch"
+                                    },
+                                    {
+                                      "Name": "ToolTip",
+                                      "Value": "null"
+                                    },
+                                    {
+                                      "Name": "ContextMenu",
+                                      "Value": "null"
+                                    },
+                                    {
+                                      "Name": "Visibility",
+                                      "Value": "Visible"
+                                    }
+                                  ],
+                                  "Children": [
+                                    {
+                                      "Name": "Border",
+                                      "Properties": [
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": ""
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": []
+                                    },
+                                    {
+                                      "Name": "RepeatButton",
+                                      "Properties": [
+                                        {
+                                          "Name": "Content",
+                                          "Value": "System.Windows.Shapes.Path"
+                                        },
+                                        {
+                                          "Name": "ContentTemplate",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "1,1,1,1"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_LineLeftButton"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "Border",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": "border"
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "ContentPresenter",
+                                              "Properties": [
+                                                {
+                                                  "Name": "Content",
+                                                  "Value": "System.Windows.Shapes.Path"
+                                                },
+                                                {
+                                                  "Name": "ContentTemplate",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "contentPresenter"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "1,1,1,1"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": [
+                                                {
+                                                  "Name": "Path",
+                                                  "Properties": [
+                                                    {
+                                                      "Name": "Data",
+                                                      "Value": "M3.18,7C3.18,7 5,7 5,7 5,7 1.81,3.5 1.81,3.5 1.81,3.5 5,0 5,0 5,0 3.18,0 3.18,0 3.18,0 0,3.5 0,3.5 0,3.5 3.18,7 3.18,7z"
+                                                    },
+                                                    {
+                                                      "Name": "DataContext",
+                                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                    },
+                                                    {
+                                                      "Name": "Name",
+                                                      "Value": "ArrowLeft"
+                                                    },
+                                                    {
+                                                      "Name": "Margin",
+                                                      "Value": "3,3,3,3"
+                                                    },
+                                                    {
+                                                      "Name": "HorizontalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "VerticalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "ToolTip",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "ContextMenu",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "Visibility",
+                                                      "Value": "Visible"
+                                                    }
+                                                  ],
+                                                  "Children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Name": "Track",
+                                      "Properties": [
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_Track"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Hidden"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "RepeatButton",
+                                          "Properties": [
+                                            {
+                                              "Name": "Content",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContentTemplate",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": ""
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Name": "RepeatButton",
+                                          "Properties": [
+                                            {
+                                              "Name": "Content",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContentTemplate",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": ""
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Name": "Thumb",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": ""
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "Rectangle",
+                                              "Properties": [
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "rectangle"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "0,0,0,0"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Stretch"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": []
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Name": "RepeatButton",
+                                      "Properties": [
+                                        {
+                                          "Name": "Content",
+                                          "Value": "System.Windows.Shapes.Path"
+                                        },
+                                        {
+                                          "Name": "ContentTemplate",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Padding",
+                                          "Value": "1,1,1,1"
+                                        },
+                                        {
+                                          "Name": "DataContext",
+                                          "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                        },
+                                        {
+                                          "Name": "Name",
+                                          "Value": "PART_LineRightButton"
+                                        },
+                                        {
+                                          "Name": "Margin",
+                                          "Value": "0,0,0,0"
+                                        },
+                                        {
+                                          "Name": "HorizontalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "VerticalAlignment",
+                                          "Value": "Stretch"
+                                        },
+                                        {
+                                          "Name": "ToolTip",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "ContextMenu",
+                                          "Value": "null"
+                                        },
+                                        {
+                                          "Name": "Visibility",
+                                          "Value": "Visible"
+                                        }
+                                      ],
+                                      "Children": [
+                                        {
+                                          "Name": "Border",
+                                          "Properties": [
+                                            {
+                                              "Name": "Padding",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "DataContext",
+                                              "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                            },
+                                            {
+                                              "Name": "Name",
+                                              "Value": "border"
+                                            },
+                                            {
+                                              "Name": "Margin",
+                                              "Value": "0,0,0,0"
+                                            },
+                                            {
+                                              "Name": "HorizontalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "VerticalAlignment",
+                                              "Value": "Stretch"
+                                            },
+                                            {
+                                              "Name": "ToolTip",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "ContextMenu",
+                                              "Value": "null"
+                                            },
+                                            {
+                                              "Name": "Visibility",
+                                              "Value": "Visible"
+                                            }
+                                          ],
+                                          "Children": [
+                                            {
+                                              "Name": "ContentPresenter",
+                                              "Properties": [
+                                                {
+                                                  "Name": "Content",
+                                                  "Value": "System.Windows.Shapes.Path"
+                                                },
+                                                {
+                                                  "Name": "ContentTemplate",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "DataContext",
+                                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                },
+                                                {
+                                                  "Name": "Name",
+                                                  "Value": "contentPresenter"
+                                                },
+                                                {
+                                                  "Name": "Margin",
+                                                  "Value": "1,1,1,1"
+                                                },
+                                                {
+                                                  "Name": "HorizontalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "VerticalAlignment",
+                                                  "Value": "Center"
+                                                },
+                                                {
+                                                  "Name": "ToolTip",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "ContextMenu",
+                                                  "Value": "null"
+                                                },
+                                                {
+                                                  "Name": "Visibility",
+                                                  "Value": "Visible"
+                                                }
+                                              ],
+                                              "Children": [
+                                                {
+                                                  "Name": "Path",
+                                                  "Properties": [
+                                                    {
+                                                      "Name": "Data",
+                                                      "Value": "M1.81,7C1.81,7 0,7 0,7 0,7 3.18,3.5 3.18,3.5 3.18,3.5 0,0 0,0 0,0 1.81,0 1.81,0 1.81,0 5,3.5 5,3.5 5,3.5 1.81,7 1.81,7z"
+                                                    },
+                                                    {
+                                                      "Name": "DataContext",
+                                                      "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                                    },
+                                                    {
+                                                      "Name": "Name",
+                                                      "Value": "ArrowRight"
+                                                    },
+                                                    {
+                                                      "Name": "Margin",
+                                                      "Value": "3,3,3,3"
+                                                    },
+                                                    {
+                                                      "Name": "HorizontalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "VerticalAlignment",
+                                                      "Value": "Stretch"
+                                                    },
+                                                    {
+                                                      "Name": "ToolTip",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "ContextMenu",
+                                                      "Value": "null"
+                                                    },
+                                                    {
+                                                      "Name": "Visibility",
+                                                      "Value": "Visible"
+                                                    }
+                                                  ],
+                                                  "Children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Name": "Border",
+                              "Properties": [
+                                {
+                                  "Name": "Padding",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "DataContext",
+                                  "Value": "Microsoft.VisualStudio.R.Package.DataInspect.MatrixView"
+                                },
+                                {
+                                  "Name": "Name",
+                                  "Value": ""
+                                },
+                                {
+                                  "Name": "Margin",
+                                  "Value": "0,0,0,0"
+                                },
+                                {
+                                  "Name": "HorizontalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "VerticalAlignment",
+                                  "Value": "Stretch"
+                                },
+                                {
+                                  "Name": "ToolTip",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "ContextMenu",
+                                  "Value": "null"
+                                },
+                                {
+                                  "Name": "Visibility",
+                                  "Value": "Visible"
+                                }
+                              ],
+                              "Children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Package/TestApp/Files/VariableGridSnapshot.tree
+++ b/src/Package/TestApp/Files/VariableGridSnapshot.tree
@@ -440,7 +440,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,1]"
+                                      "Value": "V1"
                                     }
                                   ],
                                   "Children": []
@@ -536,7 +536,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[1,]"
+                                      "Value": "1"
                                     }
                                   ],
                                   "Children": []
@@ -546,7 +546,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[2,]"
+                                      "Value": "2"
                                     }
                                   ],
                                   "Children": []
@@ -556,7 +556,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[3,]"
+                                      "Value": "3"
                                     }
                                   ],
                                   "Children": []
@@ -566,7 +566,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[4,]"
+                                      "Value": "4"
                                     }
                                   ],
                                   "Children": []
@@ -576,7 +576,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[5,]"
+                                      "Value": "5"
                                     }
                                   ],
                                   "Children": []
@@ -586,7 +586,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[6,]"
+                                      "Value": "6"
                                     }
                                   ],
                                   "Children": []
@@ -596,7 +596,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[7,]"
+                                      "Value": "7"
                                     }
                                   ],
                                   "Children": []
@@ -606,7 +606,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[8,]"
+                                      "Value": "8"
                                     }
                                   ],
                                   "Children": []
@@ -616,7 +616,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[9,]"
+                                      "Value": "9"
                                     }
                                   ],
                                   "Children": []
@@ -626,7 +626,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[10,]"
+                                      "Value": "10"
                                     }
                                   ],
                                   "Children": []

--- a/src/Package/TestApp/Files/VariableGridSorted01.tree
+++ b/src/Package/TestApp/Files/VariableGridSorted01.tree
@@ -440,7 +440,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,1]"
+                                      "Value": "V1"
                                     }
                                   ],
                                   "Children": []
@@ -450,7 +450,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,2]"
+                                      "Value": "V2"
                                     }
                                   ],
                                   "Children": []
@@ -460,7 +460,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,3]"
+                                      "Value": "V3"
                                     }
                                   ],
                                   "Children": []
@@ -470,7 +470,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,4]"
+                                      "Value": "V4"
                                     }
                                   ],
                                   "Children": []
@@ -480,7 +480,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[,5]"
+                                      "Value": "V5"
                                     }
                                   ],
                                   "Children": []
@@ -576,7 +576,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[1,]"
+                                      "Value": "2"
                                     }
                                   ],
                                   "Children": []
@@ -586,7 +586,7 @@
                                   "Properties": [
                                     {
                                       "Name": "Text",
-                                      "Value": "[2,]"
+                                      "Value": "1"
                                     }
                                   ],
                                   "Children": []

--- a/src/Package/TestApp/Microsoft.VisualStudio.R.Interactive.Test.csproj
+++ b/src/Package/TestApp/Microsoft.VisualStudio.R.Interactive.Test.csproj
@@ -56,6 +56,8 @@
     <None Include="Files\VariableExplorer04.tree" />
     <None Include="Files\VariableGrid02.tree" />
     <AppDesigner Include="Properties\" />
+    <None Include="Files\VariableGridDynamic.tree" />
+    <None Include="Files\VariableGridSnapshot.tree" />
     <None Include="Files\VariableGridSorted01.tree" />
     <None Include="Files\VariableGridSorted02.tree" />
     <None Include="project.json" />

--- a/src/Package/TestApp/Utility/ViewTreeDump.cs
+++ b/src/Package/TestApp/Utility/ViewTreeDump.cs
@@ -19,11 +19,10 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Utility {
         }
 
         private static void CompareVisualTreesImplementation(DeployFilesFixture fixture, VisualTreeObject actual, string fileName) {
-            string testFileName = fileName + ".tree";
-            string testFilePath = fixture.GetDestinationPath(testFileName);
+            var testFileName = fileName + ".tree";
 
             var serializedActual = SerializeVisualTree(actual);
-            string baselineFilePath = fixture.GetSourcePath(testFileName);
+            var baselineFilePath = fixture.GetSourcePath(testFileName);
             if (_regenerateBaselineFiles) {
                 TestFiles.UpdateBaseline(baselineFilePath, serializedActual);
             } else {
@@ -33,8 +32,7 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Utility {
 
 
         private static string SerializeVisualTree(VisualTreeObject o) {
-            var serializer = new JsonSerializer();
-            serializer.Culture = CultureInfo.InvariantCulture;
+            var serializer = new JsonSerializer {Culture = CultureInfo.InvariantCulture};
             using (var sw = new StringWriter(CultureInfo.InvariantCulture)) {
                 using (var writer = new JsonTextWriter(sw)) {
                     writer.Culture = CultureInfo.InvariantCulture;

--- a/src/Package/TestApp/Utility/ViewTreeDump.cs
+++ b/src/Package/TestApp/Utility/ViewTreeDump.cs
@@ -15,10 +15,6 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Utility {
         private static bool _regenerateBaselineFiles = false;
 
         public static void CompareVisualTrees(DeployFilesFixture fixture, VisualTreeObject actual, string fileName) {
-            CompareVisualTreesImplementation(fixture, actual, fileName);
-        }
-
-        private static void CompareVisualTreesImplementation(DeployFilesFixture fixture, VisualTreeObject actual, string fileName) {
             var testFileName = fileName + ".tree";
 
             var serializedActual = SerializeVisualTree(actual);
@@ -32,7 +28,7 @@ namespace Microsoft.VisualStudio.R.Interactive.Test.Utility {
 
 
         private static string SerializeVisualTree(VisualTreeObject o) {
-            var serializer = new JsonSerializer {Culture = CultureInfo.InvariantCulture};
+            var serializer = new JsonSerializer { Culture = CultureInfo.InvariantCulture };
             using (var sw = new StringWriter(CultureInfo.InvariantCulture)) {
                 using (var writer = new JsonTextWriter(sw)) {
                     writer.Culture = CultureInfo.InvariantCulture;

--- a/src/R/Components/Impl/Settings/IRSettings.cs
+++ b/src/R/Components/Impl/Settings/IRSettings.cs
@@ -110,5 +110,17 @@ namespace Microsoft.R.Components.Settings {
         /// (CPU/Memory/Network load display).
         /// </summary>
         bool ShowHostLoadMeter { get; set; }
+
+        /// <summary>
+        /// Controls evaluation of the expression in the grid viewer.
+        /// </summary>
+        /// <remarks>
+        /// By default View(x) takes snapshot of data as a data frame. This may consume subtantial 
+        /// amount of memory with large data sets. With dynamic evaluation the expression is evaluated
+        /// every time grid refreshes in order to only fetch part of the data for display. However, if 
+        /// the variable changes the data in the grid will also change. This mode may be unsuitable 
+        /// for dplyr pipe expressions.
+        /// </remarks>
+        bool GridDynamicEvaluation { get; set; }
     }
 }

--- a/src/R/Editor/Impl/Completions/Providers/KeywordCompletionProvider.cs
+++ b/src/R/Editor/Impl/Completions/Providers/KeywordCompletionProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.R.Editor.Completions.Providers {
 
         public IReadOnlyCollection<ICompletionEntry> GetEntries(IRIntellisenseContext context) {
             var completions = new List<ICompletionEntry>();
-            if (!context.IsCaretInNameSpace()) {
+            if (!context.IsCaretInNamespace()) {
                 var infoSource = _snippetInformationSource?.InformationSource;
                 var keyWordGlyph = _imageService.GetImage(ImageType.Keyword);
 

--- a/src/R/Editor/Impl/Completions/Providers/PackageFunctionCompletionProvider.cs
+++ b/src/R/Editor/Impl/Completions/Providers/PackageFunctionCompletionProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.R.Editor.Completions.Providers {
 
                 foreach (var function in functions) {
                     // Snippets are suppressed if user typed namespace
-                    if (!context.IsCaretInNameSpace() && infoSource != null) {
+                    if (!context.IsCaretInNamespace() && infoSource != null) {
                         if (infoSource.IsSnippet(function.Name)) {
                             continue;
                         }
@@ -83,7 +83,7 @@ namespace Microsoft.R.Editor.Completions.Providers {
         #endregion
 
         private IEnumerable<IPackageInfo> GetPackages(IRIntellisenseContext context) {
-            if (context.IsCaretInNameSpace()) {
+            if (context.IsCaretInNamespace()) {
                 return GetSpecificPackage(context);
             }
 

--- a/src/R/Editor/Impl/Completions/Providers/SnippetCompletionProvider.cs
+++ b/src/R/Editor/Impl/Completions/Providers/SnippetCompletionProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.R.Editor.Completions.Providers {
 
         public IReadOnlyCollection<ICompletionEntry> GetEntries(IRIntellisenseContext context) {
             var completions = new List<ICompletionEntry>();
-            if (_snippetInformationSource?.InformationSource != null && !context.IsCaretInNameSpace()) {
+            if (_snippetInformationSource?.InformationSource != null && !context.IsCaretInNamespace()) {
                 foreach (ISnippetInfo info in _snippetInformationSource.InformationSource.Snippets) {
                     completions.Add(new EditorCompletionEntry(info.Name, info.Name, info.Description, _snippetGlyph));
                 }

--- a/src/R/Editor/Impl/Completions/RCompletionContextExtensions.cs
+++ b/src/R/Editor/Impl/Completions/RCompletionContextExtensions.cs
@@ -11,25 +11,11 @@ namespace Microsoft.R.Editor.Completions {
     /// caret position and other necessary data for the completion engine.
     /// </summary>
     public static class RCompletionContextExtensions {
-        public static bool IsCaretInNameSpace(this IRIntellisenseContext context)
-            => context.Session.View.IsCaretInNamespace(context.EditorBuffer);
+        public static bool IsCaretInNamespace(this IRIntellisenseContext context)
+            => context.Session.View.IsCaretInNamespace();
 
-        public static bool IsCaretInNamespace(this IEditorView view, IEditorBuffer editorBuffer = null) {
-            editorBuffer = editorBuffer ?? view.EditorBuffer;
-            var bufferPosition = view.GetCaretPosition(editorBuffer);
-            if (bufferPosition != null) {
-                return bufferPosition.Snapshot.IsPositionInNamespace(bufferPosition.Position);
-            }
-            return false;
-        }
-
-        public static bool IsCaretInNamespace(this IRIntellisenseContext context, IEditorView view) {
-            var bufferPosition = context.Session.View.GetCaretPosition(context.EditorBuffer);
-            if (bufferPosition != null) {
-                return bufferPosition.Snapshot.IsPositionInNamespace(bufferPosition.Position);
-            }
-            return false;
-        }
+        public static bool IsCaretInNamespace(this IEditorView view)
+            => view.EditorBuffer.CurrentSnapshot.IsPositionInNamespace(view.Caret.Position.Position);
 
         public static bool IsPositionInNamespace(this IEditorBufferSnapshot snapshot, int position) {
             if (position > 0) {
@@ -42,56 +28,52 @@ namespace Microsoft.R.Editor.Completions {
         }
 
         public static bool IsCaretInLibraryStatement(this IRIntellisenseContext context)
-            => context.Session.View.IsCaretInLibraryStatement(context.EditorBuffer);
+            => context.Session.View.IsCaretInLibraryStatement();
 
-        public static bool IsCaretInLibraryStatement(this IEditorView view, IEditorBuffer editorBuffer = null) {
+        public static bool IsCaretInLibraryStatement(this IEditorView view) {
             try {
-                editorBuffer = editorBuffer ?? view.EditorBuffer;
-                var bufferPosition = view.GetCaretPosition(editorBuffer);
-                if (bufferPosition != null) {
-                    var snapshot = bufferPosition.Snapshot;
-                    int caretPosition = bufferPosition.Position;
-                    var line = snapshot.GetLineFromPosition(caretPosition);
+                var caretPosition = view.Caret.Position.Position;
+                var snapshot = view.EditorBuffer.CurrentSnapshot;
+                var line = snapshot.GetLineFromPosition(caretPosition);
 
-                    if (line.Length < 8 || caretPosition < line.Start + 8 || snapshot[caretPosition - 1] != '(') {
-                        return false;
+                if (line.Length < 8 || caretPosition < line.Start + 8 || snapshot[caretPosition - 1] != '(') {
+                    return false;
+                }
+
+                int start = -1;
+                int end = -1;
+
+                for (int i = caretPosition - 2; i >= 0; i--) {
+                    if (!char.IsWhiteSpace(snapshot[i])) {
+                        end = i + 1;
+                        break;
                     }
+                }
 
-                    int start = -1;
-                    int end = -1;
+                if (end <= 0) {
+                    return false;
+                }
 
-                    for (int i = caretPosition - 2; i >= 0; i--) {
-                        if (!char.IsWhiteSpace(snapshot[i])) {
-                            end = i + 1;
-                            break;
-                        }
+                for (int i = end - 1; i >= 0; i--) {
+                    if (char.IsWhiteSpace(snapshot[i])) {
+                        start = i + 1;
+                        break;
+                    } else if (i == 0) {
+                        start = 0;
+                        break;
                     }
+                }
 
-                    if (end <= 0) {
-                        return false;
-                    }
+                if (start < 0 || end <= start) {
+                    return false;
+                }
 
-                    for (int i = end - 1; i >= 0; i--) {
-                        if (char.IsWhiteSpace(snapshot[i])) {
-                            start = i + 1;
-                            break;
-                        } else if (i == 0) {
-                            start = 0;
-                            break;
-                        }
-                    }
+                start -= line.Start;
+                end -= line.Start;
 
-                    if (start < 0 || end <= start) {
-                        return false;
-                    }
-
-                    start -= line.Start;
-                    end -= line.Start;
-
-                    string s = line.GetText().Substring(start, end - start);
-                    if (s == "library" || s == "require") {
-                        return true;
-                    }
+                string s = line.GetText().Substring(start, end - start);
+                if (s == "library" || s == "require") {
+                    return true;
                 }
             } catch (ArgumentException) { }
 

--- a/src/R/Editor/Impl/Completions/RCompletionEngine.cs
+++ b/src/R/Editor/Impl/Completions/RCompletionEngine.cs
@@ -115,12 +115,12 @@ namespace Microsoft.R.Editor.Completions.Engine {
                 providers.Add(new UserVariablesCompletionProvider(_imageService));
                 providers.Add(new SnippetCompletionProvider(_services));
 
-                if (!context.IsCaretInNameSpace()) {
+                if (!context.IsCaretInNamespace()) {
                     providers.Add(new PackagesCompletionProvider(packageIndex, _imageService));
                 }
             }
 
-            if (!context.IsCaretInNameSpace()) {
+            if (!context.IsCaretInNamespace()) {
                 providers.Add(new WorkspaceVariableCompletionProvider(variablesProvider, _imageService));
             }
 

--- a/src/R/Editor/Impl/Data/IRSessionDataObject.cs
+++ b/src/R/Editor/Impl/Data/IRSessionDataObject.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.R.DataInspection;
 
 namespace Microsoft.R.Editor.Data {
     public interface IRSessionDataObject {
@@ -23,5 +24,7 @@ namespace Microsoft.R.Editor.Data {
         string Expression { get; }
 
         Task<IReadOnlyList<IRSessionDataObject>> GetChildrenAsync();
+
+        IREvaluationResultInfo DebugEvaluation { get; }
     }
 }

--- a/src/R/Editor/Impl/Data/RSessionDataObject.cs
+++ b/src/R/Editor/Impl/Data/RSessionDataObject.cs
@@ -108,7 +108,7 @@ namespace Microsoft.R.Editor.Data {
             await TaskUtilities.SwitchToBackgroundThread();
             try {
                 if (valueEvaluation.HasChildren) {
-                    REvaluationResultProperties properties =
+                    var properties =
                         ExpressionProperty |
                         AccessorKindProperty |
                         TypeNameProperty |
@@ -129,7 +129,7 @@ namespace Microsoft.R.Editor.Data {
 
         protected virtual List<IRSessionDataObject> EvaluateChildren(IReadOnlyList<IREvaluationResultInfo> children) {
             var result = new List<IRSessionDataObject>();
-            for (int i = 0; i < children.Count; i++) {
+            for (var i = 0; i < children.Count; i++) {
                 result.Add(new RSessionDataObject(children[i], _evaluateActiveBindings, GetMaxChildrenCount(children[i])));
             }
             return result;
@@ -149,12 +149,12 @@ namespace Microsoft.R.Editor.Data {
         private string GetValue(IRValueInfo v) {
             var value = v.Representation;
             if (value != null) {
-                Match match = Regex.Match(value, DataFramePrefix);
+                var match = Regex.Match(value, DataFramePrefix);
                 if (match.Success) {
                     return match.Groups[1].Value.Trim();
                 }
             }
-            return value != null ? value.ConvertCharacterCodes() : value;
+            return value?.ConvertCharacterCodes();
         }
 
         #region IRSessionDataObject
@@ -171,15 +171,10 @@ namespace Microsoft.R.Editor.Data {
 
         public IReadOnlyList<long> Dimensions { get; protected set; }
 
-        public bool IsHidden {
-            get { return Name.StartsWithOrdinal(HiddenVariablePrefix); }
-        }
+        public bool IsHidden => Name.StartsWithOrdinal(HiddenVariablePrefix);
 
-        public string Expression {
-            get {
-                return DebugEvaluation.Expression;
-            }
-        }
+        public string Expression => DebugEvaluation.Expression;
+
         #endregion
     }
 }

--- a/src/Windows/Host/Client/Impl/project.json
+++ b/src/Windows/Host/Client/Impl/project.json
@@ -5,7 +5,7 @@
     "Microsoft.Win32.Primitives": "4.3.0",
     "Newtonsoft.Json": "9.0.1",
     "System.IO.Compression": "4.3.0",
-    "System.Net.Http.WinHttpHandler": "4.4.0",
+    "System.Net.Http.WinHttpHandler": "4.3.0",
     "System.Threading.Tasks.Dataflow": "4.5.24"
   },
   "frameworks": {

--- a/src/Windows/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
+++ b/src/Windows/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveEvaluator.cs
@@ -85,7 +85,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
         private async Task<ExecutionResult> InitializeAsync(bool isResetting) {
             try {
                 if (!Session.IsHostRunning) {
-                    var startupInfo = new RHostStartupInfo(_settings.CranMirror, null, _settings.RCodePage, _terminalWidth, !isResetting, true, true);
+                    var startupInfo = new RHostStartupInfo(_settings.CranMirror, null, _settings.RCodePage, _terminalWidth, !isResetting, true, true, _settings.GridDynamicEvaluation);
                     await Session.EnsureHostStartedAsync(startupInfo, new RSessionCallback(CurrentWindow, Session, _settings, _coreShell, _fs));
                 }
                 return ExecutionResult.Success;

--- a/src/Windows/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
+++ b/src/Windows/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
@@ -160,6 +160,8 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
                 SetMirrorToSession().DoNotWait();
             } else if (e.PropertyName == nameof(IRSettings.RCodePage)) {
                 SetSessionCodePage().DoNotWait();
+            } else if (e.PropertyName == nameof(IRSettings.GridDynamicEvaluation)) {
+                SetGridEvalMode().DoNotWait();
             }
         }
 
@@ -182,6 +184,12 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
                     await s.SetCodePageAsync(cp);
                 } catch (OperationCanceledException) { }
             }
+        }
+
+        private async Task SetGridEvalMode() {
+            try {
+                await RSession.SetGridEvalModeAsync(_settings.GridDynamicEvaluation);
+            } catch (OperationCanceledException) { }
         }
     }
 }

--- a/src/Windows/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
+++ b/src/Windows/R/Components/Impl/InteractiveWorkflow/Implementation/RInteractiveWorkflow.cs
@@ -161,7 +161,7 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             } else if (e.PropertyName == nameof(IRSettings.RCodePage)) {
                 SetSessionCodePage().DoNotWait();
             } else if (e.PropertyName == nameof(IRSettings.GridDynamicEvaluation)) {
-                SetGridEvalMode().DoNotWait();
+                RSession.SetGridEvalModeAsync(_settings.GridDynamicEvaluation).DoNotWait();
             }
         }
 
@@ -182,14 +182,8 @@ namespace Microsoft.R.Components.InteractiveWorkflow.Implementation {
             foreach (var s in RSessions.GetSessions()) {
                 try {
                     await s.SetCodePageAsync(cp);
-                } catch (OperationCanceledException) { }
+                } catch (RException) { } catch (OperationCanceledException) { }
             }
-        }
-
-        private async Task SetGridEvalMode() {
-            try {
-                await RSession.SetGridEvalModeAsync(_settings.GridDynamicEvaluation);
-            } catch (OperationCanceledException) { }
         }
     }
 }

--- a/src/Windows/R/Components/Impl/Settings/Mirrors/CranMirrorList.cs
+++ b/src/Windows/R/Components/Impl/Settings/Mirrors/CranMirrorList.cs
@@ -26,23 +26,17 @@ namespace Microsoft.R.Components.Settings.Mirrors {
         /// <summary>
         /// Returns list of mirror names such as [Cloud 0] or 'Brazil'
         /// </summary>
-        public static string[] MirrorNames {
-            get { return _mirrors.Select(m => m.Name).ToArray(); }
-        }
+        public static string[] MirrorNames => _mirrors.Select(m => m.Name).ToArray();
 
         /// <summary>
         /// Retrieves list of CRAN mirror URLs
         /// </summary>
-        public static string[] MirrorUrls {
-            get { return _mirrors.Select(m => m.Url).ToArray(); }
-        }
+        public static string[] MirrorUrls => _mirrors.Select(m => m.Url).ToArray();
 
         /// <summary>
         /// Given CRAN mirror name returns its URL.
         /// </summary>
-        public static string UrlFromName(string name) {
-            return _mirrors.FirstOrDefault((x) => x.Name.EqualsIgnoreCase(name))?.Url;
-        }
+        public static string UrlFromName(string name) => _mirrors.FirstOrDefault((x) => x.Name.EqualsIgnoreCase(name))?.Url;
 
         /// <summary>
         /// Initiates download of the CRAN mirror list
@@ -50,9 +44,7 @@ namespace Microsoft.R.Components.Settings.Mirrors {
         /// </summary>
         public static void Download() {
             if (_mirrors.Length > 0) {
-                if (DownloadComplete != null) {
-                    DownloadComplete(null, EventArgs.Empty);
-                }
+                DownloadComplete?.Invoke(null, EventArgs.Empty);
                 return;
             }
 
@@ -106,9 +98,7 @@ namespace Microsoft.R.Components.Settings.Mirrors {
                 ReadCsv(content);
             }
 
-            if(DownloadComplete != null) {
-                DownloadComplete(null, EventArgs.Empty);
-            }
+            DownloadComplete?.Invoke(null, EventArgs.Empty);
         }
 
         private static void ReadCsv(string content) {

--- a/src/Windows/R/Components/Test/Stubs/RSettingsStub.cs
+++ b/src/Windows/R/Components/Test/Stubs/RSettingsStub.cs
@@ -76,6 +76,8 @@ namespace Microsoft.R.Components.Test.Stubs {
         /// </summary>
         public bool ShowHostLoadMeter { get; set; }
 
+        public bool GridDynamicEvaluation { get; set; }
+
         public void Dispose() { }
 #pragma warning disable 67
         public event PropertyChangedEventHandler PropertyChanged;

--- a/src/Windows/R/Editor/Impl/Completions/RCompletionController.cs
+++ b/src/Windows/R/Editor/Impl/Completions/RCompletionController.cs
@@ -214,10 +214,10 @@ namespace Microsoft.R.Editor.Completions {
                         return true;
 
                     case ':':
-                        return TextView.ToEditorView().IsCaretInNamespace(_textBuffer.ToEditorBuffer());
+                        return TextView.ToEditorView().IsCaretInNamespace();
 
                     case '(':
-                        return TextView.ToEditorView().IsCaretInLibraryStatement(_textBuffer.ToEditorBuffer());
+                        return TextView.ToEditorView().IsCaretInLibraryStatement();
 
                     default:
                         if (_settings.ShowCompletionOnFirstChar) {

--- a/src/Windows/R/Editor/Test/Utility/TestRSettings.cs
+++ b/src/Windows/R/Editor/Test/Utility/TestRSettings.cs
@@ -133,6 +133,8 @@ namespace Microsoft.R.Editor.Test.Utility {
 
         public bool ShowHostLoadMeter { get; set; }
 
+        public bool GridDynamicEvaluation { get; set; }
+
         #region IRPersistentSettings
         public void LoadSettings() { }
         public Task SaveSettingsAsync() => Task.CompletedTask;


### PR DESCRIPTION
#3772 Sorting tibble data_frames in View pane results in NAs 
#3771 Can't View .Last.value 
- introduce *default* mode that takes snapshot of data as data frame (also discussed in #3231)

#3898 NRE in CreateToolWindow 

Other
- Remove PII data from telemetry
- small simplification in caret position determination (prevents exceptions when editing in REPL - they get caught but anyway)