### PR TITLE
Container manager bug fixes

### DIFF
--- a/src/Common/Core/Impl/Security/ISecurityService.cs
+++ b/src/Common/Core/Impl/Security/ISecurityService.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Security;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Common.Core.Security {
     public interface ISecurityService {
         Credentials GetUserCredentials(string authority, string workspaceName);
+        (string username, SecureString password) ReadUserCredentials(string authority);
         bool ValidateX509Certificate(X509Certificate certificate, string message);
+        void SaveUserCredentials(string authority, string userName, SecureString password, bool save);
         bool DeleteUserCredentials(string authority);
         void DeleteCredentials(string authority);
-        string GetUserName(string authority);
     }
 }

--- a/src/Common/Core/Impl/Threading/MainThreadExtensions.cs
+++ b/src/Common/Core/Impl/Threading/MainThreadExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Common.Core.Threading {
     public static class MainThreadExtensions {
@@ -28,6 +29,16 @@ namespace Microsoft.Common.Core.Threading {
             } else {
                 mainThread.Post(action, cancellationToken);
             }
+        }
+
+        public static async Task SendAsync(this IMainThread mainThread, Action action, CancellationToken cancellationToken = default(CancellationToken)) {
+            await mainThread.SwitchToAsync(cancellationToken);
+            action();
+        }
+
+        public static async Task<T> SendAsync<T>(this IMainThread mainThread, Func<T> action, CancellationToken cancellationToken = default(CancellationToken)) {
+            await mainThread.SwitchToAsync(cancellationToken);
+            return action();
         }
     }
 }

