### PR TITLE
Remove unnecessary binding redirects

### DIFF
--- a/src/Package/Impl/Properties/AssemblyInfo.cs
+++ b/src/Package/Impl/Properties/AssemblyInfo.cs
@@ -4,12 +4,8 @@
 using Microsoft.VisualStudio.Shell;
 using System.Runtime.CompilerServices;
 
-[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.Win32.Primitives",
-    OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "4.0.2.0", NewVersion = "4.0.2.0")]
 [assembly: ProvideBindingRedirection(AssemblyName = "System.Diagnostics.DiagnosticSource",
     OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "4.0.1.0", NewVersion = "4.0.1.0")]
-[assembly: ProvideBindingRedirection(AssemblyName = "System.Net.Http",
-    OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "4.1.1.1", NewVersion = "4.1.1.1")]
 
 #if SIGN
 [assembly: InternalsVisibleTo("Microsoft.VisualStudio.R.Package.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007D1FA57C4AED9F0A32E84AA0FAEFD0DE9E8FD6AEC8F87FB03766C834C99921EB23BE79AD9D5DCC1DD9AD236132102900B723CF980957FC4E177108FC607774F29E8320E92EA05ECE4E821C0A5EFE8F1645C4C0C93C1AB99285D622CAA652C1DFAD63D745D6F2DE5F17E5EAF0FC4963D261C8A12436518206DC093344D5AD293")]

--- a/src/UnitTests/app.config
+++ b/src/UnitTests/app.config
@@ -3,10 +3,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.1" newVersion="4.1.1.1" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
@@ -53,10 +49,6 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Validation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Win32.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="4.0.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
From user's email:

_The users of our tools (HDI, ASA, and Data Lake tools for VS) are running into assembly resolution issues for System.Net.Http, and we finally discovered that the root cause is that R Tools for VS changes the VS assembly binding for 4.0.0.0 to 4.1.1.1 for everything in VS.  In our apps, we have some app domains that fail to find 4.1.1.1 when they try to resolve System.Net.Http (looks that version is not standard) so it breaks those scenarios for us.  Could this be changed so that R Tools doesn’t everything else running in VS?_
