### PR TITLE
4187 REPL may become slow after large data output

### DIFF
--- a/src/R.sln
+++ b/src/R.sln
@@ -130,9 +130,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.R.Containers.Windows.Test", "Windows\Containers\Test\Microsoft.R.Containers.Windows.Test.csproj", "{62E1CA8E-8398-46FC-B14F-DE0C5759DD2D}"
 EndProject
 Global
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
@@ -894,8 +891,5 @@ Global
 		{8ED6EF0A-08A9-4F77-8EC1-F1630AAD2DDB} = {BD32A9DB-6AC3-4495-8682-E04ACC4917D0}
 		{D84CC0CF-40A7-49E0-964B-5D4114710EC1} = {3CF8DD8A-9533-498F-8B65-AF3F5AA580C7}
 		{62E1CA8E-8398-46FC-B14F-DE0C5759DD2D} = {EE50720D-A0E5-45EE-B2EC-E065B569DB27}
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {95C39C0C-C5F1-4A68-A0B4-833DFC50EED9}
 	EndGlobalSection
 EndGlobal

--- a/src/R.sln
+++ b/src/R.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.12
+VisualStudioVersion = 15.0.27010.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.R.Package", "Package\Impl\Microsoft.VisualStudio.R.Package.csproj", "{26035FE3-25AB-45EC-BB45-7FD0B6C1D545}"
 EndProject
@@ -130,6 +130,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.R.Containers.Windows.Test", "Windows\Containers\Test\Microsoft.R.Containers.Windows.Test.csproj", "{62E1CA8E-8398-46FC-B14F-DE0C5759DD2D}"
 EndProject
 Global
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
@@ -891,5 +894,8 @@ Global
 		{8ED6EF0A-08A9-4F77-8EC1-F1630AAD2DDB} = {BD32A9DB-6AC3-4495-8682-E04ACC4917D0}
 		{D84CC0CF-40A7-49E0-964B-5D4114710EC1} = {3CF8DD8A-9533-498F-8B65-AF3F5AA580C7}
 		{62E1CA8E-8398-46FC-B14F-DE0C5759DD2D} = {EE50720D-A0E5-45EE-B2EC-E065B569DB27}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {95C39C0C-C5F1-4A68-A0B4-833DFC50EED9}
 	EndGlobalSection
 EndGlobal

--- a/src/Windows/R/Editor/Impl/Completions/RCompletionController.cs
+++ b/src/Windows/R/Editor/Impl/Completions/RCompletionController.cs
@@ -214,10 +214,10 @@ namespace Microsoft.R.Editor.Completions {
                         return true;
 
                     case ':':
-                        return TextView.ToEditorView().IsCaretInNamespace();
+                        return TextView.ToEditorView().IsCaretInNamespace(_textBuffer.ToEditorBuffer());
 
                     case '(':
-                        return TextView.ToEditorView().IsCaretInLibraryStatement();
+                        return TextView.ToEditorView().IsCaretInLibraryStatement(_textBuffer.ToEditorBuffer());
 
                     default:
                         if (_settings.ShowCompletionOnFirstChar) {


### PR DESCRIPTION
https://github.com/Microsoft/RTVS/issues/4187

Map caret down and use the active editor buffer instead which is  just a few lines typically and does not include all the output.