--- a/src/Common/Core/Test/Stubs/Shell/SecurityServiceStub.cs
+++ b/src/Common/Core/Test/Stubs/Shell/SecurityServiceStub.cs
@@ -3,25 +3,28 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Common.Core.Security;
 
 namespace Microsoft.Common.Core.Test.Stubs.Shell {
     public class SecurityServiceStub : ISecurityService {
-        public ConcurrentQueue<Tuple<string, string>> GetUserCredentialsCalls { get; } = new ConcurrentQueue<Tuple<string, string>>();
-        public ConcurrentQueue<Tuple<X509Certificate, string>> ValidateX509CertificateCalls { get; } = new ConcurrentQueue<Tuple<X509Certificate, string>>();
+        public ConcurrentQueue<(string, string)> GetUserCredentialsCalls { get; } = new ConcurrentQueue<(string, string)>();
+        public ConcurrentQueue<(X509Certificate, string)> ValidateX509CertificateCalls { get; } = new ConcurrentQueue<(X509Certificate, string)>();
+        public ConcurrentQueue<(string, string, SecureString, bool)> SaveUserCredentialsCalls { get; } = new ConcurrentQueue<(string, string, SecureString, bool)>();
         public ConcurrentQueue<string> DeleteUserCredentialsCalls { get; } = new ConcurrentQueue<string>();
         public ConcurrentQueue<string> DeleteCredentialsCalls { get; } = new ConcurrentQueue<string>();
         public ConcurrentQueue<string> GetUserNameCalls { get; } = new ConcurrentQueue<string>();
 
-        public Func<string, string, Credentials> GetUserCredentialsHandler { get; set; } = (authority, workspaceName) => { throw new NotImplementedException(); };
+        public Func<string, string, Credentials> GetUserCredentialsHandler { get; set; } = (authority, workspaceName) => throw new NotImplementedException();
+        public Func<string, (string, SecureString)> ReadUserCredentialsHandler { get; set; } = authority => (authority, authority.ToSecureString());
         public Func<X509Certificate, string, bool> ValidateX509CertificateHandler { get; set; } = (deviceId, ct) => true;
+        public Action<string, string, SecureString, bool> SaveUserCredentialsHandler { get; set; } = (authority, userName, password, save) => {};
         public Func<string, bool> DeleteUserCredentialsHandler { get; set; } = authority => true;
         public Action<string> DeleteCredentialsHandler { get; set; } = authority => {};
-        public Func<string, string> GetUserNameHandler { get; set; } = authority => authority;
 
         public Credentials GetUserCredentials(string authority, string workspaceName) {
-            GetUserCredentialsCalls.Enqueue(new Tuple<string, string>(authority, workspaceName));
+            GetUserCredentialsCalls.Enqueue((authority, workspaceName));
             var handler = GetUserCredentialsHandler;
             if (handler != null) {
                 return handler(authority, workspaceName);
@@ -31,13 +34,23 @@ namespace Microsoft.Common.Core.Test.Stubs.Shell {
         }
 
         public bool ValidateX509Certificate(X509Certificate certificate, string message) {
-            ValidateX509CertificateCalls.Enqueue(new Tuple<X509Certificate, string>(certificate, message));
+            ValidateX509CertificateCalls.Enqueue((certificate, message));
             var handler = ValidateX509CertificateHandler;
             if (handler != null) {
                 return handler(certificate, message);
             }
 
             throw new NotImplementedException();
+        }
+
+        public void SaveUserCredentials(string authority, string userName, SecureString password, bool save) {
+            SaveUserCredentialsCalls.Enqueue((authority, userName, password, save));
+            var handler = SaveUserCredentialsHandler;
+            if (handler != null) {
+                handler(authority, userName, password, save);
+            } else {
+                throw new NotImplementedException();
+            }
         }
 
         public bool DeleteUserCredentials(string authority) {
@@ -60,9 +73,9 @@ namespace Microsoft.Common.Core.Test.Stubs.Shell {
             }
         }
 
-        public string GetUserName(string authority) {
+        public (string username, SecureString password) ReadUserCredentials(string authority) {
             GetUserNameCalls.Enqueue(authority);
-            var handler = GetUserNameHandler;
+            var handler = ReadUserCredentialsHandler;
             if (handler != null) {
                 return handler(authority);
             }

--- a/src/Common/Wpf/Impl/AttachedProperties.cs
+++ b/src/Common/Wpf/Impl/AttachedProperties.cs
@@ -3,11 +3,11 @@
 
 using System.Windows;
 
-namespace Microsoft.R.Wpf {
+namespace Microsoft.Common.Wpf {
     public static class AttachedProperties {
         public static readonly DependencyProperty IsValidProperty = DependencyProperty.RegisterAttached("IsValid", typeof(bool), typeof(AttachedProperties), new PropertyMetadata(false));
 
-        public static bool GetIsValid(FrameworkElement fe) => (bool)fe.GetValue(IsValidProperty);
+        public static bool GetIsValid(FrameworkElement fe) => (bool)(fe.GetValue(IsValidProperty) ?? false);
         public static void SetIsValid(FrameworkElement fe, bool value) => fe.SetValue(IsValidProperty, value);
     }
 }

--- a/src/Common/Wpf/Impl/Controls/Overlay.cs
+++ b/src/Common/Wpf/Impl/Controls/Overlay.cs
@@ -29,8 +29,7 @@ namespace Microsoft.Common.Wpf.Controls {
                 return;
             }
 
-            var frameworkElement = obj as FrameworkElement;
-            if (frameworkElement == null) {
+            if (!(obj is FrameworkElement frameworkElement)) {
                 return;
             }
 

--- a/src/Common/Wpf/Impl/Controls/Overlay.cs
+++ b/src/Common/Wpf/Impl/Controls/Overlay.cs
@@ -54,8 +54,7 @@ namespace Microsoft.Common.Wpf.Controls {
         }
 
         private static void FrameworkElement_Loaded(object sender, RoutedEventArgs e) {
-            var frameworkElement = e.OriginalSource as FrameworkElement;
-            if (frameworkElement == null) {
+            if (!(e.OriginalSource is FrameworkElement frameworkElement)) {
                 return;
             }
 

--- a/src/Common/Wpf/Impl/Microsoft.Common.Wpf.csproj
+++ b/src/Common/Wpf/Impl/Microsoft.Common.Wpf.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Compile Include="$(SourceDirectory)AssemblyVersionInfo.cs" Link="Properties\AssemblyVersionInfo.cs" />
     <Compile Include="$(SourceDirectory)GlobalAssemblyInfo.cs" Link="Properties\GlobalAssemblyInfo.cs" />
+    <Compile Include="AttachedProperties.cs" />
     <Compile Include="Automation\AutomationPropertyChangedBase.cs" />
     <Compile Include="Controls\BindableBase.cs" />
     <Compile Include="Collections\BatchObservableCollection.cs" />

--- a/src/Containers/Impl/Docker/LocalDockerService.cs
+++ b/src/Containers/Impl/Docker/LocalDockerService.cs
@@ -35,8 +35,11 @@ namespace Microsoft.R.Containers.Docker {
         public async Task<IContainer> CreateContainerFromFileAsync(BuildImageParameters buildParams, CancellationToken ct) {
             await TaskUtilities.SwitchToBackgroundThread();
 
-            var buildOptions = $"-t {buildParams.Image}:{buildParams.Tag} {Path.GetDirectoryName(buildParams.DockerfilePath)}";
-            await BuildImageAsync(buildOptions, ct);
+            var images = await ListImagesAsync(true, ct);
+            if (!images.Any(i => i.Name.EqualsOrdinal(buildParams.Image) && i.Tag.EqualsOrdinal(buildParams.Tag))) {
+                var buildOptions = $"-t {buildParams.Image}:{buildParams.Tag} \"{Path.GetDirectoryName(buildParams.DockerfilePath)}\"";
+                await BuildImageAsync(buildOptions, ct);
+            }
 
             var createOptions = Invariant($"-p 5444:5444 --name {buildParams.Name} {buildParams.Image}:{buildParams.Tag} rtvsd");
             var containerId = await CreateContainerAsync(createOptions, ct);
@@ -69,7 +72,7 @@ namespace Microsoft.R.Containers.Docker {
             var lines = output.Split(new[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
             var ids = lines.Where(line => _containerIdMatcher12.IsMatch(line) || _containerIdMatcher64.IsMatch(line));
             var arr = await InspectAsync(ids, ct);
-            return arr.Select(c => GetContainerImage(c));
+            return arr.Select(GetContainerImage);
         }
 
         private ContainerImage GetContainerImage(JToken c) {

--- a/src/Containers/Impl/Docker/LocalDockerService.cs
+++ b/src/Containers/Impl/Docker/LocalDockerService.cs
@@ -25,7 +25,7 @@ namespace Microsoft.R.Containers.Docker {
         private readonly Regex _containerIdMatcher64 = new Regex("[0-9a-f]{64}", RegexOptions.IgnoreCase);
         private readonly Regex _containerIdMatcher12 = new Regex("[0-9a-f]{12}", RegexOptions.IgnoreCase);
         private readonly int _defaultTimeout = 500;
-        private IOutput _output;
+        private volatile IOutput _output;
 
         protected LocalDockerService(IServiceContainer services) {
             _ps = services.Process();

--- a/src/Host/Client/Impl/Host/BrokerConnectionInfo.cs
+++ b/src/Host/Client/Impl/Host/BrokerConnectionInfo.cs
@@ -40,7 +40,7 @@ namespace Microsoft.R.Host.Client.Host {
                 Password = null
             };
             uri = ub.Uri;
-            var username = securityService.GetUserName(GetCredentialAuthority(name));
+            var (username, _) = securityService.ReadUserCredentials(GetCredentialAuthority(name));
             return new BrokerConnectionInfo(name, uri, rCommandLineArguments, interpreterId, true, username, fetchHostLoad);
         }
 
@@ -57,9 +57,7 @@ namespace Microsoft.R.Host.Client.Host {
             FetchHostLoad = fetchHostLoad;
         }
 
-        private static string GetCredentialAuthority(string name) {
-            return $"RTVS:{name}";
-        }
+        public static string GetCredentialAuthority(string name) => $"RTVS:{name}";
 
         public override bool Equals(object obj) => obj is BrokerConnectionInfo && Equals((BrokerConnectionInfo)obj);
 

--- a/src/R/Components/Impl/Containers/Implementation/ContainerManager.cs
+++ b/src/R/Components/Impl/Containers/Implementation/ContainerManager.cs
@@ -90,11 +90,14 @@ RUN echo ""{username}:{password}"" | chpasswd
 
 EXPOSE 5444";                
 
-            var guid = Guid.NewGuid().ToString();
+            var guid = dockerImageContent.ToGuid().ToString();
             var folder = Path.Combine(Path.GetTempPath(), guid);
             var filePath = Path.Combine(folder, "Dockerfile");
-            _fileSystem.CreateDirectory(folder);
-            _fileSystem.WriteAllText(filePath, dockerImageContent);
+
+            if (!_fileSystem.DirectoryExists(folder)) {
+                _fileSystem.CreateDirectory(folder);
+                _fileSystem.WriteAllText(filePath, dockerImageContent);
+            }
 
             try {
                 return await _containerService.CreateContainerFromFileAsync(new BuildImageParameters(filePath, guid, version, name), cancellationToken);

--- a/src/R/Components/Impl/Settings/IRSettings.cs
+++ b/src/R/Components/Impl/Settings/IRSettings.cs
@@ -30,16 +30,6 @@ namespace Microsoft.R.Components.Settings {
         ConnectionInfo LastActiveConnection { get; set; }
 
         /// <summary>
-        /// Username used for the last successfully created local docker container
-        /// </summary>
-        string LastLocalDockerUsername { get; set; }
-
-        /// <summary>
-        /// Password used for the last successfully created local docker container
-        /// </summary>
-        string LastLocalDockerPassword { get; set; }
-
-        /// <summary>
         /// Selected CRAN mirror
         /// </summary>
         string CranMirror { get; set; }

--- a/src/R/Wpf/Impl/CommonResources.xaml
+++ b/src/R/Wpf/Impl/CommonResources.xaml
@@ -9,6 +9,7 @@
                     xmlns:controls="clr-namespace:Microsoft.Common.Wpf.Controls;assembly=Microsoft.R.Common.Wpf"
                     xmlns:rcontrols="clr-namespace:Microsoft.R.Wpf.Controls"
                     xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+                    xmlns:cwpf="clr-namespace:Microsoft.Common.Wpf;assembly=Microsoft.R.Common.Wpf"
                     mc:Ignorable="d">
     <!--Icons-->
     <PathGeometry FillRule="NonZero" x:Key="ArrowRigth10" Figures="M0,0 L5,5 L0,10 z" />
@@ -235,7 +236,7 @@
         <Setter Property="Margin" Value="0,0,4,0" />
         <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StatusOKOutline}"/>
         <Style.Triggers>
-            <Trigger Property="wpf:AttachedProperties.IsValid" Value="False">
+            <Trigger Property="cwpf:AttachedProperties.IsValid" Value="False">
                 <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StatusRequiredOutline}"/>        
             </Trigger>
         </Style.Triggers>

--- a/src/R/Wpf/Impl/Controls/Watermark.cs
+++ b/src/R/Wpf/Impl/Controls/Watermark.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -9,33 +8,50 @@ using static Microsoft.Common.Wpf.Controls.Overlay;
 
 namespace Microsoft.R.Wpf.Controls {
     public class Watermark {
-        public static string GetTextBoxHint(TextBox frameworkElement) {
-            return (string)frameworkElement.GetValue(TextBoxHintProperty);
-        }
-
-        public static void SetTextBoxHint(TextBox textBox, string value) {
-            textBox.SetValue(TextBoxHintProperty, value);
-        }
-
         public static readonly DependencyProperty TextBoxHintProperty =
             DependencyProperty.RegisterAttached("TextBoxHint", typeof(string), typeof(Watermark),
-                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, OnTextBoxHintChanged));
+                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, OnHintChanged));
 
-        private static void OnTextBoxHintChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args) {
-            var oldValue = args.OldValue as string;
+        public static readonly DependencyProperty PasswordBoxHintProperty =
+            DependencyProperty.RegisterAttached("PasswordBoxHint", typeof(string), typeof(Watermark),
+                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, OnHintChanged));
+
+        public static string GetTextBoxHint(TextBox textBox) => (string)textBox.GetValue(TextBoxHintProperty);
+
+        public static void SetTextBoxHint(TextBox textBox, string value) => textBox.SetValue(TextBoxHintProperty, value);
+
+        public static string GetPasswordBoxHint(PasswordBox passwordBox) => (string)passwordBox.GetValue(PasswordBoxHintProperty);
+
+        public static void SetPasswordBoxHint(PasswordBox passwordBox, string value) => passwordBox.SetValue(PasswordBoxHintProperty, value);
+
+        private static void OnHintChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args) {
             var newValue = args.NewValue as string;
-            if (Equals(oldValue, newValue)) {
+            if (Equals(args.OldValue, newValue)) {
                 return;
             }
 
-            var textBox = obj as TextBox;
-            if (textBox == null) {
+            if (!(obj is FrameworkElement frameworkElement)) {
                 return;
             }
 
-            var textBlock = EnsureAdorner(textBox);
+            var textBlock = EnsureAdorner(frameworkElement);
+            if (textBlock == null) {
+                return;
+            }
+
             textBlock.Text = newValue;
-            textBox.ToolTip = newValue;
+            frameworkElement.ToolTip = newValue;
+        }
+
+        private static TextBlock EnsureAdorner(FrameworkElement frameworkElement) {
+            switch (frameworkElement) {
+                case TextBox textBox:
+                    return EnsureAdorner(textBox);
+                case PasswordBox passwordBox:
+                    return EnsureAdorner(passwordBox);
+                default:
+                    return null;
+            }
         }
 
         private static TextBlock EnsureAdorner(TextBox textBox) {
@@ -44,23 +60,44 @@ namespace Microsoft.R.Wpf.Controls {
                 return (TextBlock)content;
             } 
 
-            var textBlock = new TextBlock {
-                Foreground = (Brush)textBox.FindResource(Brushes.GrayTextBrushKey),
-                Margin = new Thickness(2,0,0,0),
-                VerticalAlignment = VerticalAlignment.Center,
-                Visibility = string.IsNullOrEmpty(textBox.Text) && textBox.IsVisible ? Visibility.Visible : Visibility.Collapsed
-            };
-
-            void SetTextBlockVisibility<TArgs>(object sender, TArgs args) {
-                textBlock.Visibility = string.IsNullOrEmpty(textBox.Text) && textBox.IsVisible ? Visibility.Visible : Visibility.Collapsed;
-            } 
-
-            textBox.TextChanged += SetTextBlockVisibility;
-            textBox.IsVisibleChanged += SetTextBlockVisibility;
+            var textBlock = CreateTextBlock(textBox);
+            SetTextBlockVisibility();
+            textBox.TextChanged += Handler;
+            textBox.IsVisibleChanged += Handler;
 
             SetAdornerContent(textBox, textBlock);
 
             return textBlock;
+
+            void SetTextBlockVisibility() => textBlock.Visibility = string.IsNullOrEmpty(textBox.Text) && textBox.IsVisible ? Visibility.Visible : Visibility.Collapsed;
+            void Handler<TArgs>(object sender, TArgs args) => SetTextBlockVisibility();
+        }
+
+        private static TextBlock EnsureAdorner(PasswordBox passwordBox) {
+            var content = GetAdornerContent(passwordBox);
+            if (content != null) {
+                return (TextBlock)content;
+            }
+
+            var textBlock = CreateTextBlock(passwordBox);
+            SetTextBlockVisibility();
+            passwordBox.PasswordChanged += Handler;
+            passwordBox.IsVisibleChanged += Handler;
+
+            SetAdornerContent(passwordBox, textBlock);
+
+            return textBlock;
+
+            void SetTextBlockVisibility() => textBlock.Visibility = passwordBox.SecurePassword.Length == 0 ? Visibility.Visible : Visibility.Collapsed;
+            void Handler<TArgs>(object sender, TArgs args) => SetTextBlockVisibility();
+        }
+
+        private static TextBlock CreateTextBlock(FrameworkElement frameworkElement) {
+            return new TextBlock {
+                Foreground = (Brush)frameworkElement.FindResource(Brushes.GrayTextBrushKey),
+                Margin = new Thickness(2, 0, 0, 0),
+                VerticalAlignment = VerticalAlignment.Center
+            };
         }
     }
 }

--- a/src/R/Wpf/Impl/Microsoft.R.Wpf.csproj
+++ b/src/R/Wpf/Impl/Microsoft.R.Wpf.csproj
@@ -33,7 +33,6 @@
     <Compile Include="..\..\..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="AttachedProperties.cs" />
     <Compile Include="Brushes.cs" />
     <Compile Include="Controls\IconWithOverlay.xaml.cs">
       <DependentUpon>IconWithOverlay.xaml</DependentUpon>

--- a/src/Windows/Host/Client/Test/Fixtures/RemoteBrokerMethodFixture.cs
+++ b/src/Windows/Host/Client/Test/Fixtures/RemoteBrokerMethodFixture.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Common.Core;
 using Microsoft.Common.Core.Security;
 using Microsoft.Common.Core.Services;
 using Microsoft.Common.Core.Test.Stubs.Shell;
@@ -36,7 +37,7 @@ namespace Microsoft.R.Host.Client.Test.Fixtures {
         public async Task<bool> ConnectAsync(IRSessionProvider sessionProvider) {
             var securityService = _services.GetService<ISecurityService>();
             if (securityService is SecurityServiceStub securityServiceStub) { 
-                securityServiceStub.GetUserNameHandler = s => UserName;
+                securityServiceStub.ReadUserCredentialsHandler = s => (UserName, _remoteBrokerFixture.Password);
                 securityServiceStub.GetUserCredentialsHandler = (authority, workspaceName) => Credentials.Create(UserName, _remoteBrokerFixture.Password);
             }
 

--- a/src/Windows/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
+++ b/src/Windows/R/Components/Impl/ConnectionManager/Implementation/ConnectionManager.cs
@@ -322,15 +322,23 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation {
 
         private void ContainersChanged() {
             var activeConnection = ActiveConnection;
-            foreach (var container in _containers.GetRunningContainers()) {
+            var updateActiveConnection = false;
+            foreach (var container in _containers.GetContainers()) {
                 if (container.IsRunning) {
                     _connections[container.Name] = Connection.Create(_securityService, container, string.Empty, false, _settings.ShowHostLoadMeter);
-                } else if (activeConnection == null || !container.Name.EqualsOrdinal(activeConnection.Name)) {
+                } else {
                     _connections.TryRemove(container.Name, out IConnection _);
+                    if (activeConnection != null && container.Name.EqualsOrdinal(activeConnection.Name)) {
+                        updateActiveConnection = true;
+                    }
                 }
             }
 
-            UpdateRecentConnections();
+            if (updateActiveConnection) {
+                UpdateActiveConnection();
+            } else {
+                UpdateRecentConnections();
+            }
         }
 
         private void UpdateActiveConnection(IConnection candidateConnection = null) {

--- a/src/Windows/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
+++ b/src/Windows/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:cwpf="clr-namespace:Microsoft.Common.Wpf;assembly=Microsoft.R.Common.Wpf"
              xmlns:rwpf="clr-namespace:Microsoft.R.Wpf;assembly=Microsoft.R.Wpf"
              xmlns:components="clr-namespace:Microsoft.R.Components"
              xmlns:designTime="clr-namespace:Microsoft.R.Components.ConnectionManager.Implementation.View.DesignTime"
@@ -132,9 +133,9 @@
                     </Grid.ColumnDefinitions>
 
                     <imaging:CrispImage Grid.Row="0" Grid.Column="0" x:Name="NameValidityIndicator" Style="{StaticResource ValidityIndicatorStyle}"
-                                        rwpf:AttachedProperties.IsValid="{Binding Path=IsNameValid}"/>
+                                        cwpf:AttachedProperties.IsValid="{Binding Path=IsNameValid}"/>
                     <imaging:CrispImage Grid.Row="1" Grid.Column="0" x:Name="PathValidityIndicator" Style="{StaticResource ValidityIndicatorStyle}"
-                                        rwpf:AttachedProperties.IsValid="{Binding Path=IsPathValid}"/>
+                                        cwpf:AttachedProperties.IsValid="{Binding Path=IsPathValid}"/>
 
                     <TextBox Grid.Row="0" Grid.Column="1" Style="{StaticResource InputTextBoxStyle}"
                                 Text="{Binding Path=Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"

--- a/src/Windows/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
+++ b/src/Windows/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
@@ -117,7 +117,7 @@
 
             <DataTemplate x:Key="EditConnectionDataTemplate" DataType="{x:Type viewModel:IConnectionViewModel}">
                 <Grid Margin="0,6,0,8" PreviewKeyUp="EditConnection_PreviewKeyUp"
-                        Background="{DynamicResource {x:Static rwpf:Brushes.ToolWindowBackgroundBrushKey}}">
+                      Background="{DynamicResource {x:Static rwpf:Brushes.ToolWindowBackgroundBrushKey}}">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>

--- a/src/Windows/R/Components/Impl/ContainerManager/Implementation/View/ContainerManagerControl.xaml
+++ b/src/Windows/R/Components/Impl/ContainerManager/Implementation/View/ContainerManagerControl.xaml
@@ -137,20 +137,17 @@
                     <imaging:CrispImage Grid.Row="2" Grid.Column="0" Style="{StaticResource ValidityIndicatorStyle}"
                                         cwpf:AttachedProperties.IsValid="{Binding Path=IsPasswordValid}"/>
 
-                    <TextBox Grid.Row="2" Grid.Column="1" Style="{StaticResource TextBoxSingleLineStyle}"
-                             Text="{Binding Path=Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                             rcontrols:Watermark.TextBoxHint="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Password}"
-                             ToolTip="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Version}"
-                             AutomationProperties.Name="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Version}" />
-
-                    <!--<PasswordBox Grid.Row="2" Grid.Column="1" Style="{StaticResource TextBoxSingleLineStyle}"
-                                 SecurePassword="{Binding Path=Password, Mode=OneWayToSource, UpdateSourceTrigger=PropertyChanged}" />-->
+                    <PasswordBox x:Name="PasswordBoxNewDocker" Grid.Row="2" Grid.Column="1" Style="{StaticResource TextBoxSingleLineStyle}"
+                                 rcontrols:Watermark.PasswordBoxHint="{Binding Path=PasswordWatermark}"
+                                 ToolTip="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Password}"
+                                 AutomationProperties.Name="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Password}"
+                                 PasswordChanged="PasswordBoxNewDocker_OnPasswordChanged"/>
 
                     <TextBox Grid.Row="3" Grid.Column="1" Style="{StaticResource TextBoxSingleLineStyle}" 
                              Text="{Binding Path=Version, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                              rcontrols:Watermark.TextBoxHint="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Version}"
-                             ToolTip="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Version}"
-                             AutomationProperties.Name="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Version}" />
+                             ToolTip="{x:Static components:Resources.ContainerManager_CreateLocalDocker_VersionTooltip}"
+                             AutomationProperties.Name="{x:Static components:Resources.ContainerManager_CreateLocalDocker_VersionTooltip}" />
 
                     <WrapPanel Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,0">
                         <Button Margin="-1,0,4,0" Padding="6,2,6,2" MinWidth="75" MinHeight="23"
@@ -172,14 +169,14 @@
 
             <Style x:Key="ExpandCollapseButtonLocalDockerStyle" TargetType="{x:Type controls:ExpandCollapseButton}" BasedOn="{StaticResource ExpandCollapseButtonStyle}">
                 <Setter Property="IsExpanded" Value="True" />
-                <Setter Property="Content" Value="{x:Static components:Resources.ConnectionManager_LocalConnections}" />
+                <Setter Property="Content" Value="{x:Static components:Resources.ContainerManager_LocalDocker}" />
                 <Setter Property="Visibility" Value="{Binding Path=HasLocalConnections, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}" />
                 <Setter Property="ToolTip">
                     <Setter.Value>
-                        <TextBlock Text="{x:Static components:Resources.ConnectionManager_LocalConnections_Tooltip}" />
+                        <TextBlock Text="{x:Static components:Resources.ContainerManager_LocalDocker}" />
                     </Setter.Value>
                 </Setter>
-                <Setter Property="AutomationProperties.Name" Value="{x:Static components:Resources.ConnectionManager_LocalConnections_Tooltip}" />
+                <Setter Property="AutomationProperties.Name" Value="{x:Static components:Resources.ContainerManager_LocalDocker}" />
             </Style>
 
             <Style x:Key="ContainersListBoxItemStyle" TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource FillingListBoxItemStyle}">
@@ -209,18 +206,23 @@
             </Style>
             
             <Style x:Key="WatermarkTextBlock" TargetType="TextBlock" >
-                
+                <Setter Property="Background" Value="{DynamicResource {x:Static rwpf:Brushes.WindowKey}}" />
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static rwpf:Brushes.WindowTextKey}}" />
+                <Setter Property="TextAlignment" Value="Center" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="TextWrapping" Value="Wrap" />
             </Style>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Grid x:Name="Root">
-        <TextBlock Visibility="{Binding Path=, Converter={x:Static rwpf:Converters.FalseIsHidden}}"
-                   Background="{DynamicResource {x:Static rwpf:Brushes.WindowKey}}"
-                   Foreground="{DynamicResource {x:Static rwpf:Brushes.WindowTextKey}}"
-                   TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center"
-                   TextWrapping="Wrap" Text="{x:Static components:Resources.ContainerManager_ContainerServiceIsNotInstalled}" />
+    <Grid>
+        <TextBlock Style="{StaticResource WatermarkTextBlock}" Visibility="{Binding Path=ContainerServiceIsNotInstalled, Converter={x:Static rwpf:Converters.FalseIsHidden}}"
+                   Text="{x:Static components:Resources.ContainerManager_ContainerServiceIsNotInstalled}" />
 
-        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+        <TextBlock Style="{StaticResource WatermarkTextBlock}" Visibility="{Binding Path=ContainerServiceIsNotRunning, Converter={x:Static rwpf:Converters.FalseIsHidden}}"
+                   Text="{x:Static components:Resources.ContainerManager_ContainerServiceIsNotRunning}" />
+
+        <ScrollViewer x:Name="Root" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
             <DockPanel x:Name="RootContent" LastChildFill="True" MinWidth="250" >
                 <DockPanel.MaxWidth>
                     <MultiBinding Converter="{x:Static rwpf:Converters.Max}">
@@ -233,13 +235,13 @@
                 <controls:ExpandCollapseButton x:Name="ToggleButtonLocalDocker" Style="{StaticResource ExpandCollapseButtonLocalDockerStyle}" DockPanel.Dock="Top" />
 
                 <!-- Add local docker containers -->
-                <Button x:Name="ToggleButtonAddLocalDocker" DockPanel.Dock="Top" Style="{StaticResource HyperlinkDownArrowButton}" Margin="17,4,6,0"
+                <Button x:Name="ToggleButtonAddLocalDocker" DockPanel.Dock="Top" Style="{StaticResource HyperlinkDownArrowButton}" Margin="17,4,6,4"
                         Visibility="{Binding ElementName=ToggleButtonLocalDocker, Path=IsExpanded, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}"
                         IsEnabled="{Binding Path=NewLocalDocker, Converter={x:Static rwpf:Converters.NullIsTrue}}"
                         Content="{x:Static components:Resources.ContainerManager_CreateLocalDocker}" AutomationProperties.Name="{x:Static components:Resources.ContainerManager_CreateLocalDocker}"
                         Click="ButtonAdd_Click" />
 
-                <Border DockPanel.Dock="Top" Margin="16,8,6,8">
+                <Border DockPanel.Dock="Top" Margin="16,4,6,8" Padding="0,0,0,4" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource {x:Static rwpf:Brushes.ControlKey}}">
                     <Border.Visibility>
                         <MultiBinding Converter="{x:Static rwpf:Converters.AllIsNotCollapsed}">
                             <Binding ElementName="ToggleButtonLocalDocker" Path="IsExpanded"/>

--- a/src/Windows/R/Components/Impl/ContainerManager/Implementation/View/ContainerManagerControl.xaml
+++ b/src/Windows/R/Components/Impl/ContainerManager/Implementation/View/ContainerManagerControl.xaml
@@ -4,7 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:components="clr-namespace:Microsoft.R.Components"
-             xmlns:controls="clr-namespace:Microsoft.Common.Wpf.Controls;assembly=Microsoft.R.Common.Wpf"
+             xmlns:controls="clr-namespace:Microsoft.Common.Wpf.Controls;assembly=Microsoft.R.Common.Wpf" 
+             xmlns:cwpf="clr-namespace:Microsoft.Common.Wpf;assembly=Microsoft.R.Common.Wpf"
              xmlns:rwpf="clr-namespace:Microsoft.R.Wpf;assembly=Microsoft.R.Wpf"
              xmlns:rcontrols="clr-namespace:Microsoft.R.Wpf.Controls;assembly=Microsoft.R.Wpf"
              xmlns:viewModel="clr-namespace:Microsoft.R.Components.ContainerManager.Implementation.ViewModel"
@@ -116,7 +117,7 @@
                     </Grid.ColumnDefinitions>
 
                     <imaging:CrispImage Grid.Row="0" Grid.Column="0" Style="{StaticResource ValidityIndicatorStyle}"
-                                        rwpf:AttachedProperties.IsValid="{Binding Path=IsNameValid}"/>
+                                        cwpf:AttachedProperties.IsValid="{Binding Path=IsNameValid}"/>
 
                     <TextBox Grid.Row="0" Grid.Column="1" Style="{StaticResource TextBoxSingleLineStyle}"
                              Text="{Binding Path=Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -125,7 +126,7 @@
                              AutomationProperties.Name="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Name}"/>
 
                     <imaging:CrispImage Grid.Row="1" Grid.Column="0" Style="{StaticResource ValidityIndicatorStyle}"
-                                        rwpf:AttachedProperties.IsValid="{Binding Path=IsUsernameValid}"/>
+                                        cwpf:AttachedProperties.IsValid="{Binding Path=IsUsernameValid}"/>
 
                     <TextBox Grid.Row="1" Grid.Column="1" Style="{StaticResource TextBoxSingleLineStyle}" 
                              Text="{Binding Path=Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -134,13 +135,16 @@
                              AutomationProperties.Name="{x:Static components:Resources.ContainerManager_CreateLocalDocker_UserName}"/>
 
                     <imaging:CrispImage Grid.Row="2" Grid.Column="0" Style="{StaticResource ValidityIndicatorStyle}"
-                                        rwpf:AttachedProperties.IsValid="{Binding Path=IsPasswordValid}"/>
+                                        cwpf:AttachedProperties.IsValid="{Binding Path=IsPasswordValid}"/>
 
                     <TextBox Grid.Row="2" Grid.Column="1" Style="{StaticResource TextBoxSingleLineStyle}"
                              Text="{Binding Path=Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                              rcontrols:Watermark.TextBoxHint="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Password}"
                              ToolTip="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Version}"
                              AutomationProperties.Name="{x:Static components:Resources.ContainerManager_CreateLocalDocker_Version}" />
+
+                    <!--<PasswordBox Grid.Row="2" Grid.Column="1" Style="{StaticResource TextBoxSingleLineStyle}"
+                                 SecurePassword="{Binding Path=Password, Mode=OneWayToSource, UpdateSourceTrigger=PropertyChanged}" />-->
 
                     <TextBox Grid.Row="3" Grid.Column="1" Style="{StaticResource TextBoxSingleLineStyle}" 
                              Text="{Binding Path=Version, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -203,51 +207,53 @@
             <Style x:Key="ContainersListBox" TargetType="{x:Type ListBox}" BasedOn="{StaticResource ToolWindowListBoxStyle}">
                 <Setter Property="ItemContainerStyle" Value="{StaticResource ContainersListBoxItemStyle}" />
             </Style>
+            
+            <Style x:Key="WatermarkTextBlock" TargetType="TextBlock" >
+                
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
-    <ScrollViewer x:Name="Root" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
-        <DockPanel x:Name="RootContent" LastChildFill="True" MinWidth="250" >
-            <DockPanel.MaxWidth>
-                <MultiBinding Converter="{x:Static rwpf:Converters.Max}">
-                    <Binding ElementName="Root" Path="ActualWidth" />
-                    <Binding ElementName="RootContent" Path="MinWidth" />
-                </MultiBinding>
-            </DockPanel.MaxWidth>
+    <Grid x:Name="Root">
+        <TextBlock Visibility="{Binding Path=, Converter={x:Static rwpf:Converters.FalseIsHidden}}"
+                   Background="{DynamicResource {x:Static rwpf:Brushes.WindowKey}}"
+                   Foreground="{DynamicResource {x:Static rwpf:Brushes.WindowTextKey}}"
+                   TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center"
+                   TextWrapping="Wrap" Text="{x:Static components:Resources.ContainerManager_ContainerServiceIsNotInstalled}" />
 
-            <DockPanel DockPanel.Dock="Top" Margin="16,0,0,0"
-                       Background="{DynamicResource {x:Static rwpf:Brushes.ToolWindowBackgroundBrushKey}}">
-                <WrapPanel DockPanel.Dock="Top" Margin="1,4,0,6">
-                    <Button x:Name="ButtonShowWorkspaces" Margin="-6,0,0,0" MinWidth="75" MinHeight="23"
-                            VerticalAlignment="Center" Click="ButtonShowWorkspaces_Click" 
-                            Style="{StaticResource ToolWindowButtonStyle}"
-                            Content="{x:Static components:Resources.ContainerManager_ShowWorkspaces}" 
-                            AutomationProperties.Name="{x:Static components:Resources.ContainerManager_ShowWorkspaces}" />
-                </WrapPanel>
-            </DockPanel>
-
-            <!-- Local docker containers header -->
-            <controls:ExpandCollapseButton x:Name="ToggleButtonLocalDocker" Style="{StaticResource ExpandCollapseButtonLocalDockerStyle}" DockPanel.Dock="Top" />
-
-            <!-- Add local docker containers -->
-            <Button x:Name="ToggleButtonAddLocalDocker" DockPanel.Dock="Top" Style="{StaticResource HyperlinkDownArrowButton}" Margin="17,4,6,0"
-                    Visibility="{Binding ElementName=ToggleButtonLocalDocker, Path=IsExpanded, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}"
-                    IsEnabled="{Binding Path=NewLocalDocker, Converter={x:Static rwpf:Converters.NullIsTrue}}"
-                    Content="{x:Static components:Resources.ContainerManager_CreateLocalDocker}" AutomationProperties.Name="{x:Static components:Resources.ContainerManager_CreateLocalDocker}"
-                    Click="ButtonAdd_Click" />
-
-            <Border DockPanel.Dock="Top" Margin="16,8,6,8">
-                <Border.Visibility>
-                    <MultiBinding Converter="{x:Static rwpf:Converters.AllIsNotCollapsed}">
-                        <Binding ElementName="ToggleButtonLocalDocker" Path="IsExpanded"/>
-                        <Binding Path="NewLocalDocker" Converter="{x:Static rwpf:Converters.NullIsFalse}" />    
+        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+            <DockPanel x:Name="RootContent" LastChildFill="True" MinWidth="250" >
+                <DockPanel.MaxWidth>
+                    <MultiBinding Converter="{x:Static rwpf:Converters.Max}">
+                        <Binding ElementName="Root" Path="ActualWidth" />
+                        <Binding ElementName="RootContent" Path="MinWidth" />
                     </MultiBinding>
-                </Border.Visibility>
-                <ContentPresenter Content="{Binding Path=NewLocalDocker, Mode=OneWay}" ContentTemplate="{StaticResource CreateLocalDockerDataTemplate}" />
-            </Border>
+                </DockPanel.MaxWidth>
 
-            <!-- Local docker containers -->
-            <ListBox x:Name="ListLocalDocker" DockPanel.Dock="Top" Style="{StaticResource ContainersListBox}" Margin="11,0,6,16" ItemsSource="{Binding Path=LocalContainers}" 
-                     Visibility="{Binding ElementName=ToggleButtonLocalDocker, Path=IsExpanded, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}"/>
-        </DockPanel>
-    </ScrollViewer>
+                <!-- Local docker containers header -->
+                <controls:ExpandCollapseButton x:Name="ToggleButtonLocalDocker" Style="{StaticResource ExpandCollapseButtonLocalDockerStyle}" DockPanel.Dock="Top" />
+
+                <!-- Add local docker containers -->
+                <Button x:Name="ToggleButtonAddLocalDocker" DockPanel.Dock="Top" Style="{StaticResource HyperlinkDownArrowButton}" Margin="17,4,6,0"
+                        Visibility="{Binding ElementName=ToggleButtonLocalDocker, Path=IsExpanded, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}"
+                        IsEnabled="{Binding Path=NewLocalDocker, Converter={x:Static rwpf:Converters.NullIsTrue}}"
+                        Content="{x:Static components:Resources.ContainerManager_CreateLocalDocker}" AutomationProperties.Name="{x:Static components:Resources.ContainerManager_CreateLocalDocker}"
+                        Click="ButtonAdd_Click" />
+
+                <Border DockPanel.Dock="Top" Margin="16,8,6,8">
+                    <Border.Visibility>
+                        <MultiBinding Converter="{x:Static rwpf:Converters.AllIsNotCollapsed}">
+                            <Binding ElementName="ToggleButtonLocalDocker" Path="IsExpanded"/>
+                            <Binding Path="NewLocalDocker" Converter="{x:Static rwpf:Converters.NullIsFalse}" />    
+                        </MultiBinding>
+                    </Border.Visibility>
+                    <ContentPresenter Content="{Binding Path=NewLocalDocker, Mode=OneWay}" ContentTemplate="{StaticResource CreateLocalDockerDataTemplate}" />
+                </Border>
+
+                <!-- Local docker containers -->
+                <ListBox x:Name="ListLocalDocker" DockPanel.Dock="Top" Style="{StaticResource ContainersListBox}" Margin="11,0,6,16" ItemsSource="{Binding Path=LocalContainers}" 
+                         Visibility="{Binding ElementName=ToggleButtonLocalDocker, Path=IsExpanded, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}"/>
+            </DockPanel>
+        </ScrollViewer>
+    </Grid>
 </UserControl>
+

--- a/src/Windows/R/Components/Impl/ContainerManager/Implementation/View/ContainerManagerControl.xaml.cs
+++ b/src/Windows/R/Components/Impl/ContainerManager/Implementation/View/ContainerManagerControl.xaml.cs
@@ -32,6 +32,13 @@ namespace Microsoft.R.Components.ContainerManager.Implementation.View {
             }
         }
 
+        private void PasswordBoxNewDocker_OnPasswordChanged(object sender, RoutedEventArgs e) {
+            var newLocalDocker = ViewModel.NewLocalDocker;
+            if (newLocalDocker != null) {
+                newLocalDocker.Password = ((PasswordBox) e.OriginalSource).SecurePassword;
+            }
+        }
+
         private void ButtonCreateLocalDocker_Click(object sender, RoutedEventArgs e) => ViewModel.CreateLocalDockerAsync().DoNotWait();
 
         private void ButtonCancelCreateLocalDocker_Click(object sender, RoutedEventArgs e) => ViewModel.CancelCreateLocalDocker();

--- a/src/Windows/R/Components/Impl/ContainerManager/Implementation/View/ContainerManagerControl.xaml.cs
+++ b/src/Windows/R/Components/Impl/ContainerManager/Implementation/View/ContainerManagerControl.xaml.cs
@@ -20,8 +20,6 @@ namespace Microsoft.R.Components.ContainerManager.Implementation.View {
 
         private void ButtonAdd_Click(object sender, RoutedEventArgs e) => ViewModel.ShowCreateLocalDocker();
 
-        private void ButtonShowWorkspaces_Click(object sender, RoutedEventArgs e) => ViewModel.ShowConnections();
-
         private void Container_PreviewKeyUp(object sender, KeyEventArgs keyEventArgs) {
             if (keyEventArgs.Key == Key.Delete && !(keyEventArgs.OriginalSource is TextBox)) {
                 ViewModel.DeleteAsync(GetContainer(keyEventArgs)).DoNotWait();

--- a/src/Windows/R/Components/Impl/ContainerManager/Implementation/ViewModel/ContainerManagerViewModel.cs
+++ b/src/Windows/R/Components/Impl/ContainerManager/Implementation/ViewModel/ContainerManagerViewModel.cs
@@ -8,26 +8,30 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Common.Core;
 using Microsoft.Common.Core.Disposables;
+using Microsoft.Common.Core.Security;
 using Microsoft.Common.Core.Services;
 using Microsoft.Common.Core.Threading;
 using Microsoft.Common.Core.UI;
 using Microsoft.Common.Wpf.Collections;
 using Microsoft.R.Common.Wpf.Controls;
 using Microsoft.R.Components.Containers;
-using Microsoft.R.Components.Settings;
 using Microsoft.R.Components.View;
 using Microsoft.R.Containers;
+using Microsoft.R.Host.Client.Host;
 
 namespace Microsoft.R.Components.ContainerManager.Implementation.ViewModel {
     internal sealed class ContainerManagerViewModel : BindableBase, IDisposable {
+        private static readonly string LastLocalDockerCredentials = $"RTVSInternal:{nameof(LastLocalDockerCredentials)}";
         private readonly IServiceContainer _services;
         private readonly IContainerManager _containers;
         private readonly BatchObservableCollection<ContainerViewModel> _localContainers;
         private readonly DisposableBag _disposable;
         private readonly IMainThread _mainThread;
         private readonly IUIService _ui;
-        private readonly IRSettings _settings;
+        private readonly ISecurityService _security;
         private CreateLocalDockerViewModel _newLocalDocker;
+        private bool _containerServiceIsNotInstalled;
+        private bool _containerServiceIsNotRunning;
 
         public ReadOnlyObservableCollection<ContainerViewModel> LocalContainers { get; }
 
@@ -36,12 +40,22 @@ namespace Microsoft.R.Components.ContainerManager.Implementation.ViewModel {
             private set => SetProperty(ref _newLocalDocker, value);
         }
 
+        public bool ContainerServiceIsNotInstalled {
+            get => _containerServiceIsNotInstalled;
+            private set => SetProperty(ref _containerServiceIsNotInstalled, value);
+        }
+
+        public bool ContainerServiceIsNotRunning {
+            get => _containerServiceIsNotRunning;
+            private set => SetProperty(ref _containerServiceIsNotRunning, value);
+        }
+
         public ContainerManagerViewModel(IServiceContainer services) {
             _disposable = DisposableBag.Create<ContainerManagerViewModel>();
             _services = services;
             _mainThread = services.MainThread();
             _ui = services.UI();
-            _settings = services.GetService<IRSettings>();
+            _security = services.Security();
             _containers = services.GetService<IContainerManager>();
             _localContainers = new BatchObservableCollection<ContainerViewModel>();
             LocalContainers = new ReadOnlyObservableCollection<ContainerViewModel>(_localContainers);
@@ -58,25 +72,30 @@ namespace Microsoft.R.Components.ContainerManager.Implementation.ViewModel {
 
         public void ShowCreateLocalDocker() {
             _mainThread.Assert();
+            var (username, password) = _security.ReadUserCredentials(LastLocalDockerCredentials);
             NewLocalDocker = new CreateLocalDockerViewModel {
-                Username = _settings.LastLocalDockerUsername,
-                Password = _settings.LastLocalDockerPassword
+                Username = username,
+                Password = password
             };
         }
 
         public async Task CreateLocalDockerAsync(CancellationToken cancellationToken = default(CancellationToken)) {
             _mainThread.Assert();
 
+            var name = NewLocalDocker.Name;
+            var username = NewLocalDocker.Username;
+            var password = NewLocalDocker.Password;
             IContainer container;
             try {
-                container = await _containers.CreateLocalDockerAsync(NewLocalDocker.Name, NewLocalDocker.Username, NewLocalDocker.Password, NewLocalDocker.Version, cancellationToken);
+                container = await _containers.CreateLocalDockerAsync(name, username, password.ToUnsecureString(), NewLocalDocker.Version, cancellationToken);
             } catch (ContainerException) {
                 _ui.ShowMessage(Resources.ContainerManager_CreateLocalDocker_CreationError, MessageButtons.OK, MessageType.Error);
                 return;
             }
-
-            _settings.LastLocalDockerUsername = NewLocalDocker.Username;
-            _settings.LastLocalDockerPassword = NewLocalDocker.Password;
+            
+            var securePassword = password;
+            _security.SaveUserCredentials(BrokerConnectionInfo.GetCredentialAuthority(name), username, securePassword, true);
+            _security.SaveUserCredentials(LastLocalDockerCredentials, username, securePassword, true);
 
             try {
                 await _containers.StartAsync(container.Id, cancellationToken);

--- a/src/Windows/R/Components/Impl/ContainerManager/Implementation/ViewModel/ContainerViewModel.cs
+++ b/src/Windows/R/Components/Impl/ContainerManager/Implementation/ViewModel/ContainerViewModel.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
+using Microsoft.Common.Core;
 using Microsoft.R.Containers;
 
 namespace Microsoft.R.Components.ContainerManager.Implementation.ViewModel {
@@ -8,11 +10,13 @@ namespace Microsoft.R.Components.ContainerManager.Implementation.ViewModel {
         public string Id { get; }
         public string Name { get; }
         public bool IsRunning { get; }
+        public IList<int> HostPorts { get; }
 
         public ContainerViewModel(IContainer container) {
             Id = container.Id;
             Name = container.Name;
             IsRunning = container.IsRunning;
+            HostPorts = container.HostPorts.AsList();
         }
     }
 }

--- a/src/Windows/R/Components/Impl/ContainerManager/Implementation/ViewModel/CreateLocalDockerViewModel.cs
+++ b/src/Windows/R/Components/Impl/ContainerManager/Implementation/ViewModel/CreateLocalDockerViewModel.cs
@@ -8,16 +8,23 @@ using Microsoft.R.Common.Wpf.Controls;
 namespace Microsoft.R.Components.ContainerManager.Implementation.ViewModel {
     internal sealed class CreateLocalDockerViewModel : BindableBase {
         private static readonly Regex NameRegex = new Regex("^[a-zA-Z0-9][a-zA-Z0-9_-]+$", RegexOptions.Compiled);
+        private static readonly string ExistingPasswordWatermark = new string('●', 8);
 
         private string _name;
         private string _username;
         private SecureString _password;
+        private string _passwordWatermark;
         private string _version;
-        private string _folder;
         private bool _isNameValid;
         private bool _isUsernameValid;
         private bool _isPasswordValid;
         private bool _isValid;
+
+        public CreateLocalDockerViewModel(string username, SecureString password) {
+            Username = username;
+            Password = password;
+            _passwordWatermark = IsPasswordValid ? ExistingPasswordWatermark : Resources.ContainerManager_CreateLocalDocker_Password;
+        }
 
         public string Name {
             get => _name;
@@ -54,9 +61,15 @@ namespace Microsoft.R.Components.ContainerManager.Implementation.ViewModel {
             set {
                 if (SetProperty(ref _password, value)) {
                     IsPasswordValid = value != null && value.Length > 0;
+                    PasswordWatermark = Resources.ContainerManager_CreateLocalDocker_Password;
                     UpdateIsValid();
                 }
             }
+        }
+
+        public string PasswordWatermark {
+            get => _passwordWatermark;
+            private set => SetProperty(ref _passwordWatermark, value);
         }
 
         public bool IsPasswordValid {

--- a/src/Windows/R/Components/Impl/ContainerManager/Implementation/ViewModel/CreateLocalDockerViewModel.cs
+++ b/src/Windows/R/Components/Impl/ContainerManager/Implementation/ViewModel/CreateLocalDockerViewModel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Security;
 using System.Text.RegularExpressions;
 using Microsoft.R.Common.Wpf.Controls;
 
@@ -10,7 +11,7 @@ namespace Microsoft.R.Components.ContainerManager.Implementation.ViewModel {
 
         private string _name;
         private string _username;
-        private string _password;
+        private SecureString _password;
         private string _version;
         private string _folder;
         private bool _isNameValid;
@@ -48,11 +49,11 @@ namespace Microsoft.R.Components.ContainerManager.Implementation.ViewModel {
             set => SetProperty(ref _isUsernameValid, value);
         }
 
-        public string Password {
+        public SecureString Password {
             get => _password;
             set {
                 if (SetProperty(ref _password, value)) {
-                    IsPasswordValid = !string.IsNullOrWhiteSpace(value);
+                    IsPasswordValid = value != null && value.Length > 0;
                     UpdateIsValid();
                 }
             }

--- a/src/Windows/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml
+++ b/src/Windows/R/Components/Impl/Plots/Implementation/View/RPlotHistoryControl.xaml
@@ -29,17 +29,6 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
-        <TextBlock Visibility="{Binding Path=ShowWatermark, Converter={x:Static rwpf:Converters.FalseIsHidden}}"
-                   Background="{DynamicResource {x:Static rwpf:Brushes.WindowKey}}"
-                   Foreground="{DynamicResource {x:Static rwpf:Brushes.WindowTextKey}}"
-                   TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center"
-                   TextWrapping="Wrap">
-            <Run Text="{x:Static components:Resources.PlotHistory_EmptyWatermark}" />
-            <LineBreak/>
-            <LineBreak/>
-            <Run Text="{x:Static components:Resources.Plot_EmptyWatermark}" />
-        </TextBlock>
-
         <ListView x:Name="HistoryListView"
                   Visibility="{Binding Path=ShowWatermark, Converter={x:Static rwpf:Converters.TrueIsHidden}}"
                   ItemsSource="{Binding Source={StaticResource plotsByDevice}}"

--- a/src/Windows/R/Components/Impl/Resources.Designer.cs
+++ b/src/Windows/R/Components/Impl/Resources.Designer.cs
@@ -241,7 +241,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add.
+        ///   Looks up a localized string similar to Add Connection.
         /// </summary>
         public static string ConnectionManager_Add {
             get {
@@ -694,6 +694,24 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Docker service isn&apos;t installed.\nTo start working with containers, install Docker for Windows and restart VS..
+        /// </summary>
+        public static string ContainerManager_ContainerServiceIsNotInstalled {
+            get {
+                return ResourceManager.GetString("ContainerManager_ContainerServiceIsNotInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Docker service isn&apos;t running.\nTo start working with containers, run Docker for Windows and restart VS..
+        /// </summary>
+        public static string ContainerManager_ContainerServiceIsNotRunning {
+            get {
+                return ResourceManager.GetString("ContainerManager_ContainerServiceIsNotRunning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Create.
         /// </summary>
         public static string ContainerManager_CreateLocalDocker {
@@ -771,15 +789,6 @@ namespace Microsoft.R.Components {
         public static string ContainerManager_DeleteTooltip_Format {
             get {
                 return ResourceManager.GetString("ContainerManager_DeleteTooltip_Format", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Workspaces.
-        /// </summary>
-        public static string ContainerManager_ShowWorkspaces {
-            get {
-                return ResourceManager.GetString("ContainerManager_ShowWorkspaces", resourceCulture);
             }
         }
         

--- a/src/Windows/R/Components/Impl/Resources.Designer.cs
+++ b/src/Windows/R/Components/Impl/Resources.Designer.cs
@@ -766,11 +766,31 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Version of R that matches Docker image tag..
+        /// </summary>
+        public static string ContainerManager_CreateLocalDocker_VersionTooltip {
+            get {
+                return ResourceManager.GetString("ContainerManager_CreateLocalDocker_VersionTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Create new docker container.
         /// </summary>
         public static string ContainerManager_CreateTooltip {
             get {
                 return ResourceManager.GetString("ContainerManager_CreateTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You&apos;re currently connected to R which is hosted on container &apos;{0}&apos;.
+        ///If you delete this container, current connection will be terminated.
+        ///All data will be lost. Do you wish to proceed?.
+        /// </summary>
+        public static string ContainerManager_DeleteActiveWarning_Format {
+            get {
+                return ResourceManager.GetString("ContainerManager_DeleteActiveWarning_Format", resourceCulture);
             }
         }
         
@@ -789,6 +809,26 @@ namespace Microsoft.R.Components {
         public static string ContainerManager_DeleteTooltip_Format {
             get {
                 return ResourceManager.GetString("ContainerManager_DeleteTooltip_Format", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Container &apos;{0}&apos; is currently running.
+        ///It has to be stopped before deleting.
+        ///Do you wish to proceed?.
+        /// </summary>
+        public static string ContainerManager_DeleteWarning_Format {
+            get {
+                return ResourceManager.GetString("ContainerManager_DeleteWarning_Format", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Local Docker Containers.
+        /// </summary>
+        public static string ContainerManager_LocalDocker {
+            get {
+                return ResourceManager.GetString("ContainerManager_LocalDocker", resourceCulture);
             }
         }
         

--- a/src/Windows/R/Components/Impl/Resources.resx
+++ b/src/Windows/R/Components/Impl/Resources.resx
@@ -364,7 +364,7 @@
     <value>R command line arguments</value>
   </data>
   <data name="ConnectionManager_Add" xml:space="preserve">
-    <value>Add</value>
+    <value>Add Connection</value>
   </data>
   <data name="ConnectionManager_ShowContainers" xml:space="preserve">
     <value>Containers</value>
@@ -442,11 +442,14 @@ If you want to delete all data on the remote machine you must delete your user p
   <data name="ConnectionManager_RemoveConnectionConfirmation" xml:space="preserve">
     <value>Are you sure you want to remove the '{0}' connection?</value>
   </data>
+  <data name="ContainerManager_ContainerServiceIsNotInstalled" xml:space="preserve">
+    <value>Docker service isn't installed.\nTo start working with containers, install Docker for Windows and restart VS.</value>
+  </data>
+  <data name="ContainerManager_ContainerServiceIsNotRunning" xml:space="preserve">
+    <value>Docker service isn't running.\nTo start working with containers, run Docker for Windows and restart VS.</value>
+  </data>
   <data name="ContainerManager_CreateLocalDocker" xml:space="preserve">
     <value>Create</value>
-  </data>
-  <data name="ContainerManager_ShowWorkspaces" xml:space="preserve">
-    <value>Workspaces</value>
   </data>
   <data name="ContainerManager_CreateLocalDocker_Name" xml:space="preserve">
     <value>Name</value>

--- a/src/Windows/R/Components/Impl/Resources.resx
+++ b/src/Windows/R/Components/Impl/Resources.resx
@@ -448,6 +448,9 @@ If you want to delete all data on the remote machine you must delete your user p
   <data name="ContainerManager_ContainerServiceIsNotRunning" xml:space="preserve">
     <value>Docker service isn't running.\nTo start working with containers, run Docker for Windows and restart VS.</value>
   </data>
+  <data name="ContainerManager_LocalDocker" xml:space="preserve">
+    <value>Local Docker Containers</value>
+  </data>
   <data name="ContainerManager_CreateLocalDocker" xml:space="preserve">
     <value>Create</value>
   </data>
@@ -462,6 +465,9 @@ If you want to delete all data on the remote machine you must delete your user p
   </data>
   <data name="ContainerManager_CreateLocalDocker_Version" xml:space="preserve">
     <value>Version</value>
+  </data>
+  <data name="ContainerManager_CreateLocalDocker_VersionTooltip" xml:space="preserve">
+    <value>Version of R that matches Docker image tag.</value>
   </data>
   <data name="ContainerManager_CreateLocalDocker_CreationError" xml:space="preserve">
     <value>There was an error creating the container. Please see R Containers output for details.</value>
@@ -489,6 +495,16 @@ If you want to delete all data on the remote machine you must delete your user p
   </data>
   <data name="ContainerManager_DeleteTooltip_Format" xml:space="preserve">
     <value>Delete container '{0}'</value>
+  </data>
+  <data name="ContainerManager_DeleteActiveWarning_Format" xml:space="preserve">
+    <value>You're currently connected to R which is hosted on container '{0}'.
+If you delete this container, current connection will be terminated.
+All data will be lost. Do you wish to proceed?</value>
+  </data>
+  <data name="ContainerManager_DeleteWarning_Format" xml:space="preserve">
+    <value>Container '{0}' is currently running.
+It has to be stopped before deleting.
+Do you wish to proceed?</value>
   </data>
   <data name="Plots_RemoveAllPlotsWarning" xml:space="preserve">
     <value>Are you sure you want to remove all plots from {0}?</value>


### PR DESCRIPTION
#3939: Save credentials for created local docker container
#3952: Container password field should show system password character
#3963: Delete should be disabled for running containers (it actually shows the popup)
#3964: Connection is not removed after the container is deleted
#3967: Use docker file hash as the image name
#3976: Container dialog 'Version' field should have tooltip/watermark with explanation
#3978: UI issues in Create Container panel
#3980: Show watermark on Containers window instead of UI that docker isn't installed