### PR TITLE
4119, 4030

### DIFF
--- a/src/R/Editor/Impl/Completions/Providers/RoxygenTagCompletionProvider.cs
+++ b/src/R/Editor/Impl/Completions/Providers/RoxygenTagCompletionProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Common.Core;
 using Microsoft.Common.Core.Imaging;
 using Microsoft.Languages.Editor.Completions;
 using Microsoft.R.Editor.Roxygen;
@@ -23,13 +24,13 @@ namespace Microsoft.R.Editor.Completions.Providers {
             var line = context.EditorBuffer.CurrentSnapshot.GetLineFromPosition(context.Position);
             var rawLineText = line.GetText();
             var lineText = rawLineText.TrimStart();
+            var positionInLine = context.Position - line.Start;
+            var typedText = lineText.TextBeforePosition(positionInLine);
 
-            // Check that we are inside the Roxygen comment
-            if (!lineText.StartsWith("#'") || context.Position < rawLineText.Length - lineText.Length + 2) {
-                return completions;
+            // Check that we are inside the Roxygen comment AND just typed character is @
+            if (lineText.StartsWith("#'") && positionInLine >= 2 && typedText.StartsWithOrdinal("@")) {
+                completions.AddRange(RoxygenKeywords.Keywords.Select(k => new EditorCompletionEntry(k, k, string.Empty, _glyph)));
             }
-
-            completions.AddRange(RoxygenKeywords.Keywords.Select(k => new EditorCompletionEntry(k, k, string.Empty, _glyph)));
             return completions;
         }
     }

--- a/src/R/Editor/Impl/Extensions/StringExtensions.cs
+++ b/src/R/Editor/Impl/Extensions/StringExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.R.Editor {
         }
 
         public static string RemoveBackticks(this string name) {
-            if (!string.IsNullOrEmpty(name) && name.Length >= 2 && name[0] == '`' && name[name.Length-1] == '`') {
+            if (!string.IsNullOrEmpty(name) && name.Length >= 2 && name[0] == '`' && name[name.Length - 1] == '`') {
                 return name.Substring(1, name.Length - 2);
             }
             return name;
@@ -45,6 +45,15 @@ namespace Microsoft.R.Editor {
             }
 
             return TextRange.FromBounds(start, end + 1);
+        }
+
+        /// <summary>
+        /// Retrieves text between given position and the nearest preceding whitespace.
+        /// </summary>
+        public static string TextBeforePosition(this string s, int position) {
+            var i = position - 1;
+            for (; i >= 0 && !char.IsWhiteSpace(s[i]); i--) { }
+            return s.Substring(i + 1, position - i - 1);
         }
     }
 }

