### PR TITLE
Assorted fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ TestFiles/
 *.tmp_proj
 *.ide
 *.ide-journal
+*.lock

--- a/src/Common/Core/Test/Utility/TestFiles.cs
+++ b/src/Common/Core/Test/Utility/TestFiles.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Common.Core.Test.Utility {
             actual = actual.TrimEnd(_whitespace);
 
             var lineNumber = BaselineCompare.CompareLines(expected, actual, out var baseLine, out var actualLine, out var index);
-            lineNumber.Should().Be(0, "there should be no difference at line {0}.\r\nExpected:{1}\r\nActual:{2}\r\nDifference at position {3}\r\n", lineNumber, baseLine, actualLine, index);
+            if(lineNumber > 0) {
+                actualLine.Should().Be(baseLine);
+            }
         }
 
         public static void UpdateBaseline(string filePath, string content) {

--- a/src/Package/Impl/Expansions/ExpansionClient.cs
+++ b/src/Package/Impl/Expansions/ExpansionClient.cs
@@ -163,21 +163,24 @@ namespace Microsoft.VisualStudio.R.Package.Expansions {
         }
 
         public int FormatSpan(IVsTextLines vsTextLines, TextSpan[] ts) {
-            var startPos = -1;
-            var endPos = -1;
-            if (ErrorHandler.Succeeded(vsTextLines.GetPositionOfLineIndex(ts[0].iStartLine, ts[0].iStartIndex, out startPos)) &&
-                ErrorHandler.Succeeded(vsTextLines.GetPositionOfLineIndex(ts[0].iEndLine, ts[0].iEndIndex, out endPos))) {
+            if (ErrorHandler.Succeeded(vsTextLines.GetPositionOfLineIndex(ts[0].iStartLine, ts[0].iStartIndex, out var startPos)) &&
+                ErrorHandler.Succeeded(vsTextLines.GetPositionOfLineIndex(ts[0].iEndLine, ts[0].iEndIndex, out var endPos))) {
                 var textBuffer = vsTextLines.ToITextBuffer(_services);
                 var range = TextRange.FromBounds(startPos, endPos);
 
-                var point = textBuffer.CurrentSnapshot.CreateTrackingPoint(range.End, PointTrackingMode.Positive);
-                var text = textBuffer.CurrentSnapshot.GetText(range.ToSpan());
+                var snapshot = textBuffer.CurrentSnapshot;
+                var point = snapshot.CreateTrackingPoint(range.End, PointTrackingMode.Positive);
+                var text = snapshot.GetText(range.ToSpan());
+
+
+                var line = snapshot.GetLineFromPosition(range.Start);
+                var lineTail = snapshot.GetText(Span.FromBounds(range.End, line.End));
 
                 var formatter = new RangeFormatter(_services);
                 formatter.FormatRange(TextView.ToEditorView(), textBuffer.ToEditorBuffer(), range);
 
                 // Do not trim whitespace after standalone operators
-                if (IsStandaloneOperator(text)) {
+                if (IsStandaloneOperator(text) && string.IsNullOrEmpty(lineTail)) {
                     textBuffer.Insert(point.GetPosition(textBuffer.CurrentSnapshot), " ");
                 }
             }

--- a/src/Package/Impl/source.extension.vsixmanifest
+++ b/src/Package/Impl/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011"
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Microsoft.RTVS" Version="1.2" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="Microsoft.RTVS" Version="1.3" Language="en-US" Publisher="Microsoft" />
     <DisplayName>R Tools for Visual Studio</DisplayName>
     <Description xml:space="preserve">R Tools for Visual Studio</Description>
   </Metadata>

--- a/src/R.Build.Version.targets
+++ b/src/R.Build.Version.targets
@@ -19,7 +19,7 @@
     <Time Condition="'$(Time)' == ''">$([System.DateTime]::Now.ToString("HHmm"))</Time>
 
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>2</MinorVersion>
+    <MinorVersion>3</MinorVersion>
     <Build>$(LastDigitOfYear)$(Date)</Build>
     <Revision>$(Time)</Revision>
   </PropertyGroup>

--- a/src/R/Components/Impl/ConnectionManager/Connection.cs
+++ b/src/R/Components/Impl/ConnectionManager/Connection.cs
@@ -48,6 +48,6 @@ namespace Microsoft.R.Components.ConnectionManager {
         public Uri Uri => BrokerConnectionInfo.Uri;
         public string ContainerName => Container?.Name;
         public bool IsRemote => BrokerConnectionInfo.IsUrlBased && !Uri.IsLoopback;
-        public bool IsDocker => Container != null;
+        public bool IsContainer => Container != null;
     }
 }

--- a/src/R/Components/Impl/ConnectionManager/IConnection.cs
+++ b/src/R/Components/Impl/ConnectionManager/IConnection.cs
@@ -17,6 +17,6 @@ namespace Microsoft.R.Components.ConnectionManager {
         /// </summary>
         bool IsRemote { get; }
 
-        bool IsDocker { get; }
+        bool IsContainer { get; }
     }
 }

--- a/src/R/Components/Impl/ConnectionManager/ViewModel/IConnectionViewModel.cs
+++ b/src/R/Components/Impl/ConnectionManager/ViewModel/IConnectionViewModel.cs
@@ -28,7 +28,7 @@ namespace Microsoft.R.Components.ConnectionManager.ViewModel {
         bool IsPathValid { get; }
         bool IsRenamed { get; }
         bool IsRemote { get; }
-        
+        bool IsContainer { get; }
         void Reset();
         
         /// <summary>

--- a/src/R/Core/Test/Files/Parser/frametools.r.tree
+++ b/src/R/Core/Test/Files/Parser/frametools.r.tree
@@ -679,9 +679,78 @@ GlobalScope  [Global]
                                                                     Variable  [`_data`]
                                                         TokenNode  [) [2354...2355)]
                                         TokenNode  [) [2355...2356)]
-                        ExpressionStatement  [matched]
-                            Expression  [matched]
-                                Variable  [matched]
+                        ExpressionStatement  [matched <- !is.na(inx)]
+                            Expression  [matched <- !is.na(inx)]
+                                TokenOperator  [<- [2370...2372)]
+                                    Variable  [matched]
+                                    TokenNode  [<- [2370...2372)]
+                                    TokenOperator  [! [2373...2374)]
+                                        TokenNode  [! [2373...2374)]
+                                        Expression  [is.na(inx)]
+                                            FunctionCall  [2374...2384)
+                                                Variable  [is.na]
+                                                TokenNode  [( [2379...2380)]
+                                                ArgumentList  [2380...2383)
+                                                    ExpressionArgument  [2380...2383)
+                                                        Expression  [inx]
+                                                            Variable  [inx]
+                                                TokenNode  [) [2383...2384)]
+                        If  []
+                            TokenNode  [if [2390...2392)]
+                            TokenNode  [( [2393...2394)]
+                            Expression  [any(matched)]
+                                FunctionCall  [2394...2406)
+                                    Variable  [any]
+                                    TokenNode  [( [2397...2398)]
+                                    ArgumentList  [2398...2405)
+                                        ExpressionArgument  [2398...2405)
+                                            Expression  [matched]
+                                                Variable  [matched]
+                                    TokenNode  [) [2405...2406)]
+                            TokenNode  [) [2406...2407)]
+                            Scope  []
+                                TokenNode  [{ [2408...2409)]
+                                ExpressionStatement  [`_data`[inx[matched]] <- e[matched]]
+                                    Expression  [`_data`[inx[matched]] <- e[matched]]
+                                        TokenOperator  [<- [2434...2436)]
+                                            Indexer  [2412...2433)
+                                                Variable  [`_data`]
+                                                TokenNode  [[ [2419...2420)]
+                                                ArgumentList  [2420...2432)
+                                                    ExpressionArgument  [2420...2432)
+                                                        Expression  [inx[matched]]
+                                                            Indexer  [2420...2432)
+                                                                Variable  [inx]
+                                                                TokenNode  [[ [2423...2424)]
+                                                                ArgumentList  [2424...2431)
+                                                                    ExpressionArgument  [2424...2431)
+                                                                        Expression  [matched]
+                                                                            Variable  [matched]
+                                                                TokenNode  [] [2431...2432)]
+                                                TokenNode  [] [2432...2433)]
+                                            TokenNode  [<- [2434...2436)]
+                                            Indexer  [2437...2447)
+                                                Variable  [e]
+                                                TokenNode  [[ [2438...2439)]
+                                                ArgumentList  [2439...2446)
+                                                    ExpressionArgument  [2439...2446)
+                                                        Expression  [matched]
+                                                            Variable  [matched]
+                                                TokenNode  [] [2446...2447)]
+                                ExpressionStatement  [`_data` <- data.frame(`_data`)]
+                                    Expression  [`_data` <- data.frame(`_data`)]
+                                        TokenOperator  [<- [2458...2460)]
+                                            Variable  [`_data`]
+                                            TokenNode  [<- [2458...2460)]
+                                            FunctionCall  [2461...2480)
+                                                Variable  [data.frame]
+                                                TokenNode  [( [2471...2472)]
+                                                ArgumentList  [2472...2479)
+                                                    ExpressionArgument  [2472...2479)
+                                                        Expression  [`_data`]
+                                                            Variable  [`_data`]
+                                                TokenNode  [) [2479...2480)]
+                                TokenNode  [} [2486...2487)]
                         If  []
                             TokenNode  [if [2493...2495)]
                             TokenNode  [( [2496...2497)]
@@ -812,5 +881,3 @@ GlobalScope  [Global]
                                         EllipsisArgument  [...]
                                             TokenNode  [... [2985...2988)]
                                     TokenNode  [) [2988...2989)]
-
-UnexpectedToken Token [2493...2495)

--- a/src/R/Core/Test/Parser/ParseExpressionsTest.cs
+++ b/src/R/Core/Test/Parser/ParseExpressionsTest.cs
@@ -342,5 +342,29 @@ namespace Microsoft.R.Core.Test.Parser {
 ";
             ParserTest.VerifyParse(expected, "if(!a()) { }");
         }
+        [Test]
+        public void ParseBangExpression04() {
+            const string expected = @"GlobalScope  [Global]
+    ExpressionStatement  [a <- !b]
+        Expression  [a <- !b]
+            TokenOperator  [<- [2...4)]
+                Variable  [a]
+                TokenNode  [<- [2...4)]
+                TokenOperator  [! [5...6)]
+                    TokenNode  [! [5...6)]
+                    Expression  [b]
+                        Variable  [b]
+    If  []
+        TokenNode  [if [8...10)]
+        TokenNode  [( [10...11)]
+        Expression  [TRUE]
+            LogicalValue  [TRUE [11...15)]
+        TokenNode  [) [15...16)]
+        Scope  []
+            TokenNode  [{ [17...18)]
+            TokenNode  [} [19...20)]
+";
+            ParserTest.VerifyParse(expected, "a <- !b\nif(TRUE) { }");
+        }
     }
 }

