### PR TITLE
Update MainThreadAwaiter

### DIFF
--- a/src/Common/Core/Impl/Threading/IMainThread.cs
+++ b/src/Common/Core/Impl/Threading/IMainThread.cs
@@ -15,7 +15,11 @@ namespace Microsoft.Common.Core.Threading {
         /// Posts cancellable action on UI thread.
         /// </summary>
         /// <param name="action"></param>
-        /// <param name="cancellationToken"></param>
-        void Post(Action action, CancellationToken cancellationToken = default(CancellationToken));
+        void Post(Action action);
+
+        /// <summary>
+        /// Creates main thread awaiter implementation
+        /// </summary>
+        IMainThreadAwaiter CreateMainThreadAwaiter(CancellationToken cancellationToken);
     }
 }

--- a/src/Common/Core/Impl/Threading/IMainThreadAwaiter.cs
+++ b/src/Common/Core/Impl/Threading/IMainThreadAwaiter.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.Common.Core.Threading {
+    public interface IMainThreadAwaiter {
+        bool IsCompleted { get; }
+        void OnCompleted(Action continuation);
+        void GetResult();
+    }
+}

--- a/src/Common/Core/Impl/Threading/MainThreadExtensions.cs
+++ b/src/Common/Core/Impl/Threading/MainThreadExtensions.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Common.Core.Threading {
             }
         }
 