--- a/src/R/Editor/Impl/Functions/PackageIndex.cs
+++ b/src/R/Editor/Impl/Functions/PackageIndex.cs
@@ -79,7 +79,9 @@ namespace Microsoft.R.Editor.Functions {
 
         private void OnBrokerStateChanged(object sender, BrokerStateChangedEventArgs e) {
             if (e.IsConnected) {
-                BuildIndexAsync().DoNotWait();
+                UpdateInstalledPackagesAsync().DoNotWait();
+            } else {
+                _updatePending = true;
             }
         }
 

--- a/src/Windows/R/Editor/Impl/Completions/RCompletionSource.cs
+++ b/src/Windows/R/Editor/Impl/Completions/RCompletionSource.cs
@@ -80,7 +80,7 @@ namespace Microsoft.R.Editor.Completions {
             var providers = _completionEngine.GetCompletionForLocation(context);
 
             // Position is in R as is the applicable spa, so no need to map down
-            var applicableSpan = GetApplicableSpan(position, session);
+            var applicableSpan = GetApplicableSpan(context, session);
             if (applicableSpan.HasValue) {
                 var snapshot = context.EditorBuffer.CurrentSnapshot.As<ITextSnapshot>();
                 var trackingSpan = snapshot.CreateTrackingSpan(applicableSpan.Value, SpanTrackingMode.EdgeInclusive);
@@ -113,7 +113,7 @@ namespace Microsoft.R.Editor.Completions {
         /// tracking span as user types and filter completion session
         /// based on the data inside the tracking span.
         /// </summary>
-        private Span? GetApplicableSpan(int position, ICompletionSession session) {
+        private Span? GetApplicableSpan(IRIntellisenseContext context, ICompletionSession session) {
             var selectedSpans = session.TextView.Selection.SelectedSpans;
             if (selectedSpans.Count == 1 && selectedSpans[0].Span.Length > 0) {
                 var spans = session.TextView.MapDownToR(selectedSpans[0]);
@@ -124,9 +124,17 @@ namespace Microsoft.R.Editor.Completions {
             }
 
             var snapshot = _textBuffer.CurrentSnapshot;
-            var line = snapshot.GetLineFromPosition(position);
+            var line = snapshot.GetLineFromPosition(context.Position);
             var lineText = snapshot.GetText(line.Start, line.Length);
-            var linePosition = position - line.Start;
+            var linePosition = context.Position - line.Start;
+
+            // If completion is in comment, such as in Roxygen, 
+            // allow any text since it is no longer language-specific
+            var document = context.EditorBuffer.GetEditorDocument<IREditorDocument>();
+            if(document.IsPositionInComment(context.Position)) {
+                var typedText = lineText.TextBeforePosition(linePosition);
+                return new Span(context.Position - typedText.Length, typedText.Length);
+            }
 
             var start = 0;
             var end = line.Length;
@@ -151,7 +159,7 @@ namespace Microsoft.R.Editor.Completions {
                 return new Span(start + line.Start, end - start);
             }
 
-            return new Span(position, 0);
+            return new Span(context.Position, 0);
         }
 
         public void Dispose() { }

--- a/src/Windows/R/Editor/Test/Completions/RCompletionTestUtilities.cs
+++ b/src/Windows/R/Editor/Test/Completions/RCompletionTestUtilities.cs
@@ -5,12 +5,15 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Common.Core.Services;
 using Microsoft.Languages.Core.Text;
+using Microsoft.Languages.Editor.Text;
 using Microsoft.R.Components.ContentTypes;
 using Microsoft.R.Core.Parser;
 using Microsoft.R.Editor.Completions;
+using Microsoft.R.Editor.Document;
 using Microsoft.VisualStudio.Editor.Mocks;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
+using NSubstitute;
 
 namespace Microsoft.R.Editor.Test.Completions {
     [ExcludeFromCodeCoverage]
@@ -26,6 +29,10 @@ namespace Microsoft.R.Editor.Test.Completions {
 
             var textBuffer = new TextBufferMock(content, RContentTypeDefinition.ContentType);
             var textView = new TextViewMock(textBuffer, caretPosition);
+
+            var document = Substitute.For<IREditorDocument>();
+            document.EditorTree.AstRoot.Returns(ast);
+            textBuffer.AddService(document);
 
             if (selectedRange != null) {
                 textView.Selection.Select(new SnapshotSpan(textBuffer.CurrentSnapshot, selectedRange.Start, selectedRange.Length), false);

--- a/src/Windows/R/Editor/Test/Roxygen/RoxygenCompletionTest.cs
+++ b/src/Windows/R/Editor/Test/Roxygen/RoxygenCompletionTest.cs
@@ -11,6 +11,7 @@ using Microsoft.R.Editor.Roxygen;
 using Microsoft.R.Editor.Test.Completions;
 using Microsoft.UnitTests.Core.XUnit;
 using Microsoft.VisualStudio.Language.Intellisense;
+using Xunit;
 
 namespace Microsoft.R.Editor.Test.Roxygen {
     [ExcludeFromCodeCoverage]
@@ -33,28 +34,37 @@ namespace Microsoft.R.Editor.Test.Roxygen {
             filtered.Should().BeEmpty();
         }
 
-        [Test]
-        public void Keywords02() {
+        [CompositeTest]
+        [InlineData("#  f", 1)]
+        [InlineData("#'  f", 2)]
+        public void Keywords02(string content, int start) {
+            for (var i = start; i < content.Length; i++) {
             var completionSets = new List<CompletionSet>();
-            RCompletionTestUtilities.GetCompletions(_services, "#  ", 1, completionSets);
-            completionSets.Should().ContainSingle();
-            completionSets.First().Completions.Should().BeEmpty();
+                RCompletionTestUtilities.GetCompletions(_services, content, i, completionSets);
+                completionSets.Should().ContainSingle();
+                completionSets.First().Completions.Should().BeEmpty();
+            }
         }
+
 
         [Test]
         public void Keywords03() {
             var completionSets = new List<CompletionSet>();
-            RCompletionTestUtilities.GetCompletions(_services, "#'  ", 1, completionSets);
-            completionSets.Should().ContainSingle();
-            completionSets.First().Completions.Should().BeEmpty();
-        }
-
-        [Test]
-        public void Keywords04() {
-            var completionSets = new List<CompletionSet>();
-            RCompletionTestUtilities.GetCompletions(_services, "#'  ", 2, completionSets);
+            RCompletionTestUtilities.GetCompletions(_services, "#' @", 4, completionSets);
             completionSets.Should().ContainSingle();
             completionSets.First().Completions.Should().HaveCount(RoxygenKeywords.Keywords.Length);
+        }
+
+        [CompositeTest]
+        [InlineData("#' @alia", 7)]
+        public void Filtering(string content, int start) {
+            for (var i = start; i < content.Length; i++) {
+                var completionSets = new List<CompletionSet>();
+                RCompletionTestUtilities.GetCompletions(_services, content, i, completionSets);
+                completionSets.Should().ContainSingle();
+                completionSets[0].Filter();
+                completionSets[0].Completions.Should().ContainSingle();
+            }
         }
     }
 }


### PR DESCRIPTION
 #4119 Roxygen IntelliSense does not incrementally search
- limit trigger to `@`
- include '@' in the applicable span in comments (normally search stops on non-identifier chars)
- add tests

#4030 Update package index on connection change 
- update list of packages when connection changes