--- a/src/R/Core/Test/Parser/ParseFilesTest.cs
+++ b/src/R/Core/Test/Parser/ParseFilesTest.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.R.Core.Test.Utility;
 using Microsoft.UnitTests.Core.XUnit;
+using Xunit;
 
 namespace Microsoft.R.Core.Test.Parser {
     [ExcludeFromCodeCoverage]
@@ -15,14 +16,11 @@ namespace Microsoft.R.Core.Test.Parser {
             _files = files;
         }
 
-        [Test]
-        public void ParseFile_CheckR() {
-            ParseFiles.ParseFile(_files, @"Parser\Check.r");
-        }
-
-        [Test]
-        public void ParseFile_FrametoolsR() {
-            ParseFiles.ParseFile(_files, @"Parser\frametools.r");
+        [CompositeTest]
+        [InlineData("Check.r")]
+        [InlineData("frametools.r")]
+        public void ParseFile(string fileName) {
+            ParseFiles.ParseFile(_files, $@"Parser\{fileName}");
         }
     }
 }

--- a/src/R/Core/Test/Utility/ParserTest.cs
+++ b/src/R/Core/Test/Utility/ParserTest.cs
@@ -11,16 +11,13 @@ using Microsoft.R.Core.Utility;
 
 namespace Microsoft.R.Core.Test.Utility {
     [ExcludeFromCodeCoverage]
-    public static class ParserTest
-    {
-        public static void VerifyParse(string expected, string expression)
-        {
+    public static class ParserTest {
+        public static void VerifyParse(string expected, string expression) {
             var ast = RParser.Parse(new TextStream(expression));
             CompareTrees(expected, ast);
-         }
+        }
 
-        public static void CompareTrees(string expected, AstRoot actualTree)
-        {
+        public static void CompareTrees(string expected, AstRoot actualTree) {
             var astWriter = new AstWriter();
             var actual = astWriter.WriteTree(actualTree);
 

--- a/src/R/Editor/Impl/Completions/Providers/ParameterNameCompletionProvider.cs
+++ b/src/R/Editor/Impl/Completions/Providers/ParameterNameCompletionProvider.cs
@@ -49,7 +49,10 @@ namespace Microsoft.R.Editor.Completions.Providers {
             // Collect parameter names from all signatures
             IEnumerable<KeyValuePair<string, IArgumentInfo>> arguments = new Dictionary<string, IArgumentInfo>();
             foreach (var signature in functionInfo.Signatures) {
-                var args = signature.Arguments.ToDictionary(x => x.Name);
+                var args = new Dictionary<string, IArgumentInfo>();
+                foreach (var arg in signature.Arguments.Where(x => !string.IsNullOrEmpty(x.Name))) {
+                    args[arg.Name] = arg;
+                }
                 arguments = arguments.Union(args);
             }
 

--- a/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
+++ b/src/R/Editor/Impl/Data/WorkspaceVariableProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.R.Editor.Data {
         private readonly Dictionary<string, IRSessionDataObject> _topLevelVariables = new Dictionary<string, IRSessionDataObject>();
         private bool _updating;
 
-        public WorkspaceVariableProvider(IServiceContainer services) : 
+        public WorkspaceVariableProvider(IServiceContainer services) :
             base(services.GetService<IRInteractiveWorkflowProvider>()) {
             _services = services;
         }
@@ -90,16 +90,16 @@ namespace Microsoft.R.Editor.Data {
 
                 IReadOnlyList<IREvaluationResultInfo> infoList = null;
 
-                async Task FillInfoList() {
+                Task.Run(async () => {
                     try {
-                        var result = await Session.TryEvaluateAndDescribeAsync(memberName, None, null);
+                        var result = await Session.TryEvaluateAndDescribeAsync(memberName, REvaluationResultProperties.None, null);
                         if (!(result is IRErrorInfo)) {
-                            infoList = await Session.DescribeChildrenAsync(REnvironments.GlobalEnv, memberName, HasChildrenProperty | AccessorKindProperty, null, _maxResults);
+                            infoList = await Session.DescribeChildrenAsync(REnvironments.GlobalEnv,
+                                memberName, HasChildrenProperty | AccessorKindProperty, null, _maxResults);
                         }
-                    } catch (Exception ex) when (!ex.IsCriticalException()) { }
-                }
 
-                _services.Tasks().Wait(FillInfoList(), CancellationToken.None, _maxWaitTime);
+                    } catch (Exception ex) when (!ex.IsCriticalException()) { }
+                }).Wait(_maxWaitTime);
 
                 if (infoList != null) {
                     return infoList

--- a/src/R/Editor/Impl/Extensions/AstRootExtensions.cs
+++ b/src/R/Editor/Impl/Extensions/AstRootExtensions.cs
@@ -208,7 +208,7 @@ namespace Microsoft.R.Editor {
         /// </summary>
         public static bool IsInObjectMemberName(this ITextProvider textProvider, int position) {
             if (position > 0) {
-                for (var i = position - 1; i >= 0; i--) {
+                for (var i = position - 1; i >= 0 && i < textProvider.Length; i--) {
                     var ch = textProvider[i];
 
                     if (ch == '$' || ch == '@') {

--- a/src/R/Editor/Impl/Functions/PackageInfo.cs
+++ b/src/R/Editor/Impl/Functions/PackageInfo.cs
@@ -59,7 +59,7 @@ namespace Microsoft.R.Editor.Functions {
                     if (!_fs.DirectoryExists(dir)) {
                         _fs.CreateDirectory(dir);
                     }
-                    using (var file = new FileStream(filePath, FileMode.Truncate, FileAccess.Write)) {
+                    using (var file = new FileStream(filePath, FileMode.Create, FileAccess.Write)) {
                         using (var sw = new StreamWriter(file)) {
                             sw.WriteLine(VersionString);
                             foreach (var f in _functions) {

--- a/src/R/Editor/Impl/RData/Parser/RdFunctionSignature.cs
+++ b/src/R/Editor/Impl/RData/Parser/RdFunctionSignature.cs
@@ -82,8 +82,7 @@ namespace Microsoft.R.Editor.RData.Parser {
                     var range = TextRange.FromBounds(fragmentStart, fragmentEnd);
                     var fragment = context.TextProvider.GetText(range);
                     sb.Append(fragment);
-                }
-                else {
+                } else {
                     break; // Something went wrong;
                 }
             }
@@ -104,7 +103,7 @@ namespace Microsoft.R.Editor.RData.Parser {
                 }
             }
             // Should be past \method{...}{...}. Now skip signature
-            var bc = new BraceCounter<char>(new [] { '(', ')' });
+            var bc = new BraceCounter<char>(new[] { '(', ')' });
             for (var i = context.Tokens[index - 1].End; i < context.TextProvider.Length; i++) {
                 if (bc.CountBrace(context.TextProvider[i])) {
                     if (bc.Count == 0) {
@@ -190,13 +189,11 @@ namespace Microsoft.R.Editor.RData.Parser {
                             argDefaultValue = nameArg.DefaultValue != null ?
                                  RdText.CleanRawRdText(context.TextProvider.GetText(nameArg.DefaultValue)) : string.Empty;
                         } else {
-                            if (arg is MissingArgument) {
-                                argName = string.Empty;
+                            if (arg is EllipsisArgument) {
+                                argName = "...";
+                                isEllipsis = true;
                             } else {
-                                if (arg is EllipsisArgument) {
-                                    argName = "...";
-                                    isEllipsis = true;
-                                }
+                                argName = string.Empty;
                             }
                         }
                     }

--- a/src/R/Wpf/Impl/CommonResources.xaml
+++ b/src/R/Wpf/Impl/CommonResources.xaml
@@ -598,6 +598,57 @@
                     <Setter Property="OverlayVisibility" Value="Collapsed"/>
                 </MultiDataTrigger.Setters>
             </MultiDataTrigger>
+            
+            <!-- Containers -->
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=IsRunning}" Value="True" />
+                    <Condition Binding="{Binding Path=IsConnected}" Value="True" />
+                    <Condition Binding="{Binding Path=IsActive}" Value="True" />
+                    <Condition Binding="{Binding Path=IsContainer}" Value="True" />
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StructurePublic}"/>
+                    <Setter Property="OverlayMoniker" Value="{x:Static imagecatalog:KnownMonikers.StatusOK}"/>
+                    <Setter Property="OverlayVisibility" Value="Visible"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=IsRunning}" Value="False" />
+                    <Condition Binding="{Binding Path=IsConnected}" Value="True" />
+                    <Condition Binding="{Binding Path=IsActive}" Value="True" />
+                    <Condition Binding="{Binding Path=IsContainer}" Value="True" />
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StructurePublic}"/>
+                    <Setter Property="OverlayMoniker" Value="{x:Static imagecatalog:KnownMonikers.StatusWarning}"/>
+                    <Setter Property="OverlayVisibility" Value="Visible"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=IsRunning}" Value="False" />
+                    <Condition Binding="{Binding Path=IsConnected}" Value="False" />
+                    <Condition Binding="{Binding Path=IsActive}" Value="True" />
+                    <Condition Binding="{Binding Path=IsContainer}" Value="True" />
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StructurePublic}"/>
+                    <Setter Property="OverlayMoniker" Value="{x:Static imagecatalog:KnownMonikers.StatusError}"/>
+                    <Setter Property="OverlayVisibility" Value="Visible"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=IsContainer}" Value="True" />
+                    <Condition Binding="{Binding Path=IsActive}" Value="False" />
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.StructurePublic}"/>
+                    <Setter Property="OverlayVisibility" Value="Collapsed"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
         </Style.Triggers>
     </Style>
 </ResourceDictionary>

--- a/src/Windows/Markdown/Editor/Impl/Preview/Code/RCodeEvaluator.cs
+++ b/src/Windows/Markdown/Editor/Impl/Preview/Code/RCodeEvaluator.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Markdown.Editor.Preview.Code {
             var blocksArray = blocks.ToArray();
             await TaskUtilities.SwitchToBackgroundThread();
 
-            foreach (var block in blocksArray.Where(b => b.State == CodeBlockState.Created)) {
+            foreach (var block in blocksArray.Where(b => b.State == CodeBlockState.Created && b.Eval)) {
                 await EvaluateBlockAsync(block, ct);
             }
         }

--- a/src/Windows/Markdown/Editor/Test/Files/Preview/01.rmd.html
+++ b/src/Windows/Markdown/Editor/Test/Files/Preview/01.rmd.html
@@ -1,4 +1,4 @@
 <link rel='stylesheet' type='text/css' href='http://bootswatch.com/cerulean/bootstrap.min.css' /><h1>Cars</h1>
-<div id='rcode_0_-2060070398'></div>
+<div id='rcode_0_2234896898'></div>
 <p id="pragma-line-10">Plots</p>
 <div id='rcode_1_153043671'></div>

--- a/src/Windows/Markdown/Editor/Test/Files/Preview/03.rmd.html
+++ b/src/Windows/Markdown/Editor/Test/Files/Preview/03.rmd.html
@@ -1,4 +1,4 @@
-<code style='white-space: pre-wrap; background-color: rgba(0, 0, 0, 0.04); display: block; '>  ```{r}
+<code style='white-space: pre-wrap; display: block; background-color: rgba(0, 0, 0, 0.04);'>  ```{r}
   summary(cars)
   ```</code>
 <p id="pragma-line-4">Plots</p>

--- a/src/Windows/Markdown/Editor/Test/Files/Preview/04.rmd
+++ b/src/Windows/Markdown/Editor/Test/Files/Preview/04.rmd
@@ -1,0 +1,9 @@
+  ```{r, eval=F}
+  summary(cars)
+  ```
+
+Plots
+
+```{r echo = FALSE}
+plot(cars)
+```

--- a/src/Windows/Markdown/Editor/Test/Files/Preview/04.rmd.html
+++ b/src/Windows/Markdown/Editor/Test/Files/Preview/04.rmd.html
@@ -1,0 +1,5 @@
+<code style='white-space: pre-wrap; display: block; background-color: rgba(0, 0, 0, 0.04);'>  ```{r, eval=F}
+  summary(cars)
+  ```</code>
+<p id="pragma-line-4">Plots</p>
+<div id='rcode_0_153043671'></div>

--- a/src/Windows/Markdown/Editor/Test/Microsoft.Markdown.Editor.Test.csproj
+++ b/src/Windows/Markdown/Editor/Test/Microsoft.Markdown.Editor.Test.csproj
@@ -45,6 +45,8 @@
   <ItemGroup>
     <Content Include="Files\Preview\01.rmd.html" />
     <Content Include="Files\Preview\02.rmd.html" />
+    <Content Include="Files\Preview\03.rmd.html" />
+    <Content Include="Files\Preview\04.rmd.html" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\..\UnitTests\app.config">
@@ -52,6 +54,7 @@
     </None>
     <None Include="Files\Classification\01.rmd" />
     <None Include="Files\Classification\01.rmd.colors" />
+    <None Include="Files\Preview\04.rmd" />
     <None Include="Files\Preview\03.rmd" />
     <None Include="Files\Preview\02.rmd" />
     <None Include="Files\Preview\01.rmd" />

--- a/src/Windows/Markdown/Editor/Test/Preview/RendererTest.cs
+++ b/src/Windows/Markdown/Editor/Test/Preview/RendererTest.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Markdown.Editor.Test.Preview {
         [InlineData("01.rmd")]
         [InlineData("02.rmd")]
         [InlineData("03.rmd")]
+        [InlineData("04.rmd")]
         public void StaticRender(string fileName) {
             var source = _files.LoadDestinationFile(Path.Combine(_files.DestinationPath, _folder, fileName));
             var renderer = new DocumentRenderer(nameof(RendererTest), _shell.Services);

--- a/src/Windows/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
+++ b/src/Windows/R/Components/Impl/ConnectionManager/Implementation/View/ConnectionManagerControl.xaml
@@ -284,7 +284,7 @@
                                                 Grayscale="{Binding Path=IsUserCreated, Converter={x:Static rwpf:Converters.Not}}" />
                         </Button>
 
-                        <ContentPresenter Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="6"
+                        <ContentPresenter Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="5"
                                           ContentTemplate="{StaticResource EditConnectionDataTemplate}"
                                           Visibility="{Binding Path=IsEditing, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}"/>
 
@@ -341,18 +341,24 @@
             <!-- Add button and settings panel -->
             <DockPanel DockPanel.Dock="Top" Margin="16,0,0,0"
                        Background="{DynamicResource {x:Static rwpf:Brushes.ToolWindowBackgroundBrushKey}}">
-                <WrapPanel DockPanel.Dock="Top" Margin="1,4,0,6">
-                    <Button x:Name="ToggleButtonAdd" Style="{StaticResource HyperlinkDownArrowButton}"
+                <Grid HorizontalAlignment="Stretch" DockPanel.Dock="Top" Margin="1,4,0,6">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+                    <Button x:Name="ToggleButtonAdd" Grid.Column="0" Style="{StaticResource HyperlinkDownArrowButton}"
                             IsEnabled="{Binding Path=IsEditingNew, Converter={x:Static rwpf:Converters.Not}}"
                             Content="{x:Static components:Resources.ConnectionManager_Add}"
+                            HorizontalAlignment="Left"
                             AutomationProperties.Name="{x:Static components:Resources.ConnectionManager_Add}"
                             Click="ButtonAdd_Click" />
-                    <Button x:Name="ButtonShowContainers" Margin="6,0,0,0" MinWidth="75" MinHeight="23"
+                    <Button x:Name="ButtonShowContainers" Grid.Column="1" Style="{StaticResource HyperlinkButton}"
+                            Margin="0,0,6,0" MinWidth="75" MinHeight="23"
                             VerticalAlignment="Center" Click="ButtonShowContainers_Click" 
-                            Style="{StaticResource ToolWindowButtonStyle}"
+                            HorizontalAlignment="Right"
                             Content="{x:Static components:Resources.ConnectionManager_ShowContainers}" 
                             AutomationProperties.Name="{x:Static components:Resources.ConnectionManager_ShowContainers}" />
-                </WrapPanel>
+                </Grid>
 
                 <!-- Add options panel -->
                 <Border DockPanel.Dock="Top" Margin="0,0,6,6" Style="{StaticResource InputBorderStyle}"
@@ -377,7 +383,7 @@
             <ListBox x:Name="LocalDockerList"
                      DockPanel.Dock="Top" Style="{StaticResource ConnectionsListBox}" Margin="11,0,6,16" ItemsSource="{Binding Path=LocalDockerConnections}" 
                      Visibility="{Binding ElementName=ToggleButtonLocalDockerConnections, Path=IsExpanded, Converter={x:Static rwpf:Converters.TrueIsNotCollapsed}}"/>
-            
+
             <!-- Remote connections header -->
             <controls:ExpandCollapseButton x:Name="ToggleButtonRemoteConnections" Style="{StaticResource ExpandCollapseButtonRemoteConnectionsStyle}" DockPanel.Dock="Top" />
 

--- a/src/Windows/R/Components/Impl/ConnectionManager/Implementation/View/DesignTime/DesignTimeConnectionViewModel.cs
+++ b/src/Windows/R/Components/Impl/ConnectionManager/Implementation/View/DesignTime/DesignTimeConnectionViewModel.cs
@@ -21,6 +21,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.View.DesignTim
         public bool IsTestConnectionSucceeded { get; set; }
         public string TestConnectionFailedText { get; set; }
         public bool IsRemote { get; set; }
+        public bool IsContainer { get; set; }
 
         public string OriginalName => Name;
         public string NameTextBoxTooltip => string.Empty;

--- a/src/Windows/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionViewModel.cs
+++ b/src/Windows/R/Components/Impl/ConnectionManager/Implementation/ViewModel/ConnectionViewModel.cs
@@ -31,6 +31,7 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.ViewModel {
         private CancellationTokenSource _testingConnectionCts;
         private bool _isTestConnectionSucceeded;
         private bool _isRemote;
+        private bool _isContainer;
         private bool _hasChanges;
         private bool _isValid;
         private bool _isNameValid;
@@ -118,6 +119,11 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.ViewModel {
         public bool IsRemote {
             get { return _isRemote; }
             private set { SetProperty(ref _isRemote, value); }
+        }
+
+        public bool IsContainer {
+            get { return _isContainer; }
+            private set { SetProperty(ref _isContainer, value); }
         }
 
         public bool IsValid {
@@ -244,9 +250,15 @@ namespace Microsoft.R.Components.ConnectionManager.Implementation.ViewModel {
             }
 
             if (IsValid && uri != null) {
-                IsRemote = !(uri.IsAbsoluteUri && uri.IsFile);
+                IsContainer = uri.IsAbsoluteUri && uri.IsLoopback && !uri.IsFile;
             } else {
-                IsRemote = true;
+                IsContainer = false;
+            }
+
+            if (IsValid && uri != null) {
+                IsRemote = !IsContainer && uri.IsAbsoluteUri && !uri.IsFile;
+            } else {
+                IsRemote = false;
             }
         }
 

--- a/src/Windows/R/Components/Impl/Resources.Designer.cs
+++ b/src/Windows/R/Components/Impl/Resources.Designer.cs
@@ -331,7 +331,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Default entry for the running local Docker container cannot be deleted. It will be removed when container is stopped or deleted..
+        ///   Looks up a localized string similar to Default entry for the running local container cannot be deleted. It will be removed when container is stopped or deleted..
         /// </summary>
         public static string ConnectionManager_DeleteLocalDockerDisabledTooltip {
             get {
@@ -367,7 +367,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit local Docker connection &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Edit local container connection &apos;{0}&apos;.
         /// </summary>
         public static string ConnectionManager_EditLocalDockerTooltip_Format {
             get {
@@ -461,7 +461,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local Docker.
+        ///   Looks up a localized string similar to Local Running Containers.
         /// </summary>
         public static string ConnectionManager_LocalDockerConnections {
             get {
@@ -470,7 +470,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local Docker Connections.
+        ///   Looks up a localized string similar to Local Containers Connections.
         /// </summary>
         public static string ConnectionManager_LocalDockerConnections_Tooltip {
             get {
@@ -612,7 +612,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Containers.
+        ///   Looks up a localized string similar to Containers....
         /// </summary>
         public static string ConnectionManager_ShowContainers {
             get {
@@ -900,7 +900,7 @@ namespace Microsoft.R.Components {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local Docker Containers.
+        ///   Looks up a localized string similar to Local Containers.
         /// </summary>
         public static string ContainerManager_LocalDocker {
             get {

--- a/src/Windows/R/Components/Impl/Resources.resx
+++ b/src/Windows/R/Components/Impl/Resources.resx
@@ -331,10 +331,10 @@
     <value>Local R installations</value>
   </data>
   <data name="ConnectionManager_LocalDockerConnections" xml:space="preserve">
-    <value>Local Docker</value>
+    <value>Local Running Containers</value>
   </data>
   <data name="ConnectionManager_LocalDockerConnections_Tooltip" xml:space="preserve">
-    <value>Local Docker Connections</value>
+    <value>Local Containers Connections</value>
   </data>
   <data name="ConnectionManager_RemoteConnections" xml:space="preserve">
     <value>Remote</value>
@@ -349,7 +349,7 @@
     <value>Edit local connection '{0}'</value>
   </data>
   <data name="ConnectionManager_EditLocalDockerTooltip_Format" xml:space="preserve">
-    <value>Edit local Docker connection '{0}'</value>
+    <value>Edit local container connection '{0}'</value>
   </data>
   <data name="ConnectionManager_EditRemoteTooltip_Format" xml:space="preserve">
     <value>Edit remote connection '{0}'</value>
@@ -370,7 +370,7 @@
     <value>Add Connection</value>
   </data>
   <data name="ConnectionManager_ShowContainers" xml:space="preserve">
-    <value>Containers</value>
+    <value>Containers...</value>
   </data>
   <data name="ConnectionManager_Save" xml:space="preserve">
     <value>Save</value>
@@ -459,7 +459,7 @@ If you want to delete all data on the remote machine you must delete your user p
 To start working with containers, run Docker for Windows and restart Visual Studio.</value>
   </data>
   <data name="ContainerManager_LocalDocker" xml:space="preserve">
-    <value>Local Docker Containers</value>
+    <value>Local Containers</value>
   </data>
   <data name="ContainerManager_CreateLocalDocker" xml:space="preserve">
     <value>Create</value>
@@ -605,7 +605,7 @@ All data will be lost. Do you wish to proceed?</value>
     <value>Entry for the automatically detected local R cannot be deleted. It will be removed when this R version is uninstalled.</value>
   </data>
   <data name="ConnectionManager_DeleteLocalDockerDisabledTooltip" xml:space="preserve">
-    <value>Default entry for the running local Docker container cannot be deleted. It will be removed when container is stopped or deleted.</value>
+    <value>Default entry for the running local container cannot be deleted. It will be removed when container is stopped or deleted.</value>
   </data>
   <data name="ConnectionManager_Connected" xml:space="preserve">
     <value>Connected</value>

--- a/src/Windows/R/Components/Test/Fixtures/RComponentServicesFixture.cs
+++ b/src/Windows/R/Components/Test/Fixtures/RComponentServicesFixture.cs
@@ -10,6 +10,8 @@ using Microsoft.R.Components.StatusBar;
 using Microsoft.R.Components.Test.Fakes.StatusBar;
 using Microsoft.R.Components.Test.StubFactories;
 using Microsoft.R.Components.Test.Stubs;
+using Microsoft.R.Containers;
+using Microsoft.R.Containers.Docker;
 using Microsoft.R.Host.Client;
 using Microsoft.R.Interpreters;
 using Microsoft.UnitTests.Core.XUnit;
@@ -40,7 +42,8 @@ namespace Microsoft.R.Components.Test.Fixtures {
                 .AddWindowsRComponentsServices()
                 .AddService<IStatusBar, TestStatusBar>()
                 .AddService<IRPlotExportDialog, TestPlotExportDialog>()
-                .AddService(RSettingsStubFactory.CreateForExistingRPath(testInput.FileSytemSafeName));
+                .AddService(RSettingsStubFactory.CreateForExistingRPath(testInput.FileSytemSafeName))
+                .AddService<IContainerService, WindowsDockerService>();
         }
     }
 }

--- a/src/Windows/R/Components/Test/Microsoft.R.Components.Test.csproj
+++ b/src/Windows/R/Components/Test/Microsoft.R.Components.Test.csproj
@@ -153,6 +153,10 @@
       <Project>{9de5e0b5-c8bd-482c-85c3-b8e20f08453b}</Project>
       <Name>Microsoft.Common.Wpf</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\Containers\Impl\Microsoft.R.Containers.csproj">
+      <Project>{baea19c5-e1f7-4580-ae19-9fb3c890570b}</Project>
+      <Name>Microsoft.R.Containers</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\Host\Client\Impl\Microsoft.R.Host.Client.csproj">
       <Project>{b81d01eb-ad08-4929-be99-6623af523a23}</Project>
       <Name>Microsoft.R.Host.Client</Name>
@@ -172,6 +176,10 @@
     <ProjectReference Include="..\..\..\..\UnitTests\Core\Impl\Microsoft.UnitTests.Core.csproj">
       <Project>{5ef2ad64-d6fe-446b-b350-8c7f0df0834d}</Project>
       <Name>Microsoft.UnitTests.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Containers\Impl\Microsoft.R.Containers.Windows.csproj">
+      <Project>{8ed6ef0a-08a9-4f77-8ec1-f1630aad2ddb}</Project>
+      <Name>Microsoft.R.Containers.Windows</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\Core\Impl\Microsoft.R.Common.Core.Windows.csproj">
       <Project>{01e3d8c2-9c24-492b-b13b-c6d7068b6bf8}</Project>

--- a/src/Windows/R/Editor/Impl/ContentType/TextViewExtensions.cs
+++ b/src/Windows/R/Editor/Impl/ContentType/TextViewExtensions.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Languages.Editor.Text;
 using Microsoft.R.Components.ContentTypes;
 using Microsoft.R.Core.Tokens;
+using Microsoft.R.Editor.Document;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 
@@ -54,7 +56,7 @@ namespace Microsoft.R.Editor {
                         SpanTrackingMode.EdgeInclusive,
                         textView.TextBuffer
                     )) {
-                        spans.Add(upperSpan);
+                        spans.Add(lowerSpan);
                         newStart = upperSpan.End;
                     }
                 }


### PR DESCRIPTION
- Fix tests (added container service to the fixture)

#4031 Potential NRE in PackageIndex 
- most probably index was still being built when session got disposed

#4050 RxSpark function help wrong 
- old issue, [[ and ]] in RD confused parser. Fixed and added test.

#4036 Change local Docker connection icon in Workspaces 
- changed style
- aligned `Containers...` to the right and made it hyperlink to match `Add`

#4046 Rmarkdown preview should respect code chunk options 
- handle eval
- update test baselines

#4051 Bug in parsing of scopes 
- parser continued past line break
- do terminate expression parsing at the line break by returning proper last operation type
- added test

#4042 Hang in function quick info 
- could not repro, but added reentrancy check