### PR TITLE
Fix #4034: VS crashes if docker is stopped while Vs is running.

### DIFF
--- a/src/R/Components/Impl/Containers/Implementation/ContainerManager.cs
+++ b/src/R/Components/Impl/Containers/Implementation/ContainerManager.cs
@@ -135,14 +135,15 @@ EXPOSE 5444";
 
         private async Task UpdateContainersOnceAsync(CancellationToken token) {
             try {
-                UpdateContainers(await _containerService.ListContainersAsync(true, token)); 
-            } catch (OperationCanceledException) {
+                UpdateContainers(await _containerService.ListContainersAsync(true, token));
             } catch (ContainerServiceNotInstalledException) {
                 _containersChangedCountdown.Reset();
                 Status = ContainersStatus.NotInstalled;
             } catch (ContainerServiceNotRunningException) {
                 _containersChangedCountdown.Reset();
                 Status = ContainersStatus.Stopped;
+            } catch (ContainerException) {
+            } catch (OperationCanceledException) {
             }
         }
 


### PR DESCRIPTION
`ContainerException` is swallowed.