-        public static void ExecuteOrPost(this IMainThread mainThread, Action action, CancellationToken cancellationToken = default(CancellationToken)) {
+        public static void ExecuteOrPost(this IMainThread mainThread, Action action) {
             if (mainThread.CheckAccess()) {
                 action();
             } else {
-                mainThread.Post(action, cancellationToken);
+                mainThread.Post(action);
             }
         }
 

--- a/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
+++ b/src/Package/Impl/Microsoft.VisualStudio.R.Package.csproj
@@ -254,6 +254,7 @@
     </Compile>
     <Compile Include="Shell\CompositionCatalog.cs" />
     <Compile Include="Shell\Services\VsApplication.cs" />
+    <Compile Include="Shell\Services\VsMainThreadAwaiter.cs" />
     <Compile Include="Shell\Services\VsOutputService.cs" />
     <Compile Include="Shell\Services\VsPlotExportDialog.cs" />
     <Compile Include="Shell\VsAppShell.Test.cs" />

--- a/src/Package/Impl/Shell/Services/VsMainThreadAwaiter.cs
+++ b/src/Package/Impl/Shell/Services/VsMainThreadAwaiter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using Microsoft.Common.Core.Threading;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.R.Package.Shell {
+    internal class VsMainThreadAwaiter : IMainThreadAwaiter {
+        private readonly JoinableTaskFactory.MainThreadAwaiter _awaiter;
+
+        public VsMainThreadAwaiter(JoinableTaskFactory.MainThreadAwaiter awaiter) {
+            _awaiter = awaiter;
+        }
+
+        public bool IsCompleted => _awaiter.IsCompleted;
+        public void OnCompleted(Action continuation) => _awaiter.OnCompleted(continuation);
+        public void GetResult() => _awaiter.GetResult();
+    }
+}

--- a/src/Package/Impl/Telemetry/Windows/ToolWindowTracker.cs
+++ b/src/Package/Impl/Telemetry/Windows/ToolWindowTracker.cs
@@ -30,9 +30,7 @@ namespace Microsoft.VisualStudio.R.Package.Telemetry.Windows {
         }
 
         private void OnElapsed(object sender, ElapsedEventArgs e) {
-            _services.MainThread().Post(() => {
-                ReportWindowLayout();
-            });
+            _services.MainThread().Post(ReportWindowLayout);
         }
 
 

--- a/src/UnitTests/Core/Impl/Microsoft.UnitTests.Core.csproj
+++ b/src/UnitTests/Core/Impl/Microsoft.UnitTests.Core.csproj
@@ -31,6 +31,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Threading\TestMainThread.cs" />
+    <Compile Include="Threading\TestMainThreadAwaiter.cs" />
     <Compile Include="XUnit\TaskObserver.cs" />
     <Compile Include="XUnit\VsAssemblyLoaderAttribute.cs" />
     <Compile Include="XUnit\XunitTestEnvironment.cs" />

--- a/src/UnitTests/Core/Impl/Threading/TestMainThread.cs
+++ b/src/UnitTests/Core/Impl/Threading/TestMainThread.cs
@@ -16,7 +16,7 @@ namespace Microsoft.UnitTests.Core.Threading {
     public class TestMainThread : ITaskService, IProgressDialog, IMainThread, IDisposable {
         private readonly Action _onDispose;
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
-        private readonly AsyncLocal<BlockingLoop> _blockingLoop = new System.Threading.AsyncLocal<BlockingLoop>();
+        private readonly AsyncLocal<BlockingLoop> _blockingLoop = new AsyncLocal<BlockingLoop>();
 
         public TestMainThread(Action onDispose) {
             _onDispose = onDispose;
@@ -26,17 +26,17 @@ namespace Microsoft.UnitTests.Core.Threading {
 
         public void Dispose() => _onDispose();
 
-        public void Post(Action action, CancellationToken cancellationToken) {
+        public void Post(Action action) {
             var bl = _blockingLoop.Value;
             if (bl != null) {
                 bl.Post(action);
             } else {
-                var token = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken).Token;
-                var registration = token.Register(action, false);
-                var task = UIThreadHelper.Instance.InvokeAsync(action);
-                registration.UnregisterOnCompletion(task);
+                UIThreadHelper.Instance.InvokeAsync(action).DoNotWait();
             }
         }
+
+        public IMainThreadAwaiter CreateMainThreadAwaiter(CancellationToken cancellationToken) =>
+            new TestMainThreadAwaiter(this, cancellationToken);
 
         public void Show(Func<CancellationToken, Task> method, string waitMessage, int delayToShowDialogMs = 0)
             => BlockUntilCompleted(() => method(CancellationToken.None));
@@ -99,6 +99,14 @@ namespace Microsoft.UnitTests.Core.Threading {
         }
 
         public void CancelPendingTasks() => _cts.Cancel();
+
+        private CancellationToken GetPostCancellationToken(CancellationToken cancellationToken) {
+            try {
+                return CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken).Token;
+            } catch (ObjectDisposedException) {
+                return _cts.Token;
+            }
+        }
 
         private class BlockingLoop {
             private readonly Func<Task> _func;

--- a/src/UnitTests/Core/Impl/Threading/TestMainThreadAwaiter.cs
+++ b/src/UnitTests/Core/Impl/Threading/TestMainThreadAwaiter.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading;
+using Microsoft.Common.Core.Threading;
+
+namespace Microsoft.UnitTests.Core.Threading {
+    internal class TestMainThreadAwaiter : IMainThreadAwaiter {
+        private static readonly WaitCallback ThreadPoolCallback = state => ((ContinuationWrapper)state).Invoke();
+        // In case of CancellationToken, we need to call ContinuationWrapper.Invoke as a separate item, 
+        // otherwise in case of linked CancellationToken tree it may lead to a deadlock.
+        private static readonly Action<object> CancellationTokenCallback = state => ThreadPool.QueueUserWorkItem(ThreadPoolCallback, state);
+
+        private readonly IMainThread _mainThread;
+        private readonly CancellationToken _cancellationToken;
+
+        public TestMainThreadAwaiter(IMainThread mainThread, CancellationToken cancellationToken) {
+            _mainThread = mainThread;
+            _cancellationToken = cancellationToken;
+        }
+
+        public bool IsCompleted => Thread.CurrentThread.ManagedThreadId == _mainThread.ThreadId;
+
+        public void OnCompleted(Action continuation) {
+            var wrapper = new ContinuationWrapper(continuation);
+
+            if (_cancellationToken.IsCancellationRequested) {
+                ThreadPool.QueueUserWorkItem(ThreadPoolCallback, wrapper);
+                return;
+            }
+
+            _mainThread.Post(wrapper.Invoke);
+            var registration = _cancellationToken.Register(CancellationTokenCallback, wrapper, false);
+
+            var disposeRegistration = false;
+            lock (wrapper) {
+                // wrapper.Action == null means that ContinuationWrapper.Invoke has been called before CancellationTokenRegistration was set
+                // In this case, registration should be disposed explicitly
+                if (wrapper.Action == null) {
+                    disposeRegistration = true;
+                } else {
+                    wrapper.CancellationTokenRegistration = registration;
+                }
+            }
+
+            if (disposeRegistration) {
+                registration.Dispose();
+            }
+        }
+
+        public void GetResult() {
+            if (Thread.CurrentThread.ManagedThreadId != _mainThread.ThreadId) {
+                _cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+
+        private class ContinuationWrapper {
+            public Action Action;
+            public CancellationTokenRegistration CancellationTokenRegistration;
+
+            public ContinuationWrapper(Action action) {
+                Action = action;
+            }
+
+            public void Invoke() {
+                Action action;
+                CancellationTokenRegistration registration;
+
+                lock (this) {
+                    action = Action;
+                    registration = CancellationTokenRegistration;
+                    Action = null;
+                }
+
+                if (action != null) {
+                    registration.Dispose();
+                    action.Invoke();
+                }
+            }
+        }
+    }
+}

--- a/src/Windows/R/Components/Impl/Plots/Implementation/RPlotManager.cs
+++ b/src/Windows/R/Components/Impl/Plots/Implementation/RPlotManager.cs
@@ -196,9 +196,11 @@ namespace Microsoft.R.Components.Plots.Implementation {
             _locatorCancelTokenRegistration = cancellationToken.Register(() => CancelLocatorMode(device));
 
             _mainThread.Post(() => {
-                var visualComponent = GetVisualComponentForDevice(deviceId);
-                visualComponent?.Container.Show(focus: false, immediate: true);
-            }, cancellationToken);
+                if (!cancellationToken.IsCancellationRequested) {
+                    var visualComponent = GetVisualComponentForDevice(deviceId);
+                    visualComponent?.Container.Show(focus: false, immediate: true);
+                }
+            });
 
             return _locatorTcs.Task;
         }


### PR DESCRIPTION
Changes are required to match current behavior of VS `ThreadHelper`. Since it sets SynchronizationContext in `JoinableTaskFactory.MainThreadAwaite.GetResult`, we need to call it from our own awaiter.

This change may also fix some of the rare issues when VS gets hanged on connection switching.