### PR TITLE
Bug fixes

### DIFF
--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -48,12 +48,12 @@ namespace Microsoft.R.Host.Client.Session {
         private TaskCompletionSourceEx<object> _hostStartedTcs;
         private RSessionRequestSource _currentRequestSource;
         private TaskCompletionSourceEx<object> _initializedTcs;
-        private bool _processingChangeDirectoryCommand;
         private readonly Action _onDispose;
         private readonly IExclusiveReaderLock _initializationLock;
         private readonly BinaryAsyncLock _stopHostLock;
         private readonly CountdownDisposable _disableMutatingOnReadConsole;
         private readonly DisposeToken _disposeToken;
+        private volatile bool _processingChangeDirectoryCommand;
         private volatile bool _isHostRunning;
         private volatile bool _delayedMutatedOnReadConsole;
         private volatile IRSessionCallback _callback;

--- a/src/Host/Client/Impl/Session/RSession.cs
+++ b/src/Host/Client/Impl/Session/RSession.cs
@@ -48,17 +48,19 @@ namespace Microsoft.R.Host.Client.Session {
         private TaskCompletionSourceEx<object> _hostStartedTcs;
         private RSessionRequestSource _currentRequestSource;
         private TaskCompletionSourceEx<object> _initializedTcs;
+
         private readonly Action _onDispose;
         private readonly IExclusiveReaderLock _initializationLock;
         private readonly BinaryAsyncLock _stopHostLock;
         private readonly CountdownDisposable _disableMutatingOnReadConsole;
         private readonly DisposeToken _disposeToken;
+        private readonly CountdownDisposable _readUserInputReentrancyCounter = new CountdownDisposable();
+
         private volatile bool _processingChangeDirectoryCommand;
         private volatile bool _isHostRunning;
         private volatile bool _delayedMutatedOnReadConsole;
         private volatile IRSessionCallback _callback;
         private volatile RHostStartupInfo _startupInfo;
-        private readonly CountdownDisposable _readUserInputReentrancyCounter = new CountdownDisposable();
 
         public int Id { get; }
         public string Name { get; }

--- a/src/Package/Impl/Package.vsct
+++ b/src/Package/Impl/Package.vsct
@@ -308,6 +308,7 @@
       <Group guid="guidRToolsCmdSet" id="markdownPreviewGroup" priority="0x0400" />
       <Group guid="guidRToolsCmdSet" id="markdownAutoSyncGroup" priority="0x0450" />
       <Group guid="guidRToolsCmdSet" id="markdownSyncGroup" priority="0x0500" />
+      <Group guid="guidRToolsCmdSet" id="markdownEditGroup" priority="0x0550" />
 
       <!-- R code editor context menu groups -->
       <!-- R Formatting -->
@@ -494,6 +495,10 @@
       </Group>
 
       <Group guid="guidRToolsCmdSet" id="markdownPreviewGroup" priority="0x0210">
+        <Parent guid="guidRToolsCmdSet" id="markdownSubMenu"/>
+      </Group>
+
+      <Group guid="guidRToolsCmdSet" id="markdownEditGroup" priority="0x0215">
         <Parent guid="guidRToolsCmdSet" id="markdownSubMenu"/>
       </Group>
 
@@ -1223,6 +1228,20 @@
           <ToolTipText>Run all code chunks above and update preview pane</ToolTipText>
         </Strings>
       </Button>
+      
+      <Button guid="guidMdToolsCmdSet" id="icmdInsertRCodeBlock" priority="0x0100" type="Button">
+        <Parent guid="guidRToolsCmdSet" id="markdownEditGroup"/>
+        <Icon guid="ImageCatalogGuid" id="InsertClause"/>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>I&amp;nsert R Code Block</ButtonText>
+          <CommandName>Insert R Code Block</CommandName>
+          <ToolTipText>Insert R Code Block</ToolTipText>
+        </Strings>
+      </Button>
+
       <!-- End of Publish flyout -->
 
       <!-- Windows flyout -->
@@ -2084,8 +2103,12 @@
     <CommandPlacement guid="guidMdToolsCmdSet" id="icmdRunCurrentChunk" priority="0x207">
       <Parent guid="guidRToolsCmdSet" id="groupRContextRepl"/>
     </CommandPlacement>
-
+    
     <CommandPlacement guid="guidMdToolsCmdSet" id="icmdRunAllChunksAbove" priority="0x208">
+      <Parent guid="guidRToolsCmdSet" id="groupRContextRepl"/>
+    </CommandPlacement>
+    
+    <CommandPlacement guid="guidMdToolsCmdSet" id="icmdInsertRCodeBlock" priority="0x209">
       <Parent guid="guidRToolsCmdSet" id="groupRContextRepl"/>
     </CommandPlacement>
 
@@ -2162,6 +2185,10 @@
     </CommandPlacement>
 
     <CommandPlacement guid="guidRToolsCmdSet" id="markdownSyncGroup" priority="0x0210">
+      <Parent guid="guidMdToolsCmdSet" id="mdEditorContextMenu"/>
+    </CommandPlacement>
+
+    <CommandPlacement guid="guidRToolsCmdSet" id="markdownEditGroup" priority="0x0215">
       <Parent guid="guidMdToolsCmdSet" id="mdEditorContextMenu"/>
     </CommandPlacement>
 
@@ -2627,6 +2654,7 @@
     <KeyBinding guid="guidMdToolsCmdSet" id="icmdAutomaticSync" editor="RmdEditor" key1="Y" mod1="CONTROL SHIFT" />
     <KeyBinding guid="guidMdToolsCmdSet" id="icmdRunCurrentChunk" editor="RmdEditor" key1="R" mod1="CONTROL SHIFT" />
     <KeyBinding guid="guidMdToolsCmdSet" id="icmdRunAllChunksAbove" editor="RmdEditor" key1="B" mod1="CONTROL SHIFT" />
+    <KeyBinding guid="guidMdToolsCmdSet" id="icmdInsertRCodeBlock" editor="RmdEditor" key1="I" mod1="CONTROL ALT" />
   </KeyBindings>
 
   <UsedCommands>
@@ -2669,6 +2697,7 @@
       <IDSymbol name="icmdRunCurrentChunk" value="613" />
       <IDSymbol name="icmdRunAllChunksAbove" value="614" />
       <IDSymbol name="icmdReloadPreview" value="615"/>
+      <IDSymbol name="icmdInsertRCodeBlock" value="616"/>
     </GuidSymbol>
 
     <GuidSymbol name="guidRToolsCmdSet" value="{AD87578C-B324-44DC-A12A-B01A6ED5C6E3}">
@@ -2943,6 +2972,7 @@
       <IDSymbol name="markdownPreviewGroup" value="0x2360"/>
       <IDSymbol name="markdownSyncGroup" value="0x2361"/>
       <IDSymbol name="markdownAutoSyncGroup" value="0x2362"/>
+      <IDSymbol name="markdownEditGroup" value="0x2363"/>
       <IDSymbol name="feedbackSubMenu" value="0x2380"/>
       <IDSymbol name="feedbackSubMenuGroup" value="0x2390"/>
       <IDSymbol name="rtvsDocsSubMenu" value="0x2391"/>

--- a/src/Package/Impl/Repl/Commands/General/ResetReplCommand.cs
+++ b/src/Package/Impl/Repl/Commands/General/ResetReplCommand.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Common.Core;
 using Microsoft.R.Components.InteractiveWorkflow;
-using Microsoft.R.Host.Client.Session;
 using Microsoft.VisualStudio.R.Package.Commands;
 
 namespace Microsoft.VisualStudio.R.Package.Repl.Commands {
@@ -11,13 +10,6 @@ namespace Microsoft.VisualStudio.R.Package.Repl.Commands {
         public ResetReplCommand(IRInteractiveWorkflowVisual interactiveWorkflow) : 
             base(interactiveWorkflow, RPackageCommandId.icmdResetRepl) { }
 
-        protected override void DoOperation() =>
-            // Remember the working directory
-            Workflow.RSession.GetRWorkingDirectoryAsync().ContinueWith(async t => {
-                var directory = t.Result;
-                await Workflow.Operations.ResetAsync();
-                await Workflow.RSession.HostStarted;
-                await Workflow.RSession.SetWorkingDirectoryAsync(directory);
-            }).DoNotWait();
+        protected override void DoOperation() => Workflow.Operations.ResetAsync().DoNotWait();
     }
 }

--- a/src/Package/Impl/Repl/Commands/General/ResetReplCommand.cs
+++ b/src/Package/Impl/Repl/Commands/General/ResetReplCommand.cs
@@ -3,12 +3,21 @@
 
 using Microsoft.Common.Core;
 using Microsoft.R.Components.InteractiveWorkflow;
+using Microsoft.R.Host.Client.Session;
 using Microsoft.VisualStudio.R.Package.Commands;
 
 namespace Microsoft.VisualStudio.R.Package.Repl.Commands {
     internal sealed class ResetReplCommand : ReplCommandBase {
         public ResetReplCommand(IRInteractiveWorkflowVisual interactiveWorkflow) : 
             base(interactiveWorkflow, RPackageCommandId.icmdResetRepl) { }
-        protected override void DoOperation() => Workflow.Operations.ResetAsync().DoNotWait();
+
+        protected override void DoOperation() =>
+            // Remember the working directory
+            Workflow.RSession.GetRWorkingDirectoryAsync().ContinueWith(async t => {
+                var directory = t.Result;
+                await Workflow.Operations.ResetAsync();
+                await Workflow.RSession.HostStarted;
+                await Workflow.RSession.SetWorkingDirectoryAsync(directory);
+            }).DoNotWait();
     }
 }

--- a/src/R/Editor/Impl/Tree/TextChangeAnalyzer.cs
+++ b/src/R/Editor/Impl/Tree/TextChangeAnalyzer.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using Microsoft.Common.Core;
 using Microsoft.Languages.Core.Text;
 using Microsoft.R.Core.AST;
-using Microsoft.R.Core.AST.Scopes;
-using Microsoft.R.Core.AST.Statements;
 using Microsoft.R.Core.AST.Statements.Conditionals;
 using Microsoft.R.Core.Tokens;
 
@@ -164,7 +162,7 @@ namespace Microsoft.R.Editor.Tree {
             var change = context.PendingChanges;
             positionType = context.EditorTree.AstRoot.GetPositionNode(change.Start, out node);
 
-            if (positionType == PositionType.Token) {
+            if (positionType == PositionType.Token && change.Start > node.Start) {
                 var tokenNode = node as TokenNode;
                 Debug.Assert(tokenNode != null);
 

--- a/src/Windows/Markdown/Editor/Impl/Commands/InsertRCodeBlock.cs
+++ b/src/Windows/Markdown/Editor/Impl/Commands/InsertRCodeBlock.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using Microsoft.Common.Core;
+using Microsoft.Common.Core.Services;
+using Microsoft.Common.Core.UI.Commands;
+using Microsoft.Languages.Editor.Controllers.Commands;
+using Microsoft.Markdown.Editor.ContentTypes;
+using Microsoft.R.Editor;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Microsoft.Markdown.Editor.Commands {
+    internal sealed class InsertRCodeBlock : ViewCommand {
+        private readonly IREditorSettings _settings;
+        public InsertRCodeBlock(ITextView textView, IServiceContainer services)
+            : base(textView, new CommandId(MdPackageCommandId.MdCmdSetGuid, MdPackageCommandId.icmdInsertRCodeBlock), false) {
+            _settings = services.GetService<IREditorSettings>();
+        }
+
+        public override CommandStatus Status(Guid group, int id) {
+            if (!TextView.TextBuffer.ContentType.TypeName.EqualsOrdinal(MdProjectionContentTypeDefinition.ContentType)) {
+                return CommandStatus.Invisible;
+            }
+            return TextView.IsCaretInRCode() ? CommandStatus.Supported : CommandStatus.SupportedAndEnabled;
+        }
+
+        public override CommandResult Invoke(Guid group, int id, object inputArg, ref object outputArg) {
+            const string fragment = @"
+```{r}
+
+```
+";
+            var caretPosition = TextView.Caret.Position.BufferPosition;
+            var tb = TextView.TextBuffer;
+            var lineNum = tb.CurrentSnapshot.GetLineNumberFromPosition(caretPosition);
+
+            TextView.TextBuffer.Insert(caretPosition, fragment);
+            var newLine = tb.CurrentSnapshot.GetLineFromLineNumber(lineNum + 2);
+            TextView.Caret.MoveTo(new VirtualSnapshotPoint(newLine, _settings.TabSize));
+
+            return CommandResult.Executed;
+        }
+    }
+}

--- a/src/Windows/Markdown/Editor/Impl/Commands/MdCommandFactory.cs
+++ b/src/Windows/Markdown/Editor/Impl/Commands/MdCommandFactory.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Markdown.Editor.Commands {
                 new RunCurrentChunkCommand(textView, _services),
                 new RunAllChunksAboveCommand(textView, _services),
                 new ReloadPreviewCommand(textView, _services),
-                new FormatDocumentCommand(textView, textBuffer, _services)
+                new FormatDocumentCommand(textView, textBuffer, _services),
+                new InsertRCodeBlock(textView, _services)
             };
             return commands;
         }

--- a/src/Windows/Markdown/Editor/Impl/Commands/MdPackageCommandId.cs
+++ b/src/Windows/Markdown/Editor/Impl/Commands/MdPackageCommandId.cs
@@ -17,5 +17,6 @@ namespace Microsoft.Markdown.Editor.Commands {
         public const int icmdRunCurrentChunk = 613;
         public const int icmdRunAllChunksAbove = 614;
         public const int icmdReloadPreview = 615;
+        public const int icmdInsertRCodeBlock = 616;
     }
 }

--- a/src/Windows/Markdown/Editor/Impl/Microsoft.Markdown.Editor.Windows.csproj
+++ b/src/Windows/Markdown/Editor/Impl/Microsoft.Markdown.Editor.Windows.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Commands\MdMainController.cs" />
     <Compile Include="Commands\MdPackageCommandId.cs" />
     <Compile Include="Commands\MdTextViewConnectionListener.cs" />
+    <Compile Include="Commands\InsertRCodeBlock.cs" />
     <Compile Include="Commands\RunRChunkCommand.cs" />
     <Compile Include="ContainedLanguage\IRLanguageBlock.cs" />
     <Compile Include="ContainedLanguage\RContainedLanguageHost.cs" />

--- a/src/Windows/R/Components/Impl/Plots/Implementation/ViewModel/RPlotHistoryViewModel.cs
+++ b/src/Windows/R/Components/Impl/Plots/Implementation/ViewModel/RPlotHistoryViewModel.cs
@@ -105,9 +105,7 @@ namespace Microsoft.R.Components.Plots.Implementation.ViewModel {
                 // This can happen if an existing plot was resized too small.
                 // Don't overwrite the history image in this case, because the
                 // existing image in history will be better than no image at all.
-                if (plotImage != null) {
-                    entry.PlotImage = plotImage;
-                }
+                entry.PlotImage = plotImage;
             } else {
                 Entries.Add(new RPlotHistoryEntryViewModel(_plotManager, _mainThread, plot, plotImage));
             }
@@ -181,7 +179,7 @@ namespace Microsoft.R.Components.Plots.Implementation.ViewModel {
             _mainThread.Post(() => {
                 var device = (IRPlotDevice)sender;
                 var plot = device.ActivePlot;
-                if (plot != null) {
+                if (plot?.Image != null) {
                     AddOrUpdate(plot, plot.Image);
                 }
             });


### PR DESCRIPTION
#4243 Visual Studio Crashes with ggmap 
- Add null check

#4220 invalid highlighting of syntax on quoted vector elements 
- Make sure we recognize typing in front of `"` as NOT in string

#4206 Add shortcut to insert R Markdown code chunk 
- Add basic command and shortcut

#4078 Resetting REPL changes working directory back to default 
- restore directory upon